### PR TITLE
Freeze pytest version to be compatible with py3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -254,7 +254,7 @@ setup(name='kytos',
                         for line in open("requirements/run.txt").readlines()
                         if not line.startswith('#')],
       setup_requires=PYTEST_RUNNER,
-      tests_require=['pytest'],
+      tests_require=['pytest==7.0.0'],
       cmdclass={
           'clean': Cleaner,
           'ci': CITest,


### PR DESCRIPTION
pytest `7.1.0` [has dropped support for python 3.6](https://github.com/pytest-dev/pytest/issues/9437), this has impacted some Kytos NApps continuous integration with scrutinizer on GitHub that we haven't prioritized upgrading their tox environment yet, so if you see failing tests that's the reason why. On kytos core, we also still had some tests running on py36 on the CI, I think we should also start dropping support to facilitate maintenance. 