### PR TITLE
[Feature] Changed `msg_out` to use a PriorityQueue instead of a FIFO Queue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,8 @@ Changed
    app: it's meant for general NApps event, it's default pool if no other one has been specified
    db: it can be used by for higher priority db related tasks (need to be parametrized on decorator), it's also used automatically by kytos.storehouse.* events
 
+- ``msg_out`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
+
 Deprecated
 ==========
 

--- a/kytos/core/buffers.py
+++ b/kytos/core/buffers.py
@@ -1,8 +1,8 @@
 """Kytos Buffer Classes, based on Python Queue."""
 import logging
 
-# from queue import Queue
 from janus import Queue
+from janus import PriorityQueue
 
 from kytos.core.events import KytosEvent
 from kytos.core.helpers import get_thread_pool_max_workers
@@ -15,7 +15,8 @@ LOG = logging.getLogger(__name__)
 class KytosEventBuffer:
     """KytosEventBuffer represents a queue to store a set of KytosEvents."""
 
-    def __init__(self, name, event_base_class=None, loop=None, maxsize=0):
+    def __init__(self, name, event_base_class=None, loop=None, maxsize=0,
+                 queue_cls=Queue):
         """Contructor of KytosEventBuffer receive the parameters below.
 
         Args:
@@ -23,11 +24,12 @@ class KytosEventBuffer:
             event_base_class (class): Class of KytosEvent.
             loop (class): asyncio event loop
             maxsize (int): maxsize _queue producer buffer
+            queue_cls (class): queue class from janus
         """
         self.name = name
         self._event_base_class = event_base_class
         self._loop = loop
-        self._queue = Queue(maxsize=maxsize, loop=self._loop)
+        self._queue = queue_cls(maxsize=maxsize, loop=self._loop)
         self._reject_new_events = False
 
     def put(self, event):
@@ -59,14 +61,9 @@ class KytosEventBuffer:
             event (:class:`~kytos.core.events.KytosEvent`):
                 KytosEvent sent to queue.
         """
-        # qsize = self._queue.async_q.qsize()
-        # print('qsize before:', qsize)
         if not self._reject_new_events:
             await self._queue.async_q.put(event)
             LOG.debug('[buffer: %s] Added: %s', self.name, event.name)
-
-        # qsize = self._queue.async_q.qsize()
-        # print('qsize after:', qsize)
 
         if event.name == "kytos/core.shutdown":
             LOG.info('[buffer: %s] Stop mode enabled. Rejecting new events.',
@@ -156,7 +153,8 @@ class KytosBuffers:
         self.msg_in = KytosEventBuffer("msg_in_event", loop=self._loop,
                                        maxsize=self._get_maxsize("sb"))
         self.msg_out = KytosEventBuffer('msg_out_event', loop=self._loop,
-                                        maxsize=self._get_maxsize("sb"))
+                                        maxsize=0,
+                                        queue_cls=PriorityQueue)
         self.app = KytosEventBuffer('app_event', loop=self._loop,
                                     maxsize=self._get_maxsize("app"))
 

--- a/kytos/core/buffers.py
+++ b/kytos/core/buffers.py
@@ -1,8 +1,7 @@
 """Kytos Buffer Classes, based on Python Queue."""
 import logging
 
-from janus import Queue
-from janus import PriorityQueue
+from janus import PriorityQueue, Queue
 
 from kytos.core.events import KytosEvent
 from kytos.core.helpers import get_thread_pool_max_workers

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -13,7 +13,7 @@ class KytosEvent:
     dictionary.
     """
 
-    def __init__(self, name=None, content=None, trace_parent=None):
+    def __init__(self, name=None, content=None, trace_parent=None, priority=0):
         """Create an event to be published.
 
         Args:
@@ -25,11 +25,14 @@ class KytosEvent:
                                    set the root parent, and then you have to
                                    pass the trace_parent to subsequent
                                    correlated KytosEvent(s).
+            priority (int): Priority of this event if a PriorityQueue is being
+                            used, the lower the number the higher the priority.
         """
         self.name = name
         self.content = content if content is not None else {}
         self.timestamp = now()
         self.reinjections = 0
+        self.priority = priority
 
         # pylint: disable=invalid-name
         self.id = uuid4()
@@ -39,7 +42,13 @@ class KytosEvent:
         return self.name
 
     def __repr__(self):
-        return f"KytosEvent({self.name!r}, {self.content!r})"
+        return f"KytosEvent({self.name!r}, {self.content!r}, {self.priority})"
+
+    def __lt__(self, other):
+        """Less than operator."""
+        if self.priority != other.priority:
+            return self.priority < other.priority
+        return self.timestamp < other.timestamp
 
     def as_dict(self):
         """Return KytosEvent as a dict."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,logging-format-interpolation,protected-access
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,logging-format-interpolation,protected-access,too-many-arguments
 linters=pylint,pycodestyle,isort
 
 [pydocstyle]

--- a/tests/unit/test_core/test_buffers.py
+++ b/tests/unit/test_core/test_buffers.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from kytos.core.buffers import KytosBuffers, KytosEventBuffer
+from kytos.core.events import KytosEvent
 
 
 # pylint: disable=protected-access
@@ -117,6 +118,14 @@ class TestKytosBuffers(TestCase):
         asyncio.set_event_loop(None)
 
         self.kytos_buffers = KytosBuffers(loop=self.loop)
+
+    def test_msg_out_queue_prio(self):
+        """Test msg_out queue priorities."""
+        prios = [-10, 10, 0, -20]
+        for prio in prios:
+            self.kytos_buffers.msg_out.put(KytosEvent(priority=prio))
+        for prio in sorted(prios):
+            assert self.kytos_buffers.msg_out.get().priority == prio
 
     def test_send_stop_signal(self):
         """Test send_stop_signal method."""

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 
 from kytos.core import Controller
 from kytos.core.config import KytosConfig
+from kytos.core.events import KytosEvent
 from kytos.core.logs import LogManager
 
 
@@ -706,13 +707,10 @@ class TestController(TestCase):
         msg = MagicMock()
         msg.pack.return_value = packet
 
-        event_1 = MagicMock()
-        event_1.name = 'kytos/core.any'
-        event_1.destination = dst
-        event_1.content = {"message": msg}
+        event_1 = KytosEvent('kytos/core.any',
+                             content={'message': msg, 'destination': dst})
 
-        event_2 = MagicMock()
-        event_2.name = 'kytos/core.shutdown'
+        event_2 = KytosEvent('kytos/core.shutdown')
 
         self.controller.buffers.msg_out._queue.sync_q.put(event_1)
         self.controller.buffers.msg_out._queue.sync_q.put(event_2)

--- a/tests/unit/test_core/test_events.py
+++ b/tests/unit/test_core/test_events.py
@@ -25,9 +25,19 @@ class TestKytosEvent(TestCase):
                               "source": "src",
                               "message": "msg"}
         expected = "KytosEvent('kytos/core.any', {'destination': 'dest', " + \
-                   "'source': 'src', 'message': 'msg'})"
+                   "'source': 'src', 'message': 'msg'}, 0)"
 
         self.assertEqual(repr(self.event), expected)
+
+    def test__lt__(self):
+        """test less than operator."""
+        event_a = KytosEvent('a', priority=5)
+        event_b = KytosEvent('b', priority=-10)
+        assert event_b < event_a
+
+        event_a = KytosEvent('a')
+        event_b = KytosEvent('b')
+        assert event_a < event_b
 
     def test_destination(self):
         """Test destination property and set_destination method."""
@@ -57,6 +67,7 @@ class TestKytosEvent(TestCase):
         assert self.event.timestamp <= datetime.now(timezone.utc)
         assert self.event.id and isinstance(self.event.id, UUID)
         assert self.event.reinjections == 0
+        assert self.event.priority == 0
 
     def test_trace_parent(self):
         """Test trace_parent."""

--- a/tests/unit/test_core/test_events.py
+++ b/tests/unit/test_core/test_events.py
@@ -29,7 +29,8 @@ class TestKytosEvent(TestCase):
 
         self.assertEqual(repr(self.event), expected)
 
-    def test__lt__(self):
+    @staticmethod
+    def test__lt__():
         """test less than operator."""
         event_a = KytosEvent('a', priority=5)
         event_b = KytosEvent('b', priority=-10)


### PR DESCRIPTION
This address issue #224 partly by changing `msg_out` to use a PriorityQueue instead of a FIFO Queue. It address partly because the OF keepalive messages are symmetric and to fully solve the starvation we also need to implement the same approach for the `msg_in` queue, however that depends on issue #172 first (which will be delivered in the future, we also need to discuss thread/taks per connection regarding the msg_in queue, so making changes on `msg_in` now could result in extra refactoring). 

### Description of the change

- Changed ``msg_out`` core queue now leverages a PriorityQueue instead of a FIFO Queue.

### Results

- Some improvements also in the case where a 250 FlowMods / sec over 10 secs via REST was result in starvation and runtime slowness, now it can still crash, but since it solved for the outbound part it slightly improved it at least: 

![250_spike_new_branch](https://user-images.githubusercontent.com/1010796/172196487-8e698808-9fb3-46d3-bcfb-d93f01ea550f.png)

- Here's a sustained 300 FlowMods / sec, using this branch via KytosEvent and queue, you can see that 300 FlowMods results in a steady rate, so for this case, in the local environment conditions it's a relatively stable rate:

- This branch with 500 FlowMods / sec over 60 secs via KytosEvent and queue (which is far more stable than using via REST), it doesn't result in connection issues, but you can see that the rate isn't as steady as the 300 FlowMods / sec that was tested before, so the platform can handle this case, and getting close to this value it's recommended that NApps start batching messages:

![500_event_flow_mods](https://user-images.githubusercontent.com/1010796/172196497-42d9f96a-924e-49e2-9fc5-1875dbf5777e.png)

![master_500_events_sec_flow_mods](https://user-images.githubusercontent.com/1010796/172196502-9a4f55fe-eed4-4dd6-a39b-506234c0f9d9.png)

### Next

- Continue to work on the priority related issues
- Standardize some default values of OpenFlow message priorities on `of_core` where NApps like `flow_manager`, `of_lldp`, `sdntrace` and other ones that put messages on `msg_out` could import to set the priority accordingly.
