### PR TITLE
[Feature] Dead letter structure for unhandled exceptions of KytosEvents indexed by their names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ Added
 - Added MongoDB environment variables ``MONGO_HOST_SEEDS, MONGO_USERNAME, MONGO_PASSWORD``
 - Added optional MongoDB environment ``MONGO_DBNAME, MONGO_MAX_POOLSIZE, MONGO_MIN_POOLSIZE``
 - Added a docker-compose.yml file for local development to compose with MongoDB replica set cluster
+- Added an in-memory dead letter structure for storing KytosEvents indexed by ``listen_to`` subscribed topics.
+- Added core endpoints for dead letter structure:
+
+  .. code:: console
+
+   GET /api/kytos/core/dead_letter/?topic=<topic>
+   PATCH /api/kytos/core/dead_letter/ (requires request body)
+   DELETE /api/kytos/core/dead_letter/ (requires request body)
 
 Changed
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,18 +15,19 @@ Added
 - Added MongoDB environment variables ``MONGO_HOST_SEEDS, MONGO_USERNAME, MONGO_PASSWORD``
 - Added optional MongoDB environment ``MONGO_DBNAME, MONGO_MAX_POOLSIZE, MONGO_MIN_POOLSIZE``
 - Added a docker-compose.yml file for local development to compose with MongoDB replica set cluster
-- Added an in-memory dead letter structure for storing KytosEvents indexed by ``listen_to`` subscribed topics.
-- Added core endpoints for dead letter structure:
+- Added an in-memory dead letter structure for unhandled exceptions of KytosEvents indexed by their names
+- Added core endpoints for the dead letter structure:
 
   .. code:: console
 
-   GET /api/kytos/core/dead_letter/?topic=<topic>
+   GET /api/kytos/core/dead_letter/?event_name=<name>
    PATCH /api/kytos/core/dead_letter/ (requires request body)
    DELETE /api/kytos/core/dead_letter/ (requires request body)
 
 Changed
 =======
 - Kytos controller can shutdown if the database is configured but not reachable during startup time.
+- Augmented ``KytosEvent`` with internal attributes (``id`` and ``reinjections``), no breaking changes.
 
 Deprecated
 ==========

--- a/docs/developer/rest_endpoints.rst
+++ b/docs/developer/rest_endpoints.rst
@@ -159,25 +159,25 @@ Run ``kytosd -f``, and run the code below on the kytos console:
 
 **Dead Letter Endpoints**
 
-List KytosEvent dead letter structure (and filter a given subscribed topic).
+List KytosEvent dead letter structure (and filter a given KytosEvent name).
 
 .. code:: console
 
-   GET /api/kytos/core/dead_letter/?topic=<topic>
+   GET /api/kytos/core/dead_letter/?event_name=<name>
 
-Reinject KytosEvents from a given subscribed topic back into a Kytos buffer queue (``app`` or ``msg_in``).
+Reinject KytosEvents into a Kytos buffer queue (``app`` or ``msg_in``).
 
 .. code:: console
 
    PATCH /api/kytos/core/dead_letter/
-   request body: {"topic": "some_topic", "ids": ["id"], "kytos_queue_buffer": "app"}
+   request body: {"event_name": "some_name", "ids": ["id"], "kytos_queue_buffer": "app"}
 
-Delete a single KytosEvent or all from a given subscribed topic.
+Delete a single KytosEvent or all.
 
 .. code:: console
 
    DELETE /api/kytos/core/dead_letter/
-   request body: {"topic": "all", "ids": ["id"]}
+   request body: {"event_name": "all", "ids": ["id"]}
 
 
 NApps' REST Endpoints

--- a/docs/developer/rest_endpoints.rst
+++ b/docs/developer/rest_endpoints.rst
@@ -157,6 +157,28 @@ Run ``kytosd -f``, and run the code below on the kytos console:
     routes = [(str(rule), rule.methods) for rule in urls]
     sorted(routes)
 
+**Dead Letter Endpoints**
+
+List KytosEvent dead letter structure (and filter a given subscribed topic).
+
+.. code:: console
+
+   GET /api/kytos/core/dead_letter/?topic=<topic>
+
+Reinject KytosEvents from a given subscribed topic back into a Kytos buffer queue (``app`` or ``msg_in``).
+
+.. code:: console
+
+   PATCH /api/kytos/core/dead_letter/
+   request body: {"topic": "some_topic", "ids": ["id"], "kytos_queue_buffer": "app"}
+
+Delete a single KytosEvent or all from a given subscribed topic.
+
+.. code:: console
+
+   DELETE /api/kytos/core/dead_letter/
+   request body: {"topic": "all", "ids": ["id"]}
+
 
 NApps' REST Endpoints
 =====================

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -36,6 +36,7 @@ from kytos.core.buffers import KytosBuffers
 from kytos.core.config import KytosConfig
 from kytos.core.connection import ConnectionState
 from kytos.core.db import db_conn_wait
