### PR TITLE
Updated tox and scrutinizer to run on py39

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,42 +2,28 @@ checks:
     python:
         code_rating: true
         duplicate_code: true
+filter:
+    paths: ['*']
 build:
+    environment:
+        python: 3.9.12
+        postgresql: false
+        redis: false
+    dependencies:
+        before:
+            - pip install tox coverage
+    tests:
+        override:
+            -
+                command: 'tox'
+                idle_timeout: 300
+                coverage:
+                    file: '.coverage'
+                    config_file: '.coveragerc'
+                    format: 'py-cc'
     nodes:
-        py37:
-            environment:
-                python: 3.7.1
-                postgresql: false
-                redis: false
-            dependencies:
-                before:
-                    - pip install coverage
+        analysis:
             tests:
                 override:
-                    -
-                        command: 'tox -e py37'
-                        only_if: 'tox -a | grep -q py37'
-                        idle_timeout: 300
-                        coverage:
-                            file: '.coverage'
-                            config_file: '.coveragerc'
-                            format: 'py-cc'
                     - py-scrutinizer-run
-        pyOthers:
-            environment:
-                python: 3.6
-                postgresql: false
-                redis: false
-            dependencies:
-                before:
-                    - pip install coverage
-            tests:
-                override:
-                    -
-                        command: 'for env in $(tox -a | grep -v py37); do tox -e $env; done'
-                        idle_timeout: 300
-                        coverage:
-                            file: '.coverage'
-                            config_file: '.coveragerc'
-                            format: 'py-cc'
-                    - py-scrutinizer-run
+        tests: true

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,8 +2,6 @@ checks:
     python:
         code_rating: true
         duplicate_code: true
-filter:
-    paths: ['*']
 build:
     environment:
         python: 3.9.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 [yala]
 radon mi args = --min C
 pylint args = --disable=too-few-public-methods,too-many-instance-attributes,logging-format-interpolation,protected-access
+linters=pylint,pycodestyle,isort
 
 [pydocstyle]
 add-ignore = D105

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py39
 
 [gh-actions]
 python =


### PR DESCRIPTION
py39 is the official main supported for Kytos-ng at the moment, as we've discussed, so updated tox.ini and scrutinizer accordingly.