### PR TITLE
Add __repr__ to Link

### DIFF
--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -33,6 +33,9 @@ class Link(GenericEntity):
     def __hash__(self):
         return hash(self.id)
 
+    def __repr__(self):
+        return f"Link({self.endpoint_a!r}, {self.endpoint_b!r})"
+
     def is_enabled(self):
         """Override the is_enabled method.
 

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -48,6 +48,13 @@ class TestLink(unittest.TestCase):
         self.assertTrue(link_1.__eq__(link_2))
         self.assertFalse(link_1.__eq__(link_3))
 
+    def test__repr__(self):
+        """Test __repr__ method."""
+        link = Link(self.iface1, self.iface2)
+        expected = ("Link(Interface('interface1', 41, Switch('dpid1')), "
+                    "Interface('interface2', 42, Switch('dpid2')))")
+        self.assertEqual(repr(link), expected)
+
     def test_id(self):
         """Test id property."""
         link = Link(self.iface1, self.iface2)


### PR DESCRIPTION
Fixes kytos-ng/mef_eline#98

### Description of the change

This PR adds the `__repr__()` method to Link class. Tests were created accordingly. Having the string representation of a Link will be useful for applications that needs to report on Link objects, such as the case detailed at Issue kytos-ng/mef_eline#98

### Release notes

- Added Link string representation