+from kytos.core.dead_letter import DeadLetter
 from kytos.core.events import KytosEvent
 from kytos.core.exceptions import KytosDBInitException
 from kytos.core.helpers import executor as executor_pool
@@ -144,6 +145,7 @@ class Controller:
                                     self.napps_manager, self.options.napps)
 
         self.auth = Auth(self)
+        self.dead_letter = DeadLetter(self)
 
         self._register_endpoints()
         #: Adding the napps 'enabled' directory into the PATH
@@ -353,6 +355,7 @@ class Controller:
         self.api_server.register_core_endpoint('reload/all',
                                                self.rest_reload_all_napps)
         self.auth.register_core_auth_services()
+        self.dead_letter.register_endpoints()
 
     def register_rest_endpoint(self, url, function, methods):
         """Deprecate in favor of @rest decorator."""

--- a/kytos/core/dead_letter.py
+++ b/kytos/core/dead_letter.py
@@ -14,18 +14,21 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 class KytosQueueBufferNames(str, Enum):
     """KytosQueueBufferNames."""
+
     app = "app"
     msg_in = "msg_in"
 
 
 class DeadLetterDeletePayload(BaseModel):
     """DeadLetterDeletePayload."""
+
     event_name: constr(min_length=1)
     ids: List[str] = []
 
 
 class DeadLetterPatchPayload(DeadLetterDeletePayload):
     """DeadLetterPatchPayload."""
+
     kytos_queue_buffer: KytosQueueBufferNames
 
 

--- a/kytos/core/dead_letter.py
+++ b/kytos/core/dead_letter.py
@@ -6,11 +6,14 @@ from threading import Lock
 from typing import List
 
 from flask import jsonify, request
+# pylint: disable=no-name-in-module
 from pydantic import BaseModel, ValidationError, constr
+# pylint: enable=no-name-in-module
 from werkzeug.exceptions import BadRequest, NotFound
 
 
 class KytosQueueBufferNames(str, Enum):
+    """KytosQueueBufferNames."""
     app = "app"
     msg_in = "msg_in"
 
@@ -41,7 +44,8 @@ class DeadLetter:
         self._lock = Lock()
         self._max_len_per_topic = 100000
 
-    def _get_request(self):
+    @staticmethod
+    def _get_request():
         """Get request context."""
         return request
 
@@ -123,14 +127,15 @@ class DeadLetter:
         """List dead letter by topic."""
         response = defaultdict(dict)
         for key, value in self.dict[topic].items():
-            response[topic][str(value.id)] = json.loads(value.as_json())
+            response[topic][key] = json.loads(value.as_json())
         return response
 
     def list_topics(self):
+        """List dead letter topics."""
         response = defaultdict(dict)
         for topic, _dict in self.dict.items():
             for key, value in _dict.items():
-                response[topic][str(value.id)] = json.loads(value.as_json())
+                response[topic][key] = json.loads(value.as_json())
         return response
 
     def add_event(self, event):

--- a/kytos/core/dead_letter.py
+++ b/kytos/core/dead_letter.py
@@ -1,17 +1,13 @@
 """Dead letter dict tructure."""
 import json
 from collections import OrderedDict, defaultdict
+from enum import Enum
 from threading import Lock
-
-from werkzeug.exceptions import BadRequest, NotFound
-
-from flask import jsonify, request
-from pydantic import BaseModel
-from pydantic import ValidationError
-from pydantic import constr
 from typing import List
 
-from enum import Enum
+from flask import jsonify, request
+from pydantic import BaseModel, ValidationError, constr
+from werkzeug.exceptions import BadRequest, NotFound
 
 
 class KytosQueueBufferNames(str, Enum):

