### PR TITLE
using specific version for py37 venv

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,24 +2,42 @@ checks:
     python:
         code_rating: true
         duplicate_code: true
-filter:
-    paths: ['kytos/*', 'tests/*']
-    excluded_paths:
-        - 'kytos/web-ui/*'
 build:
-    environment:
-        python: 3.6
-        postgresql: false
-        redis: false
-    dependencies:
-        before:
-            - pip install coverage
-    tests:
-        override:
-            -
-                command: 'tox'
-                coverage:
-                    file: '.coverage'
-                    config_file: '.coveragerc'
-                    format: 'py-cc'
-            - py-scrutinizer-run
+    nodes:
+        py37:
+            environment:
+                python: 3.7.1
+                postgresql: false
+                redis: false
+            dependencies:
+                before:
+                    - pip install coverage
+            tests:
+                override:
+                    -
+                        command: 'tox -e py37'
+                        only_if: 'tox -a | grep -q py37'
+                        idle_timeout: 300
+                        coverage:
+                            file: '.coverage'
+                            config_file: '.coveragerc'
+                            format: 'py-cc'
+                    - py-scrutinizer-run
+        pyOthers:
+            environment:
+                python: 3.6
+                postgresql: false
+                redis: false
+            dependencies:
+                before:
+                    - pip install coverage
+            tests:
+                override:
+                    -
+                        command: 'for env in $(tox -a | grep -v py37); do tox -e $env; done'
+                        idle_timeout: 300
+                        coverage:
+                            file: '.coverage'
+                            config_file: '.coveragerc'
+                            format: 'py-cc'
+                    - py-scrutinizer-run

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 envlist = py36,py37,py38,py39
 
-[testenv:py37]
-basepython=python3.7.1
-
 [testenv]
 whitelist_externals=
     rm

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist = py36,py37,py38,py39
 
+[testenv:py37]
+basepython=python3.7.1
+
 [testenv]
 whitelist_externals=
     rm


### PR DESCRIPTION
Fixes #146 

### Description of the change

This PR changes the scrutinizer-ci configuration file in way that different tox environments will be run at different scrutinizer nodes. Thus, we can run tox py37 in a node which support python3.7 base executer (i.e., `python: 3.7.1`) and all other nodes will be run in a standard `python: 3.6` node (as it used to be).

The proposed change is already in place for Scrutinizer, but it is applied using a [Repository config](https://scrutinizer-ci.com/g/kytos-ng/kytos/settings/build-config). This PR will synchronize the config to our Checkout config at `.scrutinizer.yml` 

### Release notes

N/A