### PR TITLE
adding lock to avoid race conditions on Link's endpoint's Tags

### DIFF
--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -166,7 +166,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
 
     def is_tag_available(self, tag):
         """Check if a tag is available."""
-        return tag in self.available_tags
+        with self._tag_lock:
+            return tag in self.available_tags
 
     def get_next_available_tag(self):
         """Get the next available tag from the interface.

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from enum import IntEnum
+from threading import Lock
 
 from pyof.v0x01.common.phy_port import Port as PortNo01
 from pyof.v0x01.common.phy_port import PortFeatures as PortFeatures01
@@ -97,6 +98,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         self.link = None
         self.lldp = True
         self._custom_speed = speed
+        self._tag_lock = Lock()
         self.set_available_tags(range(1, 4096))
 
         super().__init__()
@@ -134,12 +136,13 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         Args:
             iterable ([int]): range of VLANs.
         """
-        self.available_tags = []
+        with self._tag_lock:
+            self.available_tags = []
 
-        for i in iterable:
-            vlan = TAGType.VLAN
-            tag = TAG(vlan, i)
-            self.available_tags.append(tag)
+            for i in iterable:
+                vlan = TAGType.VLAN
+                tag = TAG(vlan, i)
+                self.available_tags.append(tag)
 
     def enable(self):
         """Enable this interface instance.
@@ -155,7 +158,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         Return False in case the tag is already removed.
         """
         try:
-            self.available_tags.remove(tag)
+            with self._tag_lock:
+                self.available_tags.remove(tag)
         except ValueError:
             return False
         return True
