### PR TITLE
[Fix] file already exists error when creating config dirs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,7 @@ Removed
 
 Fixed
 =====
+- Fixed file already exists error when creating config dirs, issue 222
 
 Security
 ========

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -227,8 +227,7 @@ def _render_config_templates(templates,
     # Create the paths used by Kytos.
     directories = [os.path.join(BASE_ENV, ETC_KYTOS)]
     for directory in directories:
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+        os.makedirs(directory, exist_ok=True)
 
     tmpl_path = Path(os.path.abspath(os.path.dirname(__file__))).parent
 


### PR DESCRIPTION
Fixes #222. Same approach as we have [for the pid dir](https://github.com/kytos-ng/kytos/blob/master/kytos/core/kytosd.py#L33) when creating it.

### Release notes

- Fixed file already exists error when creating config dirs, issue 222
