### PR TITLE
[Feature] Elasticsearch log input integration with Filebeat

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,12 +29,14 @@ Added
 - ``kytosd`` Elastic APM integration provides instrumentation for MongoDB, Flask, requests and ``KytosEvent``
 - ``@begin_span`` decorator for on-demand APM custom functions/methods instrumentation
 - Augmented docker-compose.yml to also spin up Elastsearch, Kibana and APM server with authentication
+- Augmented docker-compose to also spin up Filebeat, integrating log file as input
 
 Changed
 =======
 - Kytos controller can shutdown if the database is configured but not reachable during startup time.
 - Augmented ``KytosEvent`` with internal attributes (``id`` and ``reinjections``), no breaking changes.
 - ``KytosEvent`` now optionally supports a ``trace_parent`` argument for APM distributed tracing to also instrument and correlate ``KytosEvent``.
+- Added file formatter and file handler boilerplate on logging.ini.template to facilitate hooking the file handler on logger_root and logger_kytos as needed.
 
 Deprecated
 ==========

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       - elasticsearch
   filebeat:
     container_name: filebeat
-    image: docker.elastic.co/beats/filebeat:7.17.1
+    image: docker.elastic.co/beats/filebeat:7.17.3
     command: >
        filebeat -e
          --strict.perms=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,22 @@ services:
       - 5601:5601
     depends_on:
       - elasticsearch
-
+  logstash:
+    container_name: logstash
+    image: docker.elastic.co/logstash/logstash:7.17.1
+    environment:
+      - "LS_JAVA_OPTS=-Xmx512m -Xms512m"
+      - ELASTICSEARCH_USERNAME=${ELASTIC_USERNAME:-elastic}
+      - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD:-elastic_pw}
+      - ELASTICSEARCH_HOSTS="elasticsearch:9200"
+    volumes:
+      - ./docker/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml
+      - ./docker/logstash/pipeline:/usr/share/logstash/pipeline
+    ports:
+      - "5000:5000/udp"
+      - "9600:9600"
+    depends_on:
+      - elasticsearch
   apm-server:
     container_name: apm
     image: docker.elastic.co/apm/apm-server:7.17.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,6 @@ services:
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
       - ELASTICSEARCH_URL=http://elasticsearch:9200
-      - xpack.apm.enabled=false
       - ELASTICSEARCH_USERNAME=${ELASTIC_USERNAME:-elastic}
       - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD:-elastic_pw}
       - XPACK_SECURITY_ENABLED=true
@@ -89,20 +88,22 @@ services:
       - 5601:5601
     depends_on:
       - elasticsearch
-  logstash:
-    container_name: logstash
-    image: docker.elastic.co/logstash/logstash:7.17.1
+  filebeat:
+    container_name: filebeat
+    image: docker.elastic.co/beats/filebeat:7.17.1
+    command: >
+       filebeat -e
+         --strict.perms=false
+         -E output.elasticsearch.hosts=["elasticsearch:9200"]
     environment:
-      - "LS_JAVA_OPTS=-Xmx512m -Xms512m"
       - ELASTICSEARCH_USERNAME=${ELASTIC_USERNAME:-elastic}
       - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD:-elastic_pw}
       - ELASTICSEARCH_HOSTS="elasticsearch:9200"
+      - KIBANA_HOST="kibana:5601"
     volumes:
-      - ./docker/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml
-      - ./docker/logstash/pipeline:/usr/share/logstash/pipeline
-    ports:
-      - "5000:5000/udp"
-      - "9600:9600"
+      - ./docker/filebeat/config/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - .:/kytos:ro
+      - filebeat_data:/usr/share/filebeat/data
     depends_on:
       - elasticsearch
   apm-server:
@@ -138,3 +139,4 @@ volumes:
   mongo3_data:
   esdata:
   kibana_data:
+  filebeat_data:

