### PR TITLE
[Feature] Configurable and default thread pools

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Added
 - ``@begin_span`` decorator for on-demand APM custom functions/methods instrumentation
 - Augmented docker-compose.yml to also spin up Elastsearch, Kibana and APM server with authentication
 - Augmented docker-compose to also spin up Filebeat, integrating log file as input
+- The ``listen_to`` decorator now supports a ``pool`` keyword argument to specify which thread pool the execution should be submitted
 
 Changed
 =======
@@ -37,6 +38,14 @@ Changed
 - Augmented ``KytosEvent`` with internal attributes (``id`` and ``reinjections``), no breaking changes.
 - ``KytosEvent`` now optionally supports a ``trace_parent`` argument for APM distributed tracing to also instrument and correlate ``KytosEvent``.
 - Added file formatter and file handler boilerplate on logging.ini.template to facilitate hooking the file handler on logger_root and logger_kytos as needed.
+- Broke compatibility in the ``thread_pool_max_workers``, it uses a dict now instead of a single integer. If you were using a single integer for a global pool, please migrate it to ``{"sb": 256, "db": 256, "app": x}``, where x should be the value that you used to use or the default 512.
+- The following pools are available by default to be used in the listen_to decorator with the ``pool`` option:
+
+  .. code-block:: console
+
+   sb: it's used automatically by kytos/of_core.* events, it's meant for southbound related messages
+   app: it's meant for general NApps event, it's default pool if no other one has been specified
+   db: it can be used by for higher priority db related tasks (need to be parametrized on decorator), it's also used automatically by kytos.storehouse.* events
 
 Deprecated
 ==========

--- a/kytos/core/buffers.py
+++ b/kytos/core/buffers.py
@@ -15,8 +15,7 @@ LOG = logging.getLogger(__name__)
 class KytosEventBuffer:
     """KytosEventBuffer represents a queue to store a set of KytosEvents."""
 
-    def __init__(self, name, event_base_class=None, loop=None,
-                 maxsize=get_thread_pool_max_workers()):
+    def __init__(self, name, event_base_class=None, loop=None, maxsize=0):
         """Contructor of KytosEventBuffer receive the parameters below.
 
         Args:
@@ -150,11 +149,20 @@ class KytosBuffers:
         :attr:`app`: :class:`~kytos.core.buffers.KytosEventBuffer` with events
         sent to NApps.
         """
+        self._pool_max_workers = get_thread_pool_max_workers()
         self._loop = loop
-        self.raw = KytosEventBuffer('raw_event', loop=self._loop)
-        self.msg_in = KytosEventBuffer('msg_in_event', loop=self._loop)
-        self.msg_out = KytosEventBuffer('msg_out_event', loop=self._loop)
-        self.app = KytosEventBuffer('app_event', loop=self._loop)
+        self.raw = KytosEventBuffer("raw_event", loop=self._loop,
+                                    maxsize=self._get_maxsize("sb"))
+        self.msg_in = KytosEventBuffer("msg_in_event", loop=self._loop,
+                                       maxsize=self._get_maxsize("sb"))
+        self.msg_out = KytosEventBuffer('msg_out_event', loop=self._loop,
+                                        maxsize=self._get_maxsize("sb"))
+        self.app = KytosEventBuffer('app_event', loop=self._loop,
+                                    maxsize=self._get_maxsize("app"))
+
+    def _get_maxsize(self, queue_name):
+        """Get queue maxsize if it's been set."""
+        return self._pool_max_workers.get(queue_name, 0)
 
     def send_stop_signal(self):
         """Send a ``kytos/core.shutdown`` event to each buffer."""

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -144,7 +144,7 @@ class KytosConfig():
                     'authenticate_urls': [],
                     'vlan_pool': {},
                     'token_expiration_minutes': 180,
-                    'thread_pool_max_workers': 256,
+                    'thread_pool_max_workers': {},
                     'database': '',
                     'apm': '',
                     'debug': False}
@@ -201,6 +201,8 @@ class KytosConfig():
         options.napps_pre_installed = _parse_json(options.napps_pre_installed)
         options.vlan_pool = _parse_json(options.vlan_pool)
         options.authenticate_urls = _parse_json(options.authenticate_urls)
+        thread_pool_max_workers = options.thread_pool_max_workers
+        options.thread_pool_max_workers = _parse_json(thread_pool_max_workers)
 
         return options
 

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -40,7 +40,7 @@ from kytos.core.db import db_conn_wait
 from kytos.core.dead_letter import DeadLetter
 from kytos.core.events import KytosEvent
 from kytos.core.exceptions import KytosAPMInitException, KytosDBInitException
-from kytos.core.helpers import executor as executor_pool
+from kytos.core.helpers import executors
 from kytos.core.helpers import now
 from kytos.core.interface import Interface
 from kytos.core.logs import LogManager
@@ -438,8 +438,8 @@ class Controller:
         self.napp_dir_listener.stop()
 
         self.log.info("Stopping threadpool: %s", self._pool)
