### PR TITLE
Unhandled exception on a listen_to decorated function is now logged as error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ UNRELEASED - Under development
 ******************************
 Added
 =====
+- Unhandled exception on a ``listen_to`` decorated function (running in a ThreadPool) is logged as error.
 
 Changed
 =======

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -104,8 +104,8 @@ def listen_to(event, *events):
             else:
                 exc_str = f"{type(future.exception())}: {future.exception()}"
                 args = (
-                    getattr(future, "__inner_args")
-                    if hasattr(future, "__inner_args")
+                    getattr(future, "__args")
+                    if hasattr(future, "__args")
                     else tuple()
                 )
                 LOG.error(f"listen_to handler: {handler}, "
@@ -114,7 +114,7 @@ def listen_to(event, *events):
         def inner(*args):
             """Decorate the handler to run in the thread pool."""
             future = executor.submit(handler, *args)
-            setattr(future, "__inner_args", args)
+            setattr(future, "__args", args)
             future.add_done_callback(done_callback)
 
         inner.events = [event]

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -114,8 +114,7 @@ def listen_to(event, *events):
         def inner(*args):
             """Decorate the handler to run in the thread pool."""
             future = executor.submit(handler, *args)
-            inner_args = args[1:] if len(args) > 1 else args
-            setattr(future, "__inner_args", inner_args)
+            setattr(future, "__inner_args", args)
             future.add_done_callback(done_callback)
 
         inner.events = [event]

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -1,4 +1,6 @@
 """Utilities functions used in Kytos."""
+import logging
+
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from threading import Thread
@@ -7,6 +9,7 @@ from kytos.core.config import KytosConfig
 
 __all__ = ['listen_to', 'now', 'run_on_thread', 'get_time']
 
+LOG = logging.getLogger(__name__)
 
 # APP_MSG = "[App %s] %s | ID: %02d | R: %02d | P: %02d | F: %s"
 
@@ -99,10 +102,21 @@ def listen_to(event, *events):
             """Done callback."""
             if not future.exception():
                 _ = future.result()
+            else:
+                exc_str = f"{type(future.exception())}: {future.exception()}"
+                args = (
+                    getattr(future, "__inner_args")
+                    if hasattr(future, "__inner_args")
+                    else tuple()
+                )
+                LOG.error(f"listen_to handler: {handler}, "
+                          f"args: {args}, exception: {exc_str}")
 
         def inner(*args):
             """Decorate the handler to run in the thread pool."""
             future = executor.submit(handler, *args)
+            inner_args = args[1:] if len(args) > 1 else args
+            setattr(future, "__inner_args", inner_args)
             future.add_done_callback(done_callback)
 
         inner.events = [event]

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -1,6 +1,5 @@
 """Utilities functions used in Kytos."""
 import logging
-
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from threading import Thread

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 radon mi args = --min C
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,logging-format-interpolation
 
 [pydocstyle]
 add-ignore = D105


### PR DESCRIPTION
Fixes #195

### Description of the change

Unhandled exception on a listen_to decorated function (running in a ThreadPool) is logged as error. 

### Example

- Running the same example mentioned on issue 195, the exception is logged as an error with enough information o start debugging, so now if you're debugging or refactoring multiple `listen_to` decorated methods/functions it should be more helpful:

```
2022-03-25 15:19:08,079 - ERROR [kytos.core.helpers] (ThreadPoolExecutor-0_6) listen_to handler: <function Main.on_new_switch at 0x7fdd3c5d5f70>, args: (<Main(sample_ui, stopped 140587953018432)>, KytosEvent('kytos/core.switch.reconnected', {'switch': Switch('00:00:00:00:00:00:00:03')})), exception: <class 'ValueError'>: crashed
2022-03-25 15:19:08,081 - ERROR [kytos.core.helpers] (ThreadPoolExecutor-0_4) listen_to handler: <function Main.on_new_switch at 0x7fdd3c5d5f70>, args: (<Main(sample_ui, stopped 140587953018432)>, KytosEvent('kytos/core.switch.reconnected', {'switch': Switch('00:00:00:00:00:00:00:01')})), exception: <class 'ValueError'>: crashed
2022-03-25 15:19:08,107 - ERROR [kytos.core.helpers] (ThreadPoolExecutor-0_7) listen_to handler: <function Main.on_new_switch at 0x7fdd3c5d5f70>, args: (<Main(sample_ui, stopped 140587953018432)>, KytosEvent('kytos/core.switch.reconnected', {'switch': Switch('00:00:00:00:00:00:00:02')})), exception: <class 'ValueError'>: crashed
```