--- a/kytos/core/dead_letter.py
+++ b/kytos/core/dead_letter.py
@@ -1,0 +1,160 @@
+"""Dead letter dict tructure."""
+import json
+from collections import OrderedDict, defaultdict
+from threading import Lock
+
+from werkzeug.exceptions import BadRequest, NotFound
+
+from flask import jsonify, request
+from pydantic import BaseModel
+from pydantic import ValidationError
+from pydantic import constr
+from typing import List
+
+from enum import Enum
+
+
+class KytosQueueBufferNames(str, Enum):
+    app = "app"
+    msg_in = "msg_in"
+
+
+class DeadLetterDeletePayload(BaseModel):
+    """DeadLetterDeletePayload."""
+    topic: constr(min_length=1)
+    ids: List[str] = []
+
+
+class DeadLetterPatchPayload(DeadLetterDeletePayload):
+    """DeadLetterPatchPayload."""
+    kytos_queue_buffer: KytosQueueBufferNames
+
+
+class DeadLetter:
+    """DeadLetter."""
+
+    def __init__(self, controller):
+        """Init DeadLetter.
+
+        Args:
+            controller(kytos.core.controller): A Controller instance.
+
+        """
+        self.controller = controller
+        self.dict = defaultdict(OrderedDict)  # topic dict of KytosEvents
+        self._lock = Lock()
+        self._max_len_per_topic = 100000
+
+    def register_endpoints(self) -> None:
+        """Register core endpoints."""
+        api = self.controller.api_server
+        api.register_core_endpoint("dead_letter/", self.rest_list,
+                                   methods=["GET"])
+        api.register_core_endpoint("dead_letter/", self.rest_delete,
+                                   methods=["DELETE"])
+        api.register_core_endpoint("dead_letter/", self.rest_patch,
+                                   methods=["PATCH"])
+
+    def rest_list(self):
+        """List dead letter topics."""
+        topic = request.args.get("topic")
+        response = (
+            self.list_topics()
+            if not topic
+            else self.list_topic(topic)
+        )
+        return jsonify(response)
+
+    def rest_patch(self):
+        """Reinject dead letter events."""
+        body = request.json or {}
+        try:
+            body = DeadLetterPatchPayload(**body)
+        except ValidationError as exc:
+            raise BadRequest(exc.errors())
+
+        topic = body.topic
+        if topic not in self.dict:
+            raise NotFound(f"topic {topic} not found")
+
+        diff_ids = set(body.ids) - set(self.dict[topic].keys())
+        if diff_ids:
+            raise NotFound(f"KytosEvent ids not found: {diff_ids}")
+
+        _ids = body.ids or self.dict[topic].keys()
+        for _id in _ids:
+            self.reinject(topic, _id, body.kytos_queue_buffer)
+
+        return jsonify()
+
+    def rest_delete(self):
+        """Delete dead letter events.
+
+        topic 'all' means explicitly delete all topics and events
+
+        """
+        body = request.json or {}
+        try:
+            body = DeadLetterDeletePayload(**body)
+        except ValidationError as exc:
+            raise BadRequest(exc.errors())
+
+        topic = body.topic
+        if topic == "all":
+            for topic in self.dict.keys():
+                self.delete_topic(topic)
+            return jsonify()
+
+        if topic not in self.dict:
+            return NotFound(f"topic {topic} not found")
+
+        diff_ids = set(body.ids) - set(self.dict[topic].keys())
+        if diff_ids:
+            raise NotFound(f"KytosEvent ids not found: {diff_ids}")
+
+        if not body.ids:
+            self.delete_topic(topic)
+        else:
+            for _id in body.ids:
+                self.delete_event(topic, _id)
+        return jsonify()
+
+    def list_topic(self, topic: str):
+        """List dead letter by topic."""
+        response = defaultdict(dict)
+        for key, value in self.dict[topic].items():
+            response[topic][str(value.id)] = json.loads(value.as_json())
+        return response
+
+    def list_topics(self):
+        response = defaultdict(dict)
+        for topic, _dict in self.dict.items():
+            for key, value in _dict.items():
+                response[topic][str(value.id)] = json.loads(value.as_json())
+        return response
+
+    def add_event(self, event):
+        """Add a KytoEvent to the dead letter."""
+        if len(self.dict[event.name]) >= self._max_len_per_topic:
+            self.dict[event.name].popitem(last=False)
+        self.dict[event.name][str(event.id)] = event
+
+    def delete_event(self, topic: str, event_id: str):
+        """Delete a KytoEvent from the dead letter."""
+        return self.dict[topic].pop(event_id, None)
+
+    def delete_topic(self, topic: str):
+        """Delete a topic from the dead letter."""
+        return self.dict.pop(topic, None)
+
+    def reinject(self, topic: str, event_id: str, buffer_name: str):
+        """Reinject an KytosEvent into a KytosEventBuffer."""
+        if buffer_name not in {"app", "msg_in"}:
+            return
+        with self._lock:
+            kytos_event = self.dict[topic].pop(event_id, None)
+            if not kytos_event:
+                return
+            kytos_event.reinjections += 1
+        event_buffer = getattr(self.controller.buffers, buffer_name)
+        event_buffer.put(kytos_event)

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -36,7 +36,7 @@ class KytosEvent:
     def as_dict(self):
         """Return KytosEvent as a dict."""
         return {'id': str(self.id), 'name': self.name, 'content': self.content,
-                'timestamp': self.timestamp, 'reinjections': 0}
+                'timestamp': self.timestamp, 'reinjections': self.reinjections}
 
     def as_json(self):
         """Return KytosEvent as json."""

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -1,4 +1,7 @@
 """Module with Kytos Events."""
+import json
+from datetime import datetime
+from uuid import uuid4
 
 from kytos.core.helpers import now
 
@@ -21,12 +24,30 @@ class KytosEvent:
         self.name = name
         self.content = content if content is not None else {}
         self.timestamp = now()
+        self.id = uuid4()
+        self.reinjections = 0
 
     def __str__(self):
         return self.name
 
     def __repr__(self):
         return f"KytosEvent({self.name!r}, {self.content!r})"
