### PR TITLE
[Feature] ThreadPoolExecutor for `listen_to` events handlers

### DIFF
--- a/kytos/core/buffers.py
+++ b/kytos/core/buffers.py
@@ -5,6 +5,7 @@ import logging
 from janus import Queue
 
 from kytos.core.events import KytosEvent
+from kytos.core.helpers import get_thread_pool_max_workers
 
 __all__ = ('KytosBuffers', )
 
@@ -14,17 +15,20 @@ LOG = logging.getLogger(__name__)
 class KytosEventBuffer:
     """KytosEventBuffer represents a queue to store a set of KytosEvents."""
 
-    def __init__(self, name, event_base_class=None, loop=None):
+    def __init__(self, name, event_base_class=None, loop=None,
+                 maxsize=get_thread_pool_max_workers()):
         """Contructor of KytosEventBuffer receive the parameters below.
 
         Args:
             name (string): name of KytosEventBuffer.
             event_base_class (class): Class of KytosEvent.
+            loop (class): asyncio event loop
+            maxsize (int): maxsize _queue producer buffer
         """
         self.name = name
         self._event_base_class = event_base_class
         self._loop = loop
-        self._queue = Queue(loop=self._loop)
+        self._queue = Queue(maxsize=maxsize, loop=self._loop)
         self._reject_new_events = False
 
     def put(self, event):

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -88,6 +88,10 @@ class KytosConfig():
                             action='store_true',
                             help="Create a kytos superuser.")
 
+        parser.add_argument('-t', '--thread_pool_max_workers',
+                            action='store',
+                            help="Maximum number of threads in the pool.")
+
         self.conf_parser, self.parser = conf_parser, parser
         self.parse_args()
 
@@ -109,6 +113,7 @@ class KytosConfig():
                         'protocol_name': '',
                         'enable_entities_by_default': False,
                         'token_expiration_minutes': 180,
+                        'thread_pool_max_workers': 256,
                         'debug': False}
 
         """
@@ -131,6 +136,7 @@ class KytosConfig():
                     'authenticate_urls': [],
                     'vlan_pool': {},
                     'token_expiration_minutes': 180,
+                    'thread_pool_max_workers': 256,
                     'debug': False}
 
         options, argv = self.conf_parser.parse_known_args()

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -35,6 +35,7 @@ from kytos.core.buffers import KytosBuffers
 from kytos.core.config import KytosConfig
 from kytos.core.connection import ConnectionState
 from kytos.core.events import KytosEvent
+from kytos.core.helpers import executor as executor_pool
 from kytos.core.helpers import now
 from kytos.core.interface import Interface
 from kytos.core.logs import LogManager
@@ -85,6 +86,7 @@ class Controller:
 
         self._loop = loop or asyncio.get_event_loop()
         self._pool = ThreadPoolExecutor(max_workers=1)
+
         # asyncio tasks
         self._tasks = []
 
@@ -408,6 +410,8 @@ class Controller:
         self.napp_dir_listener.stop()
 
         self.log.info("Stopping threadpool: %s", self._pool)
+        if executor_pool:
+            self.log.info(f"Stopping threadpool: {executor_pool}")
 
         threads = threading.enumerate()
         self.log.debug("%s threads before threadpool shutdown: %s",
@@ -418,8 +422,12 @@ class Controller:
             # pylint: disable=unexpected-keyword-arg
             self._pool.shutdown(wait=graceful, cancel_futures=True)
             # pylint: enable=unexpected-keyword-arg
+            if executor_pool:
+                executor_pool.shutdown(wait=graceful, cancel_futures=True)
         except TypeError:
             self._pool.shutdown(wait=graceful)
+            if executor_pool:
+                executor_pool.shutdown(wait=graceful)
 
         # self.server.socket.shutdown()
         # self.server.socket.close()

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -421,7 +421,6 @@ class Controller:
             # Python >= 3.9
             # pylint: disable=unexpected-keyword-arg
             self._pool.shutdown(wait=graceful, cancel_futures=True)
-            # pylint: enable=unexpected-keyword-arg
             if executor_pool:
                 executor_pool.shutdown(wait=graceful, cancel_futures=True)
         except TypeError:

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -411,7 +411,7 @@ class Controller:
 
         self.log.info("Stopping threadpool: %s", self._pool)
         if executor_pool:
-            self.log.info(f"Stopping threadpool: {executor_pool}")
+            self.log.info("Stopping threadpool: %s", executor_pool)
 
         threads = threading.enumerate()
         self.log.debug("%s threads before threadpool shutdown: %s",

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -1,11 +1,23 @@
 """Utilities functions used in Kytos."""
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from threading import Thread
+
+from kytos.core.config import KytosConfig
 
 __all__ = ['listen_to', 'now', 'run_on_thread', 'get_time']
 
 
 # APP_MSG = "[App %s] %s | ID: %02d | R: %02d | P: %02d | F: %s"
+
+
+def get_thread_pool_max_workers():
+    """Get the number of thread pool max workers."""
+    return int(KytosConfig().options["daemon"].thread_pool_max_workers)
+
+
+if get_thread_pool_max_workers():
+    executor = ThreadPoolExecutor(max_workers=get_thread_pool_max_workers())
 
 
 def listen_to(event, *events):
@@ -56,7 +68,7 @@ def listen_to(event, *events):
             def my_stats_handler_of_any_message(self, event):
                 # Do stuff here...
     """
