### PR TITLE
Remove doctest from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
 script:
   - python setup.py lint
   - python setup.py coverage
-  - python setup.py doctest
+  # - python setup.py doctest


### PR DESCRIPTION
Remove the doctest setup from travis while no new
documentation site is created.
Fixes #119