+
+    def as_dict(self):
+        """Return KytosEvent as a dict."""
+        return {'id': str(self.id), 'name': self.name, 'content': self.content,
+                'timestamp': self.timestamp, 'reinjections': 0}
+
+    def as_json(self):
+        """Return KytosEvent as json."""
+        as_dict = self.as_dict()
+        ts = datetime.strftime(as_dict['timestamp'], '%Y-%m-%dT%H:%M:%S')
+        as_dict['timestamp'] = ts
+        try:
+            return json.dumps(as_dict)
+        except TypeError:
+            as_dict.pop('content', None)
+            return json.dumps(as_dict)
 
     @property
     def destination(self):

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -24,8 +24,11 @@ class KytosEvent:
         self.name = name
         self.content = content if content is not None else {}
         self.timestamp = now()
-        self.id = uuid4()
         self.reinjections = 0
+
+        # pylint: disable=invalid-name
+        self.id = uuid4()
+        # pylint: enable=invalid-name
 
     def __str__(self):
         return self.name
@@ -41,8 +44,9 @@ class KytosEvent:
     def as_json(self):
         """Return KytosEvent as json."""
         as_dict = self.as_dict()
-        ts = datetime.strftime(as_dict['timestamp'], '%Y-%m-%dT%H:%M:%S')
-        as_dict['timestamp'] = ts
+        timestamp = datetime.strftime(as_dict['timestamp'],
+                                      '%Y-%m-%dT%H:%M:%S')
+        as_dict['timestamp'] = timestamp
         try:
             return json.dumps(as_dict)
         except TypeError:

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -46,7 +46,7 @@ class KytosEvent:
         try:
             return json.dumps(as_dict)
         except TypeError:
-            as_dict.pop('content', None)
+            as_dict['content'] = str(as_dict['content'])
             return json.dumps(as_dict)
 
     @property

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -101,15 +101,19 @@ def listen_to(event, *events):
             """Done callback."""
             if not future.exception():
                 _ = future.result()
-            else:
-                exc_str = f"{type(future.exception())}: {future.exception()}"
-                args = (
-                    getattr(future, "__args")
-                    if hasattr(future, "__args")
-                    else tuple()
-                )
-                LOG.error(f"listen_to handler: {handler}, "
-                          f"args: {args}, exception: {exc_str}")
+                return
+
+            exc_str = f"{type(future.exception())}: {future.exception()}"
+            args = (
+                getattr(future, "__args")
+                if hasattr(future, "__args")
+                else tuple()
+            )
+            LOG.error(f"listen_to handler: {handler}, "
+                      f"args: {args}, exception: {exc_str}")
+            if len(args) > 1 and hasattr(args[0], "controller"):
+                cls, kytos_event = args[0], args[1]
+                cls.controller.dead_letter.add_event(kytos_event)
 
         def inner(*args):
             """Decorate the handler to run in the thread pool."""

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -725,3 +725,8 @@ class TestController(TestCase):
         self.loop.run_until_complete(self.controller.app_event_handler())
 
         mock_notify_listeners.assert_called_with(event)
+
+    def test_init_attrs(self):
+        """Test init attrs."""
+        assert self.controller.auth
+        assert self.controller.dead_letter

--- a/tests/unit/test_core/test_dead_letter.py
+++ b/tests/unit/test_core/test_dead_letter.py
@@ -3,6 +3,7 @@
 
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
+
 from werkzeug.exceptions import NotFound
 
 from kytos.core.dead_letter import DeadLetter

--- a/tests/unit/test_core/test_dead_letter.py
+++ b/tests/unit/test_core/test_dead_letter.py
@@ -40,14 +40,14 @@ class TestDeadLetter(TestCase):
         assert self.dead_letter.delete_event(mock_ev.name, mock_ev.id)
         assert mock_ev.id not in self.dead_letter.dict[mock_ev.name]
 
-    def test_delete_topic(self):
-        """test delete_topic."""
-        topic = "topic"
-        assert topic not in self.dead_letter.dict
-        self.dead_letter.dict["topic"] = "some_value"
-        assert topic in self.dead_letter.dict
-        self.dead_letter.delete_topic(topic)
-        assert topic not in self.dead_letter.dict
+    def test_delete_event_name(self):
+        """test delete_event_name."""
+        event_name = "event_name"
+        assert event_name not in self.dead_letter.dict
+        self.dead_letter.dict[event_name] = "some_value"
+        assert event_name in self.dead_letter.dict
+        self.dead_letter.delete_event_name(event_name)
+        assert event_name not in self.dead_letter.dict
 
     def test_register_endpoints(self):
         """test register_endpoints."""
@@ -67,11 +67,12 @@ class TestDeadLetter(TestCase):
         jsonify.assert_called()
 
     @patch("kytos.core.dead_letter.jsonify")