-    def decorator(handler):
+    def thread_decorator(handler):
         """Decorate the handler method.
 
         Returns:
@@ -73,7 +85,25 @@ def listen_to(event, *events):
         threaded_handler.events.extend(events)
         return threaded_handler
 
-    return decorator
+    def thread_pool_decorator(handler):
+        """Decorate the handler method.
+
+        Returns:
+            A method with an `events` attribute (list of events to be listened)
+            and also decorated to run on in the thread pool
+
+        """
+        def inner(*args):
+            """Decorate the handler to run in the thread pool."""
+            executor.submit(handler, *args)
+
+        inner.events = [event]
+        inner.events.extend(events)
+        return inner
+
+    if get_thread_pool_max_workers():
+        return thread_pool_decorator
+    return thread_decorator
 
 
 def now(tzone=timezone.utc):

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -16,6 +16,7 @@ def get_thread_pool_max_workers():
     return int(KytosConfig().options["daemon"].thread_pool_max_workers)
 
 
+# pylint: disable=invalid-name
 executor = None
 if get_thread_pool_max_workers():
     executor = ThreadPoolExecutor(max_workers=get_thread_pool_max_workers())

--- a/tests/unit/test_core/test_helpers.py
+++ b/tests/unit/test_core/test_helpers.py
@@ -2,7 +2,8 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from kytos.core.helpers import get_time, run_on_thread
+from kytos.core.helpers import (get_thread_pool_max_workers, get_time,
+                                listen_to, run_on_thread)
 
 
 class TestHelpers(TestCase):
@@ -20,6 +21,19 @@ class TestHelpers(TestCase):
         test()
 
         mock_thread.return_value.start.assert_called()
+
+    @patch('kytos.core.helpers.executor')
+    def test_listen_to_run_on_threadpool_by_default(self, mock_executor):
+        """Test listen_to runs on ThreadPoolExecutor by default."""
+
+        assert get_thread_pool_max_workers() > 0
+
+        @listen_to("some_event")
+        def test(event):
+            pass
+
+        assert test({}) is None
+        mock_executor.submit.assert_called()
 
     def test_get_time__str(self):
         """Test get_time method passing a string as parameter."""

--- a/tests/unit/test_core/test_helpers.py
+++ b/tests/unit/test_core/test_helpers.py
@@ -22,15 +22,16 @@ class TestHelpers(TestCase):
 
         mock_thread.return_value.start.assert_called()
 
+    @staticmethod
     @patch('kytos.core.helpers.executor')
-    def test_listen_to_run_on_threadpool_by_default(self, mock_executor):
+    def test_listen_to_run_on_threadpool_by_default(mock_executor):
         """Test listen_to runs on ThreadPoolExecutor by default."""
 
         assert get_thread_pool_max_workers() > 0
 
         @listen_to("some_event")
         def test(event):
-            pass
+            _ = event
 
         assert test({}) is None
         mock_executor.submit.assert_called()


### PR DESCRIPTION
Fixes #148 

- Added a `ThreadPoolExecutor` for the `listen_to` decorator to enhance memory management and increase the overall responsiveness by making use of queue buffering for producers. 

### Description of the change

- Added on `kytosd` a `--thread_pool_max_workers` configuration option to control the size of the thread pool. 

- As you can see in the results below, if the producers start overwhelmingly create events, `kytosd` doesn't have an upper bound limit in terms of threads, and executions can start piling up which in turn can lead to a lot of memory usage, and if producers won't stop, this can further lead to starvation problems like unresponsiveness, in this picture below, there are 700+ events/sec using these two stress tests (throw-away) NApps [ping](https://www.github.com/viniarck/kytos_ping) and [pong](https://www.github.com/viniarck/kytos_pong): 

![thread_pool_res](https://user-images.githubusercontent.com/1010796/145088723-428da89a-af47-4e3c-8faf-f2385f5f1705.png)


- The optimal number of threads depends on how many producers, consumers, events, locks, IO interruptions being used and the underlying capacity of CPU/MEM of the host runtime and OS. I've run several benchmark test (in a scenario with 700+ events/sec) to try to provide a reasonable default value that should be good for most of the cases, and as you can see in the figure below, based on an idea that @italovalcy has also suggested to measure delay response times of the events 256 threads has demonstrated to be good enough, notice that with `32`  threads the response times and overall statistics were better, probably because of fewer context switching for this case in particular, but considering a case where several NApps are running, slower methods, and also if there are a significant number of locks, it would be handy to have some extra threads ready in the pool, so, that's why I believe that having a default of `256` threads despite slightly worse time diff responsiveness for some events in case when it's overwhelmed, it would provide a better experience out of the box, and then operators can tune accordingly based on what they have.

![ping_pong_time_diff_results](https://user-images.githubusercontent.com/1010796/145089285-181c79c8-c103-44cb-b20d-5feec11fdbf4.png)

- Notice that this isn't also a completely bullet proof solution, but it'll result in less memory usage and more stability in terms of `listen_to` handlers executions, and if there are still producers overwhelmingly queuing too much the memory usage can still keep increasing although at a way slower pace than the unbounded case that we used to have, as the queue will hold that in memory, however, as consumers start doing their job it should eventually normalize. 

**Future work/improvements**: 

- In the same way the we could have dedicated `queues` for events, we could have dedicated or high priority `ThreadPoolExecutor` for different NApps, let's say `of_core` could have higher priority than other less critical NApps.  
- `async alisten_to` version of `listen_to` for NApps that are heavily using IO and waiting a lot (when this pattern use case arises)
- Invest time and effort to migrate to a specific message broker like RabbitMQ but that has a high effort considering all the objects being passed around, architecture, infrastructure and so on, the team is aware of this, but just mentioning here again, for the record, for future readers of this PR. 


