### PR TITLE
[Feature] Retry core library `tenacity`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Added
    PATCH /api/kytos/core/dead_letter/ (requires request body)
    DELETE /api/kytos/core/dead_letter/ (requires request body)
 
+- Added ``tenacity`` as a core dependency for retries.
+
 Changed
 =======
 - Kytos controller can shutdown if the database is configured but not reachable during startup time.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -233,6 +233,8 @@ traitlets==4.3.3
     # via
     #   -r requirements/run.txt
     #   ipython
+tenacity==8.0.1
+    # via -r requirements/run.txt
 typing-extensions==4.0.1
     # via
     #   -r requirements/run.txt

--- a/requirements/run.in
+++ b/requirements/run.in
@@ -13,3 +13,4 @@ watchdog
 pyjwt
 pymongo==4.1.0
 pydantic==1.9.0
+tenacity=8.0.1

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -39,6 +39,7 @@ werkzeug==1.0.1           # via flask
 pydantic==1.9.0           # via -r requirements/run.in
 pymongo==4.1.0            # via -r requirements/run.in
 typing-extensions==4.0.1  # via pydantic
+tenacity==8.0.1           # via -r requirements/run.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Fixes #205

- Added ``tenacity`` as a core dependency for retries.

This PR is on top of PR #204 (to facilitate development)

Retrying is a common functionality that NApps requires, for instance when handling IO errors like database failures or requests, just so NApps don't have to reimplement or keep installing other retry libraries.