### PR TITLE
[Fix] Updated `lastseen` before publishing `kytos/core.switch.new|reconnected`

### DIFF
--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -675,6 +675,7 @@ class Controller:
                 if old_connection is not connection:
                     self.remove_connection(old_connection)
 
+            switch.update_lastseen()
             self.buffers.app.put(event)
 
             return switch


### PR DESCRIPTION
Fixes `of_core` issue 38 

### Description of the change

It turns out that the `is_active` method on the switch, depends on the `lastseen` attr, but this was only being updated once the `switch` had been known in the [`handle_raw_in` listener](https://github.com/kytos-ng/of_core/blob/master/main.py#L222-L231), which left room for incorrectly assuming the Switch connection [`is_connected` ](https://github.com/kytos-ng/kytos/blob/master/kytos/core/switch.py#L192-L196) as false in some cases, since it depends on the `is_active() and lastseen`. This problem can be observed when applications like `of_lldp` send a flow mod right away after the handshake has just been completed, which was the case of some system test cases failures that @italovalcy has caught and reported [on `of_core` issue 38](https://github.com/kytos-ng/of_core/issues/38)

### Release notes

Updated `lastseen` before publishing `kytos/core.switch.new|reconnected`, just so the `connection.is_active()` works as intended 
