### PR TITLE
Fixed failing unit tests for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install --upgrade pip
   - pip install -r requirements/dev.txt

--- a/tests/unit/test_core/test_api_server.py
+++ b/tests/unit/test_core/test_api_server.py
@@ -54,22 +54,19 @@ class TestAPIServer(unittest.TestCase):
 
         mock_exit.assert_called()
 
-    @patch('kytos.core.api_server.request')
-    def test_shutdown_api(self, mock_request):
+    def test_shutdown_api(self):
         """Test shutdown_api method."""
-        mock_request.host = 'localhost:8181'
+        path = "http://localhost:8181"
+        with self.api_server.app.test_request_context(path=path):
+            self.api_server.shutdown_api()
+            self.api_server.server.stop.assert_called()
 
-        self.api_server.shutdown_api()
-
-        self.api_server.server.stop.assert_called()
-
-    @patch('kytos.core.api_server.request')
-    def test_shutdown_api__error(self, mock_request):
+    def test_shutdown_api__error(self):
         """Test shutdown_api method to error case."""
-        mock_request.host = 'any:port'
-        self.api_server.shutdown_api()
-
-        self.api_server.server.stop.assert_not_called()
+        path = "http://any:port"
+        with self.api_server.app.test_request_context(path=path):
+            self.api_server.shutdown_api()
+            self.api_server.server.stop.assert_not_called()
 
     def test_status_api(self):
         """Test status_api method."""

--- a/tests/unit/test_core/test_atcp_server.py
+++ b/tests/unit/test_core/test_atcp_server.py
@@ -28,13 +28,11 @@ class TestKytosServer:
 
     def test_connection_to_server(self):
         """Test if we really can connect to TEST_ADDRESS."""
-        @asyncio.coroutine
-        def wait_and_go():
+        async def wait_and_go():
             """Wait a little for the server to go up, then connect."""
-            yield from asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01, loop=self.loop)
             # reader, writer = ...
-            _ = yield from asyncio.open_connection(
-                *TEST_ADDRESS, loop=self.loop)
+            _ = await asyncio.open_connection(*TEST_ADDRESS, loop=self.loop)
 
         self.loop.run_until_complete(wait_and_go())
 

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -216,11 +216,8 @@ class TestController(TestCase):
         controller.start_controller()
 
         controller.server.serve_forever.assert_called()
-        calls = [call(mock_raw_event_handler.return_value),
-                 call(mock_msg_in_event_handler.return_value),
-                 call(mock_msg_out_event_handler.return_value),
-                 call(mock_app_event_handler.return_value)]
-        loop.create_task.assert_has_calls(calls)
+        loop.create_task.call_count == 5
+        assert len(controller._tasks) == 5
         mock_pre_install_napps.assert_called_with([napp])
         mock_load_napps.assert_called()
 

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -202,9 +202,7 @@ class TestController(TestCase):
     @patch('kytos.core.controller.Controller.pre_install_napps')
     def test_start_controller(*args):
         """Test activate method."""
-        (mock_pre_install_napps, mock_load_napps, mock_raw_event_handler,
-         mock_msg_in_event_handler, mock_msg_out_event_handler,
-         mock_app_event_handler, _) = args
+        (mock_pre_install_napps, mock_load_napps, _, _, _, _, _) = args
 
         napp = MagicMock()
         loop = MagicMock()
@@ -216,7 +214,7 @@ class TestController(TestCase):
         controller.start_controller()
 
         controller.server.serve_forever.assert_called()
-        loop.create_task.call_count == 5
+        assert loop.create_task.call_count == 5
         assert len(controller._tasks) == 5
         mock_pre_install_napps.assert_called_with([napp])
         mock_load_napps.assert_called()


### PR DESCRIPTION
This PR fixed #122 that @italovalcy has reported. Unit tests for Python `3.8` are passing now. I've also taken the opportunity to enable tests to run for Python `3.9` since the team has discussed supporting that. This PR is on top of PR #121, so it's carrying extra commits, but these will be gone in the diffs once they're merged. 

I've also mapped an issue #136 to re-asses and fix some warnings since `asyncio` has evolved and some args have got deprecation warnings. 