### PR TITLE
Change initial value of Switch last seen to be a lower datetime

### DIFF
--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -5,7 +5,7 @@ from threading import Lock
 
 from kytos.core.common import GenericEntity
 from kytos.core.constants import CONNECTION_TIMEOUT, FLOOD_TIMEOUT
-from kytos.core.helpers import now
+from kytos.core.helpers import get_time, now
 from kytos.core.interface import Interface
 
 __all__ = ('Switch',)
@@ -63,7 +63,7 @@ class Switch(GenericEntity):
         self.connection = connection
         self.features = features
         self.firstseen = now()
-        self.lastseen = now()
+        self.lastseen = get_time("0001-01-01T00:00:00")
         self.sent_xid = None
         self.waiting_for_reply = False
         self.request_timestamp = 0

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -66,6 +66,7 @@ class TestInterface(unittest.TestCase):
         switch = Switch('dpid')
         switch.connection = Mock()
         switch.connection.protocol.version = 0x04
+        switch.update_lastseen()
         return Interface('name', 42, switch, *args, **kwargs)
 
     def test_speed_feature_none(self):

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -1,7 +1,7 @@
 """Test kytos.core.switch module."""
 import asyncio
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -42,6 +42,7 @@ class TestSwitch(TestCase):
         connection.protocol.version = 0x04
         switch = Switch('00:00:00:00:00:00:00:01', connection)
         switch._enabled = True
+        switch.update_lastseen()
         return switch
 
     def test_repr(self):
@@ -363,3 +364,12 @@ class TestSwitch(TestCase):
                                     'enabled': True})
 
         self.assertEqual(self.switch.as_json(), expected_json)
+
+    def test_switch_initial_lastseen(self):
+        """Test lastseen attribute initialization."""
+        connection = MagicMock()
+        connection.protocol.version = 0x04
+        switch = Switch('00:00:00:00:00:00:00:01', connection)
+        self.assertEqual(switch.is_active(), False)
+        self.assertEqual(switch.lastseen,
+                         datetime(1, 1, 1, 0, 0, 0, 0, timezone.utc))


### PR DESCRIPTION
This PR fixes #124 

Description of the change
-----------------------------
Switch object is created with `lastseen` attribute default to `now()` date/time. This attribute is also used to verify if the switch is active: if it has received OpenFlow messages recently (each OF message updates the lastseen attribute), then the switch is considered active. If a Switch is instantiated without OpenFlow connection, Kytos will take a couple of minutes considering the switch active before identify it is not actually active. With the proposed notification, the switch is created inactive and as soon as the first OpenFlow message arrives, it becomes active.

Release notes
---------------
- Changing the initial value of `Switch.lastseen` attribute to "0001-01-01T00:00:00" (a lower date/time), so that the switch is created as inactive and upon receiving the first OpenFlow packet, it will become active.