--- a/docker/filebeat/config/filebeat.yml
+++ b/docker/filebeat/config/filebeat.yml
@@ -1,0 +1,35 @@
+---
+# https://github.com/elastic/beats/blob/main/filebeat/filebeat.reference.yml
+
+filebeat.modules:
+- module: system
+  syslog:
+    enabled: false
+  auth:
+    enabled: false
+
+processors:
+  - dissect:
+      # kytos log formatter tokenizer to be able to search for fields easily
+      tokenizer: '%{kytos.timestamp} - %{kytos.level} [%{kytos.logger}] [%{kytos.file}:%{kytos.line}:%{kytos.func}] (%{kytos.thread}) %{kytos.message}'
+      field: "message"
+      target_prefix: ""
+
+filebeat.inputs:
+- type: log
+  enabled: true
+  # Paths that should be crawled and fetched. Glob based paths.
+  # Make sure not file is defined twice as this can lead to unexpected behaviour.
+  paths:
+    # /kytos will be mounted when developing locally
+    - /kytos/*.log
+
+output.elasticsearch:
+  hosts: ${ELASTICSEARCH_HOSTS}
+  username: ${ELASTICSEARCH_USERNAME}
+  password: ${ELASTICSEARCH_PASSWORD}
+
+setup.kibana:
+  host: ${KIBANA_HOST}
+  username: ${ELASTICSEARCH_USERNAME}
+  password: ${ELASTICSEARCH_PASSWORD}

--- a/kytos/templates/logging.ini.template
+++ b/kytos/templates/logging.ini.template
@@ -1,8 +1,8 @@
 [formatters]
-keys: console,syslog
+keys: console,syslog,file
 
 [handlers]
-keys: console,syslog
+keys: console,syslog,file
 
 [loggers]
 keys: root,kytos,api_server,socket
@@ -13,6 +13,9 @@ format: %(name)s:%(levelname)s %(module)s:%(lineno)d:  %(message)s
 [formatter_console]
 format: %(asctime)s - %(levelname)s [%(name)s] (%(threadName)s) %(message)s
 
+[formatter_file]
+format: %(asctime)s - %(levelname)s [%(name)s] [%(filename)s:%(lineno)d:%(funcName)s] (%(threadName)s) %(message)s
+
 [handler_console]
 class: StreamHandler
 args:[sys.stdout]
@@ -22,6 +25,12 @@ formatter: console
 class: handlers.SysLogHandler
 args: {{syslog_args}}
 formatter: syslog
+
+[handler_file]
+class: handlers.RotatingFileHandler
+args:["kytos.log", "a", 10*1024*1024, 5]
+formatter: file
+level: INFO
 
 [logger_root]
 level: INFO


### PR DESCRIPTION
Fixes #174 

This PR implemented searchable structured logs with Elasticsearch and [Filebeat](https://www.elastic.co/beats/filebeat), as it has been describe on this proposed blueprint #211. 

### Description of the change

- Augmented docker-compose to also spin up Filebeat, integrating log file as input
- Added file formatter and file handler boilerplate on logging.ini.template to facilitate hooking the file handler on logger_root and logger_kytos as needed


### How to use

- Make sure to edit the `logging.ini` that will be auto generated (if you haven't created one in advance), hook the `file_handler` with both `logger_root` and `logger_kytos` (this isn't done automatically not to break compatibility and not to generated logs where users wouldn't expect)
- `docker-compose up -d`
- [Open Kibana Index patterns page on your browser](http://localhost:5601/app/management/kibana/indexPatterns), and associate the ES index `filebeat-*` that filebeat is creating records for when it's reading from the log file. 
- [Open Kibana Discovery page](http://localhost:5601/app/discover#/), make sure to select the `filebeat-*` wildcard index, and you should see the logs and be able to query them

![2022-04-28-115343_1894x725_scrot](https://user-images.githubusercontent.com/1010796/165781441-6b64bfc4-7077-4415-a4e3-5f3a74e4bdb9.png)