-    def test_rest_patch_topic_not_found(self, _):
-        """test rest_patch topic not found."""
-        topic = "some_topic"
+    def test_rest_patch_event_name_not_found(self, _):
+        """test rest_patch event_name not found."""
+        event_name = "some_name"
         ids = ["id"]
-        body = {"topic": topic, "ids": ids, "kytos_queue_buffer": "app"}
+        body = {"event_name": event_name, "ids": ids,
+                "kytos_queue_buffer": "app"}
         request = self.dead_letter._get_request
         resp = MagicMock()
         resp.json = body
@@ -81,40 +82,42 @@ class TestDeadLetter(TestCase):
 
     @patch("kytos.core.dead_letter.jsonify")
     def test_rest_patch_ids_not_found(self, _):
-        """test rest_patch topic ids found."""
-        topic = "some_topic"
+        """test rest_patch event_name ids found."""
+        event_name = "some_name"
         ids = ["id"]
-        body = {"topic": topic, "ids": ids, "kytos_queue_buffer": "app"}
+        body = {"event_name": event_name, "ids": ids,
+                "kytos_queue_buffer": "app"}
         request = self.dead_letter._get_request
         resp = MagicMock()
         resp.json = body
         request.return_value = resp
-        self.dead_letter.dict[topic] = {}
+        self.dead_letter.dict[event_name] = {}
         with self.assertRaises(NotFound):
             self.dead_letter.rest_patch()
 
     @patch("kytos.core.dead_letter.jsonify")
     def test_rest_patch(self, _):
         """test rest_patch."""
-        topic = "some_topic"
+        event_name = "some_name"
         ids = ["id", "id2"]
-        body = {"topic": topic, "ids": ids, "kytos_queue_buffer": "app"}
+        body = {"event_name": event_name, "ids": ids,
+                "kytos_queue_buffer": "app"}
         request = self.dead_letter._get_request
         resp = MagicMock()
         resp.json = body
         request.return_value = resp
         for _id in ids:
-            self.dead_letter.dict[topic][_id] = {}
+            self.dead_letter.dict[event_name][_id] = {}
         self.dead_letter.reinject = MagicMock()
 
         self.dead_letter.rest_patch()
         assert self.dead_letter.reinject.call_count == len(ids)
 
     @patch("kytos.core.dead_letter.jsonify")
-    def test_rest_delete_topic_not_found(self, _):
-        """test rest_delete topic not found."""
+    def test_rest_delete_event_name_not_found(self, _):
+        """test rest_delete event_name not found."""
         ids = ["id"]
-        body = {"topic": "inexistent", "ids": ids}
+        body = {"event_name": "inexistent", "ids": ids}
         request = self.dead_letter._get_request
         resp = MagicMock()
         resp.json = body
@@ -124,16 +127,16 @@ class TestDeadLetter(TestCase):
 
     @patch("kytos.core.dead_letter.jsonify")
     def test_rest_delete_ids_not_found(self, _):
-        """test rest_delete topic ids found."""
+        """test rest_delete event_name ids found."""
 
-        topic = "some_topic"
+        event_name = "some_name"
         ids = ["id"]
-        body = {"topic": topic, "ids": ids}
+        body = {"event_name": event_name, "ids": ids}
         request = self.dead_letter._get_request
         resp = MagicMock()
         resp.json = body
         request.return_value = resp
-        self.dead_letter.dict[topic] = {}
+        self.dead_letter.dict[event_name] = {}
         with self.assertRaises(NotFound):
             self.dead_letter.rest_delete()
 
@@ -141,27 +144,27 @@ class TestDeadLetter(TestCase):
     def test_rest_delete(self, _):
         """test rest_delete."""
 
-        topic = "some_topic"
+        event_name = "some_name"
         ids = ["id", "id2"]
-        body = {"topic": topic, "ids": ids}
+        body = {"event_name": event_name, "ids": ids}
         request = self.dead_letter._get_request
         resp = MagicMock()
         resp.json = body
         request.return_value = resp
         for _id in ids:
-            self.dead_letter.dict[topic][_id] = {}
+            self.dead_letter.dict[event_name][_id] = {}
 
-        assert len(self.dead_letter.dict[topic]) == len(ids)
+        assert len(self.dead_letter.dict[event_name]) == len(ids)
         self.dead_letter.rest_delete()
-        assert len(self.dead_letter.dict[topic]) == 0
+        assert len(self.dead_letter.dict[event_name]) == 0
 
     @patch("kytos.core.dead_letter.jsonify")
     def test_reinject(self, _):
         """test reinject."""
         mock_ev = MagicMock()
         mock_ev.reinjections = 0
-        topic = "topic"
+        event_name = "event_name"
         _id = "id"
-        self.dead_letter.dict[topic][_id] = mock_ev
-        self.dead_letter.reinject(topic, _id, "app")
+        self.dead_letter.dict[event_name][_id] = mock_ev
+        self.dead_letter.reinject(event_name, _id, "app")
         assert mock_ev.reinjections == 1

