### PR TITLE
[Fix] Avoid setting `Switch.connection` as `None`, and handled socket errors

### DIFF
--- a/docs/developer/listened_events.rst
+++ b/docs/developer/listened_events.rst
@@ -38,6 +38,40 @@ with all classes and NApps who can listen to these Events.
 | kytos/core.openflow.raw.in        | Napp: kytos/of_core                             | - :func:`kytos/of_core.handle_raw_in`                             |
 +-----------------------------------+-------------------------------------------------+-------------------------------------------------------------------+
 
+Events
+======
+
+* ``kytos/core.openflow.connection.new``
+
+  * Producer:
+
+    * ``kytos.core.atcp_server.KytosServerProtocol.connection_made``
+
+  * Consumer:
+
+    * ``kytos.core.controller.Controller.new_connection``
+
+
+* ``kytos/core.openflow.connection.error``
+
+  * Producer:
+
+    * ``kytos.core.controller.Controller.msg_out_event_handler``
+
+  * Consumer:
+
+    * ``napps.kytos.flow_manager.main.Main.on_openflow_connection_error``
+
+* ``kytos/core.openflow.connection.lost``
+
+  * Producer:
+
+    * ``kytos.core.atcp_server.KytosServerProtocol.connection_lost``
+
+  * Consumer:
+
+    * ``napps.kytos.topology.main.Main.handle_connection_lost``
+
 OpenFlow Event Message
 ======================
 

--- a/kytos/core/connection.py
+++ b/kytos/core/connection.py
@@ -94,13 +94,11 @@ class Connection:
         except (OSError, SocketError) as exception:
             LOG.debug('Could not send packet. Exception: %s', exception)
             self.close()
+            raise
 
     def close(self):
         """Close the socket from connection instance."""
         self.state = ConnectionState.FINISHED
-        if self.switch and self.switch.connection is self:
-            self.switch.connection = None
-
         LOG.debug('Shutting down Connection %s', self.id)
 
         try:

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -562,9 +562,6 @@ class Controller:
                 if (destination and
                         not destination.state == ConnectionState.FINISHED):
                     packet = message.pack()
-                    if "crash" in triggered_event.content and random.randint(0, 10) >= 7:
-                        self.log.info("boom")
-                        raise OSError("boom")
                     destination.send(packet)
                     self.log.debug('Connection %s: OUT OFP, '
                                    'version: %s, type: %s, xid: %s - %s',

--- a/tests/unit/test_core/test_connection.py
+++ b/tests/unit/test_core/test_connection.py
@@ -52,11 +52,12 @@ class TestConnection(TestCase):
 
         self.connection.socket.sendall.assert_called_with(b'data')
 
-    def test_send__error(self):
+    def test_send_error(self):
         """Test send method to error case."""
         self.connection.socket.sendall.side_effect = SocketError
 
-        self.connection.send(b'data')
+        with self.assertRaises(SocketError):
+            self.connection.send(b'data')
 
         self.assertIsNone(self.connection.socket)
 
@@ -65,6 +66,7 @@ class TestConnection(TestCase):
         self.connection.close()
 
         self.assertIsNone(self.connection.socket)
+        self.assertIsNotNone(self.connection)
 
     def test_close__os_error(self):
         """Test close method to OSError case."""

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -2,9 +2,9 @@
 import asyncio
 import json
 from datetime import datetime, timezone
+from socket import error as SocketError
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
-from socket import error as SocketError
 
 from kytos.core import Controller
 from kytos.core.config import KytosConfig

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime, timezone
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
+from socket import error as SocketError
 
 from kytos.core import Controller
 from kytos.core.config import KytosConfig
@@ -236,6 +237,13 @@ class TestSwitch(TestCase):
         self.switch.send('buffer')
 
         self.switch.connection.send.assert_called_with('buffer')
+
+    def test_send_error(self):
+        """Test send method to error case."""
+        self.switch.connection.send.side_effect = SocketError
+
+        with self.assertRaises(SocketError):
+            self.switch.send(b'data')
 
     @patch('kytos.core.switch.now', return_value=get_date())
     def test_update_lastseen(self, mock_now):


### PR DESCRIPTION
This PR is needed for this this [`issue #26 on flow_manager`](https://github.com/kytos-ng/flow_manager/issues/26):

### Description of the change

- Avoided setting `switch.connection` as `None`, since the `protocol` data associated with the `connection` is needed [to derive the correct class to serialize some FlowMods](https://github.com/kytos-ng/of_core/blob/master/flow.py#L29). This was impacting when the `connection` was lost. Now, instead of completely nuking the `connection` (and losing `protocol` data info associated with it), it only nukes the `socket`. 
- Bubbled up `(OSError, SocketError)` from `Connection.send` to handle socket transmission errors that can happen to propagate back an event via this event `kytos/core.openflow.connection.error`, `flow_manager` (or any other NApp putting messages into `msg_out` queue) is supposed to listen for it (I'll open a new issue to cover this, it's also [related to propagating and handling event errors](https://github.com/kytos-ng/flow_manager/issues/2)), just so this can also be bubbled up to clients via events, something like: 
 
 ```
    @listen_to("kytos/core.openflow.connection.error")
    def on_openflow_connection_error(self, event):
        log.info(f"got error content {event.content}")
        log.info(f"got error xid {event.message.header.xid}")

```
-  Documented on `docs/developer/listened_events.rst` some of the producers and consumers of certain connection events to facilitate understanding, who publishes and who subscribes. 

The consistency checks also partly solves the error handling part if flow mods are asked to be forced, but since we also need NApps to react as soon whatever packet that was supposed to be sent to switch fails, we need to be able to be able to propagate that. So, this coupled with handling and propagating OFPT_ERRORs should help out us to achieve full error propagation. 