@@ -172,14 +176,16 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         If no tag is available return False.
         """
         try:
-            return self.available_tags.pop()
+            with self._tag_lock:
+                return self.available_tags.pop()
         except IndexError:
             return False
 
     def make_tag_available(self, tag):
         """Add a specific tag in available_tags."""
         if not self.is_tag_available(tag):
-            self.available_tags.append(tag)
+            with self._tag_lock:
+                self.available_tags.append(tag)
             return True
         return False
 

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -7,6 +7,7 @@ interfaces.
 import hashlib
 import json
 import random
+from threading import Lock
 
 from kytos.core.common import GenericEntity
 from kytos.core.exceptions import (KytosLinkCreationError,
@@ -28,6 +29,7 @@ class Link(GenericEntity):
             raise KytosLinkCreationError("endpoint_b cannot be None")
         self.endpoint_a = endpoint_a
         self.endpoint_b = endpoint_b
+        self._get_next_available_tag_lock = Lock()
         super().__init__()
 
     def __hash__(self):
@@ -112,31 +114,32 @@ class Link(GenericEntity):
 
     def get_next_available_tag(self):
         """Return the next available tag if exists."""
-        # Copy the available tags because in case of error
-        # we will remove and add elements to the available_tags
-        available_tags_a = self.endpoint_a.available_tags.copy()
-        available_tags_b = self.endpoint_b.available_tags.copy()
-        random.shuffle(available_tags_a)
-        random.shuffle(available_tags_b)
+        with self._get_next_available_tag_lock:
+            # Copy the available tags because in case of error
+            # we will remove and add elements to the available_tags
+            available_tags_a = self.endpoint_a.available_tags.copy()
+            available_tags_b = self.endpoint_b.available_tags.copy()
+            random.shuffle(available_tags_a)
+            random.shuffle(available_tags_b)
 
-        for tag in available_tags_a:
-            # Tag does not exist in endpoint B. Try another tag.
-            if tag not in available_tags_b:
-                continue
+            for tag in available_tags_a:
+                # Tag does not exist in endpoint B. Try another tag.
+                if tag not in available_tags_b:
+                    continue
 
-            # Tag already in use. Try another tag.
-            if not self.endpoint_a.use_tag(tag):
-                continue
+                # Tag already in use. Try another tag.
+                if not self.endpoint_a.use_tag(tag):
+                    continue
 
-            # Tag already in use in B. Mark the tag as available again.
-            if not self.endpoint_b.use_tag(tag):
-                self.endpoint_a.make_tag_available(tag)
-                continue
+                # Tag already in use in B. Mark the tag as available again.
+                if not self.endpoint_b.use_tag(tag):
+                    self.endpoint_a.make_tag_available(tag)
+                    continue
 
-            # Tag used successfully by both endpoints. Returning.
-            return tag
+                # Tag used successfully by both endpoints. Returning.
+                return tag
 
-        raise KytosNoTagAvailableError(self)
+            raise KytosNoTagAvailableError(self)
 
     def make_tag_available(self, tag):
         """Add a specific tag in available_tags."""

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -29,7 +29,7 @@ class Link(GenericEntity):
             raise KytosLinkCreationError("endpoint_b cannot be None")
         self.endpoint_a = endpoint_a
         self.endpoint_b = endpoint_b
-        self._get_next_available_tag_lock = Lock()
+        self._available_tag_lock = Lock()
         super().__init__()
 
     def __hash__(self):
@@ -114,7 +114,7 @@ class Link(GenericEntity):
 
     def get_next_available_tag(self):
         """Return the next available tag if exists."""
-        with self._get_next_available_tag_lock:
+        with self._available_tag_lock:
             # Copy the available tags because in case of error
             # we will remove and add elements to the available_tags
             available_tags_a = self.endpoint_a.available_tags.copy()
@@ -143,11 +143,12 @@ class Link(GenericEntity):
 
     def make_tag_available(self, tag):
         """Add a specific tag in available_tags."""
-        if not self.is_tag_available(tag):
-            self.endpoint_a.make_tag_available(tag)
-            self.endpoint_b.make_tag_available(tag)
-            return True
-        return False
+        with self._available_tag_lock:
+            if not self.is_tag_available(tag):
+                self.endpoint_a.make_tag_available(tag)
+                self.endpoint_b.make_tag_available(tag)
+                return True
+            return False
 
     def available_vlans(self):
         """Get all available vlans from each interface in the link."""

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -29,7 +29,7 @@ class Link(GenericEntity):
             raise KytosLinkCreationError("endpoint_b cannot be None")
         self.endpoint_a = endpoint_a
         self.endpoint_b = endpoint_b
-        self._available_tag_lock = Lock()
+        self._get_next_available_tag_lock = Lock()
         super().__init__()
 
     def __hash__(self):
@@ -114,7 +114,7 @@ class Link(GenericEntity):
 
     def get_next_available_tag(self):
         """Return the next available tag if exists."""
-        with self._available_tag_lock:
+        with self._get_next_available_tag_lock:
             # Copy the available tags because in case of error
             # we will remove and add elements to the available_tags
             available_tags_a = self.endpoint_a.available_tags.copy()
@@ -143,12 +143,11 @@ class Link(GenericEntity):
 
     def make_tag_available(self, tag):
         """Add a specific tag in available_tags."""
-        with self._available_tag_lock:
-            if not self.is_tag_available(tag):
-                self.endpoint_a.make_tag_available(tag)
-                self.endpoint_b.make_tag_available(tag)
-                return True
-            return False
+        if not self.is_tag_available(tag):
+            self.endpoint_a.make_tag_available(tag)
+            self.endpoint_b.make_tag_available(tag)
+            return True
+        return False
 
     def available_vlans(self):
         """Get all available vlans from each interface in the link."""


### PR DESCRIPTION
Fixes #133 

Description of the change
-----------------------------

Added a `threading.Lock` mechanism to prevent race conditions in `Link.get_next_available_tag()`. The aforementioned method deals with a shared resource, which is `self.endpoint_a.available_tags` and `self.endpoint_b.available_tags`, and when multiple parallel calls are made to this method, the final result may be the same tag for two different requests. One application that makes use of this method is Kytos-ng/mef_eline. We've seen practical situations where the race condition was triggered.

Release notes
---------------
- Fix a race condition at Link get next available tag API.