### PR TITLE
[Feature] kytos.core.retry decorators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Added
 - Augmented docker-compose.yml to also spin up Elastsearch, Kibana and APM server with authentication
 - Augmented docker-compose to also spin up Filebeat, integrating log file as input
 - The ``listen_to`` decorator now supports a ``pool`` keyword argument to specify which thread pool the execution should be submitted
+- New core ``kytos.core.retry`` module provides decorators for retries based on ``tenacity``
 
 Changed
 =======

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -174,7 +174,8 @@ def listen_to(event, *events, pool=None):
 
             if event.name.startswith("kytos/of_core") and "sb" in executors:
                 return executors["sb"]
-            if event.name.startswith("kytos/core") and "sb" in executors:
+            core_of = "kytos/core.openflow"
+            if event.name.startswith(core_of) and "sb" in executors:
                 return executors["sb"]
             if event.name.startswith("kytos.storehouse") and "db" in executors:
                 return executors["db"]

--- a/kytos/core/retry.py
+++ b/kytos/core/retry.py
@@ -1,11 +1,9 @@
 """Retry utilities module."""
 import logging
-
 from functools import wraps
 from typing import Callable
 
 from tenacity import retry
-
 
 LOG = logging.getLogger(__name__)
 

--- a/kytos/core/retry.py
+++ b/kytos/core/retry.py
@@ -1,0 +1,44 @@
+"""Retry utilities module."""
+import logging
+from functools import wraps
+from typing import Callable
+
+from tenacity import retry
+
+LOG = logging.getLogger(__name__)
+
+
+def before_sleep(state) -> None:
+    """Before sleep function for tenacity to also logs args and kwargs."""
+    LOG.warning(
+        f"Retry #{state.attempt_number} for {state.fn.__name__}, "
+        f"args: {state.args}, kwargs: {state.kwargs}, "
+        f"seconds since start: {state.seconds_since_start:.2f}",
+    )
+
+
+def retries(func: Callable, **tenacity_kwargs) -> Callable:
+    """Retries decorator."""
+    @retry(**tenacity_kwargs)
+    @wraps(func)
+    def decorated(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return decorated
+
+
+def for_all_methods(decorator: Callable, **kwargs) -> Callable:
+    """Decorator for all methods."""
+
+    def decorated(cls):
+        for attr in [
+            name
+            for name in dir(cls)
+            if callable(getattr(cls, name))
+            and not name.startswith("_")
+            and not hasattr(getattr(cls, name), "__wrapped__")
+        ]:
+            setattr(cls, attr, decorator(getattr(cls, attr), **kwargs))
+        return cls
+
+    return decorated

--- a/tests/unit/test_core/test_retry.py
+++ b/tests/unit/test_core/test_retry.py
@@ -1,4 +1,5 @@
 """Test kytos.core.retry module."""
+# pylint: disable=no-self-use
 
 from unittest.mock import MagicMock, patch
 
@@ -32,8 +33,7 @@ def test_for_all_methods_retries():
     class SomeClass:
         """SomeClass."""
 
-        @staticmethod
-        def some_method(mock) -> None:
+        def some_method(self, mock) -> None:
             """some_method."""
             mock()
             raise ValueError("some error")

--- a/tests/unit/test_core/test_retry.py
+++ b/tests/unit/test_core/test_retry.py
@@ -1,8 +1,10 @@
 """Test kytos.core.retry module."""
 
-from unittest.mock import patch, MagicMock
-from kytos.core.retry import before_sleep, for_all_methods, retries
+from unittest.mock import MagicMock, patch
+
 from tenacity import retry_if_exception_type, stop_after_attempt
+
+from kytos.core.retry import before_sleep, for_all_methods, retries
 
 
 @patch("kytos.core.retry.LOG")
@@ -28,7 +30,11 @@ def test_for_all_methods_retries():
         reraise=True,
     )
     class SomeClass:
-        def some_method(self, mock) -> None:
+        """SomeClass."""
+
+        @staticmethod
+        def some_method(mock) -> None:
+            """some_method."""
             mock()
             raise ValueError("some error")
 

--- a/tests/unit/test_core/test_retry.py
+++ b/tests/unit/test_core/test_retry.py
@@ -1,0 +1,40 @@
+"""Test kytos.core.retry module."""
+
+from unittest.mock import patch, MagicMock
+from kytos.core.retry import before_sleep, for_all_methods, retries
+from tenacity import retry_if_exception_type, stop_after_attempt
+
+
+@patch("kytos.core.retry.LOG")
+def test_before_sleep(mock_log):
+    """Test before sleep."""
+    state = MagicMock()
+    state.fn.__name__ = "some_name"
+    state.seconds_since_start = 1
+    before_sleep(state)
+    assert mock_log.warning.call_count == 1
+
+
+def test_for_all_methods_retries():
+    """test for_all_methods retries."""
+
+    mock = MagicMock()
+    max_retries = 3
+
+    @for_all_methods(
+        retries,
+        retry=retry_if_exception_type((ValueError,)),
+        stop=stop_after_attempt(max_retries),
+        reraise=True,
+    )
+    class SomeClass:
+        def some_method(self, mock) -> None:
+            mock()
+            raise ValueError("some error")
+
+    some_class = SomeClass()
+    try:
+        some_class.some_method(mock)
+    except ValueError:
+        pass
+    assert mock.call_count == max_retries


### PR DESCRIPTION
Fixes #214

### Description of the change

New `kytos.core.retry ` module providing common retry decorators for NApps

### Release notes

- New core ``kytos.core.retry`` module provides decorators for retries based on ``tenacity``. The primary use case for this is using to retry certain exceptions from MongoDB and also certain requests. For MongoDB only the basic blocks are provided to simplify maintenance, for a sample on how to use check out [this kytos-ng/topology PR 90 that's in flight](https://github.com/kytos-ng/topology/pull/90), the retry module there has been copied to core, once this current PR lands it'll import from kytos core instead.