--- a/tests/unit/test_core/test_dead_letter.py
+++ b/tests/unit/test_core/test_dead_letter.py
@@ -1,0 +1,166 @@
+"""Test kytos.core.dead_letter module."""
+# pylint: disable=invalid-name
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from werkzeug.exceptions import NotFound
+
+from kytos.core.dead_letter import DeadLetter
+
+
+class TestDeadLetter(TestCase):
+    """TestDeadLetter."""
+
+    def setUp(self):
+        """setUp."""
+        self.dead_letter = DeadLetter(MagicMock())
+        self.dead_letter._get_request = MagicMock()
+
+    def test_add_event(self):
+        """test add_event."""
+        mock_ev = MagicMock()
+        mock_ev.name = "some_name"
+        mock_ev.id = "some_id"
+        assert len(self.dead_letter.dict) == 0
+        self.dead_letter.add_event(mock_ev)
+        assert len(self.dead_letter.dict) == 1
+        assert self.dead_letter.dict[mock_ev.name][mock_ev.id] == mock_ev
+
+    def test_delete_event(self):
+        """test delete_event."""
+        mock_ev = MagicMock()
+        mock_ev.name = "some_name"
+        mock_ev.id = "some_id"
+        assert len(self.dead_letter.dict) == 0
+        self.dead_letter.add_event(mock_ev)
+        assert len(self.dead_letter.dict) == 1
+
+        assert mock_ev.id in self.dead_letter.dict[mock_ev.name]
+        assert self.dead_letter.delete_event(mock_ev.name, mock_ev.id)
+        assert mock_ev.id not in self.dead_letter.dict[mock_ev.name]
+
+    def test_delete_topic(self):
+        """test delete_topic."""
+        topic = "topic"
+        assert topic not in self.dead_letter.dict
+        self.dead_letter.dict["topic"] = "some_value"
+        assert topic in self.dead_letter.dict
+        self.dead_letter.delete_topic(topic)
+        assert topic not in self.dead_letter.dict
+
+    def test_register_endpoints(self):
+        """test register_endpoints."""
+        api = self.dead_letter.controller.api_server
+        self.dead_letter.register_endpoints()
+        assert api.register_core_endpoint.call_count == 3
+
+    @patch("kytos.core.dead_letter.jsonify")
+    def test_rest_list(self, jsonify):
+        """test rest_list."""
+        mock_ev = MagicMock()
+        mock_ev.name = "some_name"
+        mock_ev.id = "some_id"
+        self.dead_letter.add_event(mock_ev)
+
+        assert self.dead_letter.rest_list()
+        jsonify.assert_called()
+
+    @patch("kytos.core.dead_letter.jsonify")
+    def test_rest_patch_topic_not_found(self, _):
+        """test rest_patch topic not found."""
+        topic = "some_topic"
+        ids = ["id"]
+        body = {"topic": topic, "ids": ids, "kytos_queue_buffer": "app"}
+        request = self.dead_letter._get_request
+        resp = MagicMock()
+        resp.json = body
+        request.return_value = resp
+        with self.assertRaises(NotFound):
+            self.dead_letter.rest_patch()
+
+    @patch("kytos.core.dead_letter.jsonify")
+    def test_rest_patch_ids_not_found(self, _):
+        """test rest_patch topic ids found."""
+        topic = "some_topic"
+        ids = ["id"]
+        body = {"topic": topic, "ids": ids, "kytos_queue_buffer": "app"}
+        request = self.dead_letter._get_request
+        resp = MagicMock()
+        resp.json = body
+        request.return_value = resp
+        self.dead_letter.dict[topic] = {}
+        with self.assertRaises(NotFound):
+            self.dead_letter.rest_patch()
+
+    @patch("kytos.core.dead_letter.jsonify")
+    def test_rest_patch(self, _):
+        """test rest_patch."""
+        topic = "some_topic"
+        ids = ["id", "id2"]
+        body = {"topic": topic, "ids": ids, "kytos_queue_buffer": "app"}
+        request = self.dead_letter._get_request
+        resp = MagicMock()
+        resp.json = body
+        request.return_value = resp
+        for _id in ids:
+            self.dead_letter.dict[topic][_id] = {}
+        self.dead_letter.reinject = MagicMock()
+
+        self.dead_letter.rest_patch()
+        assert self.dead_letter.reinject.call_count == len(ids)
+
+    @patch("kytos.core.dead_letter.jsonify")
+    def test_rest_delete_topic_not_found(self, _):
+        """test rest_delete topic not found."""
+        ids = ["id"]
+        body = {"topic": "inexistent", "ids": ids}
+        request = self.dead_letter._get_request
+        resp = MagicMock()
+        resp.json = body
+        request.return_value = resp
+        with self.assertRaises(NotFound):
+            self.dead_letter.rest_delete()
+
+    @patch("kytos.core.dead_letter.jsonify")
+    def test_rest_delete_ids_not_found(self, _):
+        """test rest_delete topic ids found."""
+
+        topic = "some_topic"
+        ids = ["id"]
+        body = {"topic": topic, "ids": ids}
+        request = self.dead_letter._get_request
+        resp = MagicMock()
+        resp.json = body
+        request.return_value = resp
+        self.dead_letter.dict[topic] = {}
+        with self.assertRaises(NotFound):
+            self.dead_letter.rest_delete()
+
+    @patch("kytos.core.dead_letter.jsonify")
+    def test_rest_delete(self, _):
+        """test rest_delete."""
+
+        topic = "some_topic"
+        ids = ["id", "id2"]
+        body = {"topic": topic, "ids": ids}
+        request = self.dead_letter._get_request
+        resp = MagicMock()
+        resp.json = body
+        request.return_value = resp
+        for _id in ids:
+            self.dead_letter.dict[topic][_id] = {}
+
+        assert len(self.dead_letter.dict[topic]) == len(ids)
+        self.dead_letter.rest_delete()
+        assert len(self.dead_letter.dict[topic]) == 0
+
+    @patch("kytos.core.dead_letter.jsonify")
+    def test_reinject(self, _):
+        """test reinject."""
+        mock_ev = MagicMock()
+        mock_ev.reinjections = 0
+        topic = "topic"
+        _id = "id"
+        self.dead_letter.dict[topic][_id] = mock_ev
+        self.dead_letter.reinject(topic, _id, "app")
+        assert mock_ev.reinjections == 1

