### PR TITLE
[Fix] Updated requirements/dev.txt pytest 7.0.0

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -170,7 +170,7 @@ pymongo==4.1.0
     # via -r requirements/run.txt
 pyparsing==2.4.6
     # via packaging
-pytest==5.4.1
+pytest==7.0.0
     # via -r requirements/dev.in
 python-daemon==2.2.4
     # via -r requirements/run.txt


### PR DESCRIPTION
It turns out `pytest` hadn't been updated on requirements/dev.txt, this created some recent conflicts with `pytest==7.0.0` on setup.py. 