### PR TITLE
Change Switch is_active to use is_connected

### DIFF
--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -187,13 +187,14 @@ class Switch(GenericEntity):
 
     def is_active(self):
         """Return true if the switch connection is alive."""
-        return (now() - self.lastseen).seconds <= CONNECTION_TIMEOUT
+        return self.is_connected()
 
     def is_connected(self):
         """Verify if the switch is connected to a socket."""
         return (self.connection is not None and
                 self.connection.is_alive() and
-                self.connection.is_established() and self.is_active())
+                self.connection.is_established() and
+                (now() - self.lastseen).seconds <= CONNECTION_TIMEOUT)
 
     def update_connection(self, connection):
         """Update switch connection.

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -194,29 +194,32 @@ class TestSwitch(TestCase):
         connection.is_alive.return_value = True
         connection.is_established.return_value = True
         self.switch.connection = connection
-        self.switch.is_active = MagicMock()
-        self.switch.is_active.return_value = True
 
         self.assertTrue(self.switch.is_connected())
 
     def test_is_connected__not_connection(self):
         """Test is_connected method when connection does not exist."""
         self.switch.connection = None
-        self.switch.is_active = MagicMock()
-        self.switch.is_active.return_value = True
 
         self.assertFalse(self.switch.is_connected())
 
     def test_is_connected__not_alive(self):
-        """Test is_connected method when switch is not active."""
+        """Test is_connected method when switch has connection timeout."""
         connection = MagicMock()
         connection.is_alive.return_value = True
         connection.is_established.return_value = True
         self.switch.connection = connection
-        self.switch.is_active = MagicMock()
-        self.switch.is_active.return_value = False
+        self.switch.lastseen = datetime(1, 1, 1, 0, 0, 0, 0, timezone.utc)
 
         self.assertFalse(self.switch.is_connected())
+
+    def test_is_active(self):
+        """Test is_active method."""
+        self.switch.is_connected = MagicMock()
+        self.switch.is_connected.return_value = True
+        self.assertTrue(self.switch.is_active())
+        self.switch.is_connected.return_value = False
+        self.assertFalse(self.switch.is_active())
 
     def test_update_connection(self):
         """Test update_connection method."""


### PR DESCRIPTION
Fixes kytos-ng/topology#36

### Description of the change

This PR changes `Switch.is_active()` to use `Switch.is_connected()` and moves the timeout check from is_active to is_connected. The proposed change will fix the issue kytos-ng/topology#36. This change is also related to kytos-ng/of_core#38.

Unit tests were adjusted accordingly.

The end-to-end tests were run to guarantee no undesired impact would pop up from this change.

Unit tests for kytos-ng/of_core and kytos-ng/topology were also verified to check compatibility.

### Release notes

- Changed Switch.is_active to use Switch.is_connected to ensure more accuracy on switch status attribute 