### PR TITLE
Fix web update to download UI from kytos-ng.

### DIFF
--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -219,43 +219,53 @@ class APIServer:
         """
         if version == 'latest':
             try:
-                url = 'https://api.github.com/repos/kytos/ui/releases/latest'
+                url = 'https://api.github.com/repos/kytos-ng/ui/releases/latest'
                 response = urlopen(url)
                 data = response.readlines()[0]
                 version = json.loads(data)['tag_name']
             except URLError:
-                version = '1.1.1'
+                version = '1.4.1'
 
-        repository = "https://github.com/kytos/ui"
+        repository = "https://github.com/kytos-ng/ui"
         uri = repository + f"/releases/download/{version}/latest.zip"
 
         if not os.path.exists(self.flask_dir) or force:
             # download from github
             try:
+                self.log.info("Web update - Downloading UI from %s.", uri)
                 package = urlretrieve(uri)[0]
             except HTTPError:
-                return f"Uri not found {uri}."
+                self.log.error("Web update - Uri not found %s.", uri)
+                return f"Uri not found {uri}.", HTTPStatus.INTERNAL_SERVER_ERROR.value
             except URLError:
-                self.log.warning("Error accessing URL %s.", uri)
-                return f"Error accessing URL {uri}."
+                self.log.error("Web update - Error accessing URL %s.", uri)
+                return f"Error accessing URL {uri}.", HTTPStatus.INTERNAL_SERVER_ERROR.value
 
             # test downloaded zip file
             zip_ref = zipfile.ZipFile(package, 'r')
 
             if zip_ref.testzip() is not None:
-                return f'Zip file from {uri} is corrupted.'
+                self.log.error("Web update - Zip file from %s is corrupted.", uri)
+                return f'Zip file from {uri} is corrupted.', HTTPStatus.INTERNAL_SERVER_ERROR.value
 
             # backup the old web-ui files and create a new web-ui folder
             if os.path.exists(self.flask_dir):
+                self.log.info("Web update - Performing UI backup.")
                 date = datetime.now().strftime("%Y%m%d%H%M%S")
                 shutil.move(self.flask_dir, f"{self.flask_dir}-{date}")
                 os.mkdir(self.flask_dir)
+            else:
+                self.log.error("Web update - Web UI backup failed.")
 
             # unzip and extract files to web-ui/*
             zip_ref.extractall(self.flask_dir)
             zip_ref.close()
+            self.log.info("Web update - Updated")
+            return "updated the web ui", HTTPStatus.OK.value
+        else:
+            self.log.error("Web update - Web UI was not updated")
+            return "Web ui was not updated", HTTPStatus.INTERNAL_SERVER_ERROR.value
 
-        return "updated the web ui"
 
     # BEGIN decorator methods
 

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -249,13 +249,12 @@ class APIServer:
                 return f'Zip file from {uri} is corrupted.', HTTPStatus.INTERNAL_SERVER_ERROR.value
 
             # backup the old web-ui files and create a new web-ui folder
+            # if there is no path to backup, extractall will create the path.
             if os.path.exists(self.flask_dir):
                 self.log.info("Web update - Performing UI backup.")
                 date = datetime.now().strftime("%Y%m%d%H%M%S")
                 shutil.move(self.flask_dir, f"{self.flask_dir}-{date}")
                 os.mkdir(self.flask_dir)
-            else:
-                self.log.error("Web update - Web UI backup failed.")
 
             # unzip and extract files to web-ui/*
             zip_ref.extractall(self.flask_dir)

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -247,7 +247,7 @@ class APIServer:
             # test downloaded zip file
             with zipfile.ZipFile(package, 'r') as zip_ref:
                 if zip_ref.testzip() is not None:
-                    self.log.error("Web update - Zip file from %s"
+                    self.log.error("Web update - Zip file from %s "
                                    "is corrupted.", uri)
                     return (f'Zip file from {uri} is corrupted.',
                             HTTPStatus.INTERNAL_SERVER_ERROR.value)


### PR DESCRIPTION
Fix #82 and #128
Kytos command "kytos web update" is getting the latest.zip from the old kytos repository.

This PR updates the URL to get the files from kytos-ng repository.
It also adds more log messages and returns HTTP error code in case of error.