--- a/tests/unit/test_core/test_events.py
+++ b/tests/unit/test_core/test_events.py
@@ -66,9 +66,9 @@ class TestKytosEvent(TestCase):
 
     def test_as_json(self):
         """Test as_json."""
-        ts = datetime.strftime(self.event.timestamp, '%Y-%m-%dT%H:%M:%S')
+        timestamp = datetime.strftime(self.event.timestamp,
+                                      '%Y-%m-%dT%H:%M:%S')
         expected = {'content': {}, 'id': str(self.event.id),
                     'name': 'kytos/core.any', 'reinjections': 0,
-                    'timestamp': ts}
+                    'timestamp': timestamp}
         self.assertDictEqual(json.loads(self.event.as_json()), expected)
-

--- a/tests/unit/test_core/test_events.py
+++ b/tests/unit/test_core/test_events.py
@@ -1,5 +1,8 @@
 """Test kytos.core.events module."""
+import json
+from datetime import datetime, timezone
 from unittest import TestCase
+from uuid import UUID
 
 from kytos.core.events import KytosEvent
 
@@ -45,3 +48,27 @@ class TestKytosEvent(TestCase):
 
         self.event.content = {"message": "msg"}
         self.assertEqual(self.event.message, 'msg')
+
+    def test_init_attrs(self):
+        """Test init attrs."""
+        assert self.event.name == "kytos/core.any"
+        assert self.event.content == {}
+        assert self.event.timestamp <= datetime.now(timezone.utc)
+        assert self.event.id and isinstance(self.event.id, UUID)
+        assert self.event.reinjections == 0
+
+    def test_as_dict(self):
+        """Test as_dict."""
+        expected = {'content': {}, 'id': str(self.event.id),
+                    'name': 'kytos/core.any', 'reinjections': 0,
+                    'timestamp': self.event.timestamp}
+        self.assertDictEqual(self.event.as_dict(), expected)
+
+    def test_as_json(self):
+        """Test as_json."""
+        ts = datetime.strftime(self.event.timestamp, '%Y-%m-%dT%H:%M:%S')
+        expected = {'content': {}, 'id': str(self.event.id),
+                    'name': 'kytos/core.any', 'reinjections': 0,
+                    'timestamp': ts}
+        self.assertDictEqual(json.loads(self.event.as_json()), expected)
+


### PR DESCRIPTION
Fixes #197 

This dead letter in-memory structure is meant to provide a mechanism of last resort to allow re-injection of failed KytosEvent when unhandled exception happens on a `listen_to` handler (for instance, maximum retries reached, full outage of async events or even unexpected ones). This is meant to ensure production-grade error handling for errors that are transient. So far we don't have a full blown message broker (yet), so this structure fills that gap, as long as the `kytosd` is up an running it should be possible to list, reinject or delete these events. The underlying structure is an `OrderedDict` instead of a `Queue` to provide more flexibility when re-injecting and deleting arbitrary events.

This PR is on top of PR #203 (to facilitate development)

### Description of the change

- Added an in-memory dead letter structure for unhandled exceptions of KytosEvents indexed by their names
- Added core endpoints for the dead letter structure:

```
   GET /api/kytos/core/dead_letter/?event_name=<name>
   PATCH /api/kytos/core/dead_letter/ (requires request body)
   DELETE /api/kytos/core/dead_letter/ (requires request body)
```

### Practical example

