### PR TITLE
Fix/issue 140, unauthenticated git://github.com/ when installing dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx-autobuild
--e git://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme
+-e git+https://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme

--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -247,7 +247,7 @@ class Auth:
             nonlocal response
             if not box:
                 response = {
-                    "answer": f'User already exists',
+                    "answer": 'User already exists',
                     "code": HTTPStatus.CONFLICT.value,
                 }
             elif error:

--- a/kytos/core/connection.py
+++ b/kytos/core/connection.py
@@ -111,7 +111,7 @@ class Connection:
         except OSError as exception:
             if exception.errno not in (ENOTCONN, EBADF):
                 raise exception
-        except AttributeError as exception:
+        except AttributeError:
             LOG.debug('Socket Already Closed: %s', self.id)
 
     def is_alive(self):

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -898,7 +898,7 @@ class Controller:
         mod_name = '.'.join(['napps', username, napp_name, napp_file])
         try:
             napp_module = import_module(mod_name)
-        except ModuleNotFoundError as err:
+        except ModuleNotFoundError:
             self.log.error("Module '%s' not found", mod_name)
             raise
         try:

--- a/kytos/core/logs.py
+++ b/kytos/core/logs.py
@@ -142,7 +142,7 @@ class NAppLog:
     def __getattribute__(self, name):
         """Detect NApp ID and use its logger."""
         napp_id = _detect_napp_id()
-        logger = getLogger(f"kytos.napps")
+        logger = getLogger("kytos.napps")
 
         # if napp_id is detected, get the napp logger.
         if napp_id:

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,5 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme
+-e git+https://github.com/kytos-ng/sphinx-theme.git#egg=kytos-sphinx-theme
 pip-tools >= 2.0
 coverage
 pydocstyle

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,5 @@
--e git+git://github.com/kytos/python-openflow.git#egg=python-openflow
--e git+git://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme
+-e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
+-e git+https://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme
 pip-tools >= 2.0
 coverage
 pydocstyle

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in requirements/run.txt
 #
--e git+git://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme  # via -r requirements/dev.in
--e git+git://github.com/kytos/python-openflow.git#egg=python-openflow  # via -r requirements/dev.in, -r requirements/run.txt
+-e git+https://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme  # via -r requirements/dev.in
+-e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow  # via -r requirements/dev.in, -r requirements/run.txt
 alabaster==0.7.12         # via sphinx
 appdirs==1.4.3            # via virtualenv
 appnope==0.1.0            # via -r requirements/run.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in requirements/run.txt
 #
--e git+https://github.com/kytos/sphinx-theme.git#egg=kytos-sphinx-theme  # via -r requirements/dev.in
+-e git+https://github.com/kytos-ng/sphinx-theme.git#egg=kytos-sphinx-theme  # via -r requirements/dev.in
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow  # via -r requirements/dev.in, -r requirements/run.txt
 alabaster==0.7.12         # via sphinx
 appdirs==1.4.3            # via virtualenv

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements/run.txt requirements/run.in
 #
 backcall==0.1.0           # via ipython
-click==7.1.1              # via flask
+click>=7.1.1              # via flask
 decorator==4.4.2          # via ipython, traitlets
 docutils>=0.16            # via python-daemon
 flask-cors==3.0.8         # via -r requirements/run.in

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ from subprocess import CalledProcessError, call, check_call
 
 try:
     # Check if pip is installed
-    import pip  # pylint: disable=unused-import
+    # pylint: disable=unused-import
+    import pip  # noqa
     from setuptools import Command, find_packages, setup
     from setuptools.command.egg_info import egg_info
 except ModuleNotFoundError:
@@ -184,12 +185,14 @@ class CITest(TestCommand):
 
     description = 'run all CI tests: unit and doc tests, linter'
 
+    # pylint: disable=fixme
     def run(self):
         """Run unit tests with coverage, doc tests and linter."""
         coverage_cmd = 'python setup.py coverage %s' % self.get_args()
-        doctest_cmd = 'python setup.py doctest'
+        # TODO see issue 141
+        # doctest_cmd = 'python setup.py doctest'
         lint_cmd = 'python setup.py lint'
-        cmd = '%s && %s && %s' % (coverage_cmd, doctest_cmd, lint_cmd)
+        cmd = '%s && %s' % (coverage_cmd, lint_cmd)
         check_call(cmd, shell=True)
 
 

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -187,7 +187,6 @@ class TestLink(unittest.TestCase):
         def test_get_next_available_tag():
             """Assert that get_next_available_tag() returns different tags."""
             _i.append(1)
-            _i_len = len(_i)
             tag = _link.get_next_available_tag()
             time.sleep(0.0001)
             _link.use_tag(tag)

--- a/tests/unit/test_core/test_napps_base.py
+++ b/tests/unit/test_core/test_napps_base.py
@@ -21,7 +21,7 @@ class TestNapp(unittest.TestCase):
 
     def test__repr__(self):
         """Test __repr__ method."""
-        self.assertEqual(repr(self.napp), f'NApp(kytos/napp)')
+        self.assertEqual(repr(self.napp), 'NApp(kytos/napp)')
 
     def test_id(self):
         """Test id property."""


### PR DESCRIPTION
Fixes #140 

### Description of the change

- It turns out unauthenticated URLs starting with git:// is no longer supported by GitHub, so I had to update the requirements file accordingly to a supported format. I hit this when I started to work on a environment from scratch.
- I also disabled the doc tests because of issue #141
- I've also bumped `click` to unblock `black` as a development dependency (since it was conflicting if any NApps were try to install it since `kytos` had a hard dependency on this `click==7.1.1` version). I noticed we still have several frozen deps from 2020, eventually, it might be worth doing a second pass trying to upgrade some of them, reviewing change logs to add important upstream fixes. 


