### PR TITLE
Method to create or update an interface.

### DIFF
--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -149,7 +149,8 @@ class Switch(GenericEntity):
 
 
     def update_or_create_interface(self, port_no, name=None, address=None,
-                                   state=None, features=None):
+                                   state=None, features=None, speed=None,
+                                   config=None):
         """Get and upated an interface or create one if it does not exist."""
         with self._interface_lock:
             interface = self.get_interface_by_port_no(port_no)      
@@ -158,13 +159,18 @@ class Switch(GenericEntity):
                 interface.address = address or interface.address
                 interface.state = state or interface.state
                 interface.features = features or interface.features
+                interface.config = config
+                if speed:
+                    interface.set_custom_speed(speed)
             else:
                 interface = Interface(name=name,
                                       address=address,
                                       port_number=port_no,
                                       switch=self,
                                       state=state,
-                                      features=features)
+                                      features=features,
+                                      speed=speed,
+                                      config=config)
                 self.update_interface(interface)
 
     def get_flow_by_id(self, flow_id):

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -172,6 +172,7 @@ class Switch(GenericEntity):
                                       speed=speed,
                                       config=config)
                 self.update_interface(interface)
+            return interface
 
     def get_flow_by_id(self, flow_id):
         """Return a Flow using the flow_id given. None if not found in flows.

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -1,12 +1,12 @@
 """Module with main classes related to Switches."""
 import json
-from kytos.core.interface import Interface
 import logging
 from threading import Lock
 
 from kytos.core.common import GenericEntity
 from kytos.core.constants import CONNECTION_TIMEOUT, FLOOD_TIMEOUT
 from kytos.core.helpers import now
+from kytos.core.interface import Interface
 
 __all__ = ('Switch',)
 
@@ -147,13 +147,13 @@ class Switch(GenericEntity):
 
         return self.interfaces.get(port_no)
 
-
     def update_or_create_interface(self, port_no, name=None, address=None,
                                    state=None, features=None, speed=None,
                                    config=None):
+        # pylint: disable=too-many-arguments
         """Get and upated an interface or create one if it does not exist."""
         with self._interface_lock:
-            interface = self.get_interface_by_port_no(port_no)      
+            interface = self.get_interface_by_port_no(port_no)
             if interface:
                 interface.name = name or interface.name
                 interface.address = address or interface.address

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -6,7 +6,6 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
 from kytos.core import Controller
-from kytos.core import interface
 from kytos.core.config import KytosConfig
 from kytos.core.constants import FLOOD_TIMEOUT
 from kytos.core.interface import Interface
@@ -120,12 +119,12 @@ class TestSwitch(TestCase):
 
     def test_disable(self):
         """Test disable method."""
-        interface = MagicMock()
-        self.switch.interfaces = {"1": interface}
+        intf = MagicMock()
+        self.switch.interfaces = {"1": intf}
 
         self.switch.disable()
 
-        interface.disable.assert_called()
+        intf.disable.assert_called()
         self.assertFalse(self.switch._enabled)
 
     def test_disconnect(self):
@@ -150,7 +149,7 @@ class TestSwitch(TestCase):
         """Test update_or_create_interface method."""
         interface_1 = Interface(name='interface_2', port_number=2,
                                 switch=self.switch)
-        self.switch.interfaces = {2:interface_1}
+        self.switch.interfaces = {2: interface_1}
 
         self.switch.update_or_create_interface(2, name='new_interface_2')
         self.assertEqual(self.switch.interfaces[2].name, 'new_interface_2')
@@ -159,7 +158,7 @@ class TestSwitch(TestCase):
         """Test update_or_create_interface method."""
         interface_1 = Interface(name='interface_2', port_number=2,
                                 switch=self.switch)
-        self.switch.interfaces = {2:interface_1}
+        self.switch.interfaces = {2: interface_1}
 
         self.switch.update_or_create_interface(3, name='new_interface_3')
         self.assertEqual(self.switch.interfaces[2].name, 'interface_2')
@@ -169,12 +168,12 @@ class TestSwitch(TestCase):
         """Test update_or_create_interface method."""
         interface_1 = Interface(name='interface_2', port_number=2,
                                 switch=self.switch)
-        self.switch.interfaces = {2:interface_1}
+        self.switch.interfaces = {2: interface_1}
 
         self.switch.update_or_create_interface(3, name='new_interface_3')
         self.assertEqual(self.switch.interfaces[2].name, 'interface_2')
         self.assertEqual(self.switch.interfaces[3].name, 'new_interface_3')
-        
+
     def test_get_flow_by_id(self):
         """Test get_flow_by_id method."""
         flow_1 = MagicMock(id='1')
@@ -253,10 +252,10 @@ class TestSwitch(TestCase):
 
     def test_remove_interface(self):
         """Test remove_interface method."""
-        interface = MagicMock(port_number=1)
-        self.switch.interfaces[1] = interface
+        intf = MagicMock(port_number=1)
+        self.switch.interfaces[1] = intf
 
-        self.switch.remove_interface(interface)
+        self.switch.remove_interface(intf)
 
         self.assertEqual(self.switch.interfaces, {})
 

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
 from kytos.core import Controller
+from kytos.core import interface
 from kytos.core.config import KytosConfig
 from kytos.core.constants import FLOOD_TIMEOUT
 from kytos.core.interface import Interface
@@ -145,6 +146,35 @@ class TestSwitch(TestCase):
         self.assertEqual(expected_interface_1, interface_1)
         self.assertIsNone(expected_interface_2)
 
+    def test_update_or_create_interface_case1(self):
+        """Test update_or_create_interface method."""
+        interface_1 = Interface(name='interface_2', port_number=2,
+                                switch=self.switch)
+        self.switch.interfaces = {2:interface_1}
+
+        self.switch.update_or_create_interface(2, name='new_interface_2')
+        self.assertEqual(self.switch.interfaces[2].name, 'new_interface_2')
+
+    def test_update_or_create_interface_case2(self):
+        """Test update_or_create_interface method."""
+        interface_1 = Interface(name='interface_2', port_number=2,
+                                switch=self.switch)
+        self.switch.interfaces = {2:interface_1}
+
+        self.switch.update_or_create_interface(3, name='new_interface_3')
+        self.assertEqual(self.switch.interfaces[2].name, 'interface_2')
+        self.assertEqual(self.switch.interfaces[3].name, 'new_interface_3')
+
+    def test_update_or_create_interface_case3(self):
+        """Test update_or_create_interface method."""
+        interface_1 = Interface(name='interface_2', port_number=2,
+                                switch=self.switch)
+        self.switch.interfaces = {2:interface_1}
+
+        self.switch.update_or_create_interface(3, name='new_interface_3')
+        self.assertEqual(self.switch.interfaces[2].name, 'interface_2')
+        self.assertEqual(self.switch.interfaces[3].name, 'new_interface_3')
+        
     def test_get_flow_by_id(self):
         """Test get_flow_by_id method."""
         flow_1 = MagicMock(id='1')


### PR DESCRIPTION
Fixes #117

Description of the change
----------------------------

New method on switch to create or update an interface.
The whole method executes with a lock acquired, avoiding
racing condition.
New tests for this functionallity implemented.