-        if executor_pool:
-            self.log.info("Stopping threadpool: %s", executor_pool)
+        for pool_name in executors:
+            self.log.info("Stopping threadpool: %s", pool_name)
 
         threads = threading.enumerate()
         self.log.debug("%s threads before threadpool shutdown: %s",
@@ -449,11 +449,11 @@ class Controller:
             # Python >= 3.9
             # pylint: disable=unexpected-keyword-arg
             self._pool.shutdown(wait=graceful, cancel_futures=True)
-            if executor_pool:
+            for executor_pool in executors.values():
                 executor_pool.shutdown(wait=graceful, cancel_futures=True)
         except TypeError:
             self._pool.shutdown(wait=graceful)
-            if executor_pool:
+            for executor_pool in executors.values():
                 executor_pool.shutdown(wait=graceful)
 
         # self.server.socket.shutdown()

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -40,8 +40,7 @@ from kytos.core.db import db_conn_wait
 from kytos.core.dead_letter import DeadLetter
 from kytos.core.events import KytosEvent
 from kytos.core.exceptions import KytosAPMInitException, KytosDBInitException
-from kytos.core.helpers import executors
-from kytos.core.helpers import now
+from kytos.core.helpers import executors, now
 from kytos.core.interface import Interface
 from kytos.core.logs import LogManager
 from kytos.core.napps.base import NApp

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -174,7 +174,8 @@ def listen_to(event, *events, pool=None):
 
             if event.name.startswith("kytos/of_core") and "sb" in executors:
                 return executors["sb"]
-            if event.name.startswith("kytos/core") and "sb" in executors:
+            core_of = "kytos/core.openflow"
+            if event.name.startswith(core_of) and "sb" in executors:
                 return executors["sb"]
             if event.name.startswith("kytos.storehouse") and "db" in executors:
                 return executors["db"]

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -174,6 +174,8 @@ def listen_to(event, *events, pool=None):
 
             if event.name.startswith("kytos/of_core") and "sb" in executors:
                 return executors["sb"]
+            if event.name.startswith("kytos/core") and "sb" in executors:
+                return executors["sb"]
             if event.name.startswith("kytos.storehouse") and "db" in executors:
                 return executors["db"]
             return executors[default_pool]

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -80,6 +80,10 @@ def listen_to(event, *events, pool=None):
             @listen_to('kytos/of_core.message.*')
             def my_stats_handler_of_any_message(self, event):
                 # Do stuff here...
+
+            @listen_to("some_db_oriented_event", pool="db")
+            def db_update(self, event):
+                # Do stuff here...
     """
     def thread_decorator(handler):
         """Decorate the handler method.

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -165,13 +165,19 @@ def listen_to(event, *events, pool=None):
             """Get executor."""
             if pool:
                 return executors[pool]
+            if not event:
+                return executors[default_pool]
+
             if event.name.startswith("kytos/of_core") and "sb" in executors:
                 return executors["sb"]
+            if event.name.startswith("kytos.storehouse") and "db" in executors:
+                return executors["db"]
             return executors[default_pool]
 
         def inner(*args):
             """Decorate the handler to run in the thread pool."""
-            executor = get_executor(pool, args[1])
+            event = args[1] if len(args) > 1 else None
+            executor = get_executor(pool, event)
             future = executor.submit(handler_func, *args, **kwargs)
             future.add_done_callback(done_callback)
 

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -70,6 +70,13 @@ vlan_pool = {}
 # The jwt_secret parameter is responsible for signing JSON Web Tokens.
 jwt_secret = {{ jwt_secret }}
 
+# Maximum number of thread workers in a thread pool, if it's set as empty dict {} no thread pools will be used.
+# The following pools are available by default to be used in the listen_to decorator:
+# - sb: it's used automatically by kytos/of_core.* events, it's meant for southbound related messages
+# - app: it's meant for general NApps event, it's default pool if no other one has been specified
+# - db: it can be used by for higher priority db related tasks (need to be parametrized on decorator)
+thread_pool_max_workers = {"sb": 256, "db": 256, "app": 256}
+
 # Time to expire authentication token in minutes
 token_expiration_minutes = 180
 

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -75,7 +75,7 @@ jwt_secret = {{ jwt_secret }}
 # - sb: it's used automatically by kytos/of_core.* events, it's meant for southbound related messages
 # - app: it's meant for general NApps event, it's default pool if no other one has been specified
 # - db: it can be used by for higher priority db related tasks (need to be parametrized on decorator)
-thread_pool_max_workers = {"sb": 256, "db": 256, "app": 256}
+thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512}
 
 # Time to expire authentication token in minutes
 token_expiration_minutes = 180

--- a/tests/unit/test_core/test_helpers.py
+++ b/tests/unit/test_core/test_helpers.py
@@ -1,9 +1,9 @@
 """Test kytos.core.helpers module."""
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from kytos.core.helpers import (get_thread_pool_max_workers, get_time,
-                                listen_to, run_on_thread)
+from kytos.core.helpers import (executors, get_thread_pool_max_workers,
+                                get_time, listen_to, run_on_thread)
 
 
 class TestHelpers(TestCase):