- I've forced an intentional unhandled exception (in this case the error isn't transient though) on `kytos/core.switch.new` and `kytos/core.switch.reconnected`, if you list the endpoint, you'll see the events:

```
❯ http localhost:8181/api/kytos/core/dead_letter/
HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 753
Content-Type: application/json
Date: Tue, 12 Apr 2022 21:47:58 GMT
Server: Werkzeug/1.0.1 Python/3.9.12

{
    "kytos/core.switch.new": {
        "99e7d63c-1673-49e2-be63-8b7b1206663c": {
            "content": "{'switch': Switch('00:00:00:00:00:00:00:01')}",
            "id": "99e7d63c-1673-49e2-be63-8b7b1206663c",
            "name": "kytos/core.switch.new",
            "reinjections": 0,
            "timestamp": "2022-04-12T21:46:44"
        }
    },
    "kytos/core.switch.reconnected": {
        "10e70a1b-ac19-460b-ad16-51e53decde55": {
            "content": "{'switch': Switch('00:00:00:00:00:00:00:01')}",
            "id": "10e70a1b-ac19-460b-ad16-51e53decde55",
            "name": "kytos/core.switch.reconnected",
            "reinjections": 0,
            "timestamp": "2022-04-12T21:46:44"
        },
        "860b2ac1-baf4-4650-a365-2f7ca7db9d64": {
            "content": "{'switch': Switch('00:00:00:00:00:00:00:01')}",
            "id": "860b2ac1-baf4-4650-a365-2f7ca7db9d64",
            "name": "kytos/core.switch.reconnected",
            "reinjections": 0,
            "timestamp": "2022-04-12T21:46:44"
        }
    }
}
```

- You can try re-inject all `kytos/core.switch.new` events on the `app` kytos queue buffer to all subscribers again (or you could also selectively specify the KytosEvent ids):

```
echo '{"event_name": "kytos/core.switch.new", "kytos_queue_buffer": "app"}' | http PATCH localhost:8181/api/kytos/core/dead_letter/

HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 3
Content-Type: application/json
Date: Tue, 12 Apr 2022 21:48:38 GMT
Server: Werkzeug/1.0.1 Python/3.9.12

{}
```

- If you list again, notice that `reinjections` was incremented and it was reinjected on the `app` queue:

```
❯ http localhost:8181/api/kytos/core/dead_letter/
HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 753
Content-Type: application/json
Date: Tue, 12 Apr 2022 21:48:41 GMT
Server: Werkzeug/1.0.1 Python/3.9.12

{
    "kytos/core.switch.new": {
        "99e7d63c-1673-49e2-be63-8b7b1206663c": {
            "content": "{'switch': Switch('00:00:00:00:00:00:00:01')}",
            "id": "99e7d63c-1673-49e2-be63-8b7b1206663c",
            "name": "kytos/core.switch.new",
            "reinjections": 1,
            "timestamp": "2022-04-12T21:46:44"
        }
    },
    "kytos/core.switch.reconnected": {
        "10e70a1b-ac19-460b-ad16-51e53decde55": {
            "content": "{'switch': Switch('00:00:00:00:00:00:00:01')}",
            "id": "10e70a1b-ac19-460b-ad16-51e53decde55",
            "name": "kytos/core.switch.reconnected",
            "reinjections": 0,
            "timestamp": "2022-04-12T21:46:44"
        },
        "860b2ac1-baf4-4650-a365-2f7ca7db9d64": {
            "content": "{'switch': Switch('00:00:00:00:00:00:00:01')}",
            "id": "860b2ac1-baf4-4650-a365-2f7ca7db9d64",
            "name": "kytos/core.switch.reconnected",
            "reinjections": 0,
            "timestamp": "2022-04-12T21:46:44"
        }
    }
}
```

```
kytos $> 2022-04-12 18:48:38,159 - ERROR [kytos.core.helpers] (ThreadPoolExecutor-0_6) listen_to handler: <function Main.on_new_switch2 at 0x7fc9086183a0>, args: (<Main(topology, stopp
ed 140500912821824)>, KytosEvent('kytos/core.switch.new', {'switch': Switch('00:00:00:00:00:00:00:01')})), exception: <class 'ValueError'>: crashed2022-04-12 18:48:38,165 - INFO [kytos.napps.kytos/flow_manager] (Thread-41) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, flows_dict: {'flows': [
{'priority': 1000, 'table_id': 0, 'cookie': 12321848580485677057, 'match': {'dl_type': 35020, 'dl_vlan': 3799}, 'actions': [{'action_type': 'output', 'port': 4294967293}]}]}
2022-04-12 18:48:38,177 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_7) Flow saved in kytos.flow.persistence.51953dfb51854c5490dcfcbc83ee8390
2022-04-12 18:48:38,179 - INFO [kytos.napps.kytos/flow_manager] (ThreadPoolExecutor-0_5) Flow saved in kytos.flow.persistence.51953dfb51854c5490dcfcbc83ee8390
kytos $>
```