@@ -23,11 +23,19 @@ class TestHelpers(TestCase):
         mock_thread.return_value.start.assert_called()
 
     @staticmethod
-    @patch('kytos.core.helpers.executor')
-    def test_listen_to_run_on_threadpool_by_default(mock_executor):
+    def test_default_executors():
+        """Test default expected executors."""
+        pools = ["app", "db", "sb"]
+        assert sorted(pools) == sorted(executors.keys())
+
+    @staticmethod
+    def test_listen_to_run_on_threadpool_by_default():
         """Test listen_to runs on ThreadPoolExecutor by default."""
 
-        assert get_thread_pool_max_workers() > 0
+        assert get_thread_pool_max_workers()
+        assert "app" in executors
+        executors["app"] = MagicMock()
+        mock_executor = executors["app"]
 
         @listen_to("some_event")
         def test(event):


### PR DESCRIPTION
Fixes #210 

### Description of the change

- Added support for configurable and default thread pools, allowing executions on different pools depending on the handler primary responsibility and importance to avoid potential scheduling starvation. Kytos-ng will ship with three thread pools by default as illustrated in this diagram (and new ones can be configured as needed):

![kytos_arch-thread pools drawio](https://user-images.githubusercontent.com/1010796/166828333-cbab29b5-c139-4654-a12c-edae7b53d1bf.png)



### Release Notes

- The ``listen_to`` decorator now supports a ``pool`` keyword argument to specify which thread pool the execution should be submitted
- **Broke compatibility** in the ``thread_pool_max_workers``, it uses a dict now instead of a single integer. If you were using a single integer for a global pool, please migrate it to ``{"sb": 256, "db": 256, "app": x}``, where x should be the value that you used to use or the default 512.
- `kytos.storehouse.*` will automatically try to use the `db` pool this is to facilitate to avoid decorating all storehouse related handlers (it was simpler that decorating them all, once storehouse is deprecated we'll remove this default association here)


As briefly chatted with @italovalcy and @ajoaoff, for now, this implementation only solves the starvation part, the handlers that listen for `raw` messages will be augmented in this release in the `epic_core_queues` epic, when the time comes we'll decorate the raw handlers accordingly and if needed create a new pool or new tasks. 

### Execution

- Before this PR, when using the patch and the scenario that Italo has orginally reported it was resulting in the issue:

```
kytos $> controller.2022-05-04 11:04:48,538 - ERROR [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_110) Fail to update persistence box in kytos.topology.status.131443ad297e4076b67ba492c8fa32f5. Error: Timeout while waiting for storehouse
buffers.app2022-05-04 11:04:53,677 - ERROR [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_77) Fail to update persistence box in kytos.topology.status.131443ad297e4076b67ba492c8fa32f5. Error: Timeout while waiting for storehouse
kytos $> controller.buffers.app.qsise()2022-05-04 11:04:58,796 - ERROR [kytos.napps.kytos/topology] (ThreadPoolExecutor-0_105) Fail to update persistence box in kytos.topology.status.131443ad297e4076b67ba492c8fa32f5. Error: Timeout while waiting for storehouse
```

- Now it managed to install the EVCs, and as you can see, `kytos.storehouse.*` events are using the `db` thread pool, where as by default the NApps that haven't overwritten the `pool` option in the `listen_to` decorator are using the `app` pool.

```
2022-05-04 11:41:26,322 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_44) EVC 9a2bf483c67849 was synced to the storehouse.
2022-05-04 11:41:26,326 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_47) EVC 9a860dd8649843 redeployed due to link down
2022-05-04 11:41:26,328 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_44) EVC(9a2bf483c67849, my evc 444) was deployed.
2022-05-04 11:41:26,349 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_4) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,353 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_44) EVC 9a2bf483c67849 redeployed due to link down
2022-05-04 11:41:26,368 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_4) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,383 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_1) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,410 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_3) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,442 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_6) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,445 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_50) EVC f5994a45a81f4d was synced to the storehouse.
2022-05-04 11:41:26,470 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_50) EVC(f5994a45a81f4d, my evc 450) was deployed.
2022-05-04 11:41:26,479 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_50) EVC f5994a45a81f4d redeployed due to link down
2022-05-04 11:41:26,480 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_1) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,507 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_48) EVC 02997bde5b6a45 was synced to the storehouse.
2022-05-04 11:41:26,513 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_48) EVC(02997bde5b6a45, my evc 448) was deployed.
2022-05-04 11:41:26,543 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_6) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,548 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_49) EVC 08c61a6a002e4d was synced to the storehouse.
2022-05-04 11:41:26,551 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_2) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,552 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_48) EVC 02997bde5b6a45 redeployed due to link down
2022-05-04 11:41:26,574 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_49) EVC(08c61a6a002e4d, my evc 449) was deployed.
2022-05-04 11:41:26,582 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_49) EVC 08c61a6a002e4d redeployed due to link down
2022-05-04 11:41:26,602 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_4) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,608 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_4) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,632 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_6) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
2022-05-04 11:41:26,647 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_db_2) Flow saved in kytos.flow.persistence.6d6a39d624424ba7af191f3f3a4f64f8
``

