### PR TITLE
`listen_to` unhandled exceptions log error includes the traceback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Added
 - Augmented docker-compose to also spin up Filebeat, integrating log file as input
 - The ``listen_to`` decorator now supports a ``pool`` keyword argument to specify which thread pool the execution should be submitted
 - New core ``kytos.core.retry`` module provides decorators for retries based on ``tenacity``
+- Unhandled exceptions on ``@listen_to`` decorator now also include a traceback
 
 Changed
 =======

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -124,12 +124,11 @@ def listen_to(event, *events, pool=None):
             cls, kytos_event = args[0], args[1]
             try:
                 result = handler(*args)
-            except Exception as exc:
+            except Exception:
                 result = None
-                exc_str = f"{type(exc)}: {str(exc)}"
+                traceback_str = traceback.format_exc().replace("\n", ", ")
                 LOG.error(f"listen_to handler: {handler}, "
-                          f"args: {args}, exception: {exc_str} "
-                          f"traceback: {traceback.format_exc()}")
+                          f"args: {args} traceback: {traceback_str}")
                 if hasattr(cls, "controller"):
                     cls.controller.dead_letter.add_event(kytos_event)
             return result
@@ -148,10 +147,9 @@ def listen_to(event, *events, pool=None):
                 tx.result = result
             except Exception as exc:
                 result = None
-                exc_str = f"{type(exc)}: {str(exc)}"
+                traceback_str = traceback.format_exc().replace("\n", ", ")
                 LOG.error(f"listen_to handler: {handler}, "
-                          f"args: {args}, exception: {exc_str} "
-                          f"traceback: {traceback.format_exc()}")
+                          f"args: {args} traceback: {traceback_str}")
                 if hasattr(cls, "controller"):
                     cls.controller.dead_letter.add_event(kytos_event)
                 apm_client.capture_exception(

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -1,5 +1,6 @@
 """Utilities functions used in Kytos."""
 import logging
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from threading import Thread
@@ -127,7 +128,8 @@ def listen_to(event, *events, pool=None):
                 result = None
                 exc_str = f"{type(exc)}: {str(exc)}"
                 LOG.error(f"listen_to handler: {handler}, "
-                          f"args: {args}, exception: {exc_str}")
+                          f"args: {args}, exception: {exc_str} "
+                          f"traceback: {traceback.format_exc()}")
                 if hasattr(cls, "controller"):
                     cls.controller.dead_letter.add_event(kytos_event)
             return result
@@ -148,7 +150,8 @@ def listen_to(event, *events, pool=None):
                 result = None
                 exc_str = f"{type(exc)}: {str(exc)}"
                 LOG.error(f"listen_to handler: {handler}, "
-                          f"args: {args}, exception: {exc_str}")
+                          f"args: {args}, exception: {exc_str} "
+                          f"traceback: {traceback.format_exc()}")
                 if hasattr(cls, "controller"):
                     cls.controller.dead_letter.add_event(kytos_event)
                 apm_client.capture_exception(


### PR DESCRIPTION
Fixes #231 

### Changelog

- Unhandled exceptions on ``@listen_to`` decorator now also include a traceback

### Examples

- before

```
2022-06-16 17:24:27,711 - ERROR [kytos.core.helpers] (thread_pool_sb_0) listen_to handler: <function Main.handle_packet_in at 0x7ff374cac040>, args: (<Main(of_l3ls, stopped 140683264390
720)>, KytosEvent('kytos/of_core.v0x04.messages.in.ofpt_packet_in', {'message': PacketIn(xid=UBInt32(0)), 'source': Connection('127.0.0.1', 41712, <asyncio.TransportSocket fd=112, famil
y=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 41712)>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLISHED: 2
>)}, 0)), exception: <class 'AttributeError'>: 'int' object has no attribute 'value'
2022-06-16 17:24:28,742 - ERROR [kytos.core.helpers] (thread_pool_sb_0) listen_to handler: <function Main.handle_packet_in at 0x7ff374cac040>, args: (<Main(of_l3ls, stopped 140683264390
720)>, KytosEvent('kytos/of_core.v0x04.messages.in.ofpt_packet_in', {'message': PacketIn(xid=UBInt32(0)), 'source': Connection('127.0.0.1', 41712, <asyncio.TransportSocket fd=112, famil
y=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 41712)>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLISHED: 2
>)}, 0)), exception: <class 'AttributeError'>: 'int' object has no attribute 'value'
2022-06-16 17:24:29,754 - ERROR [kytos.core.helpers] (thread_pool_sb_0) listen_to handler: <function Main.handle_packet_in at 0x7ff374cac040>, args: (<Main(of_l3ls, stopped 140683264390
720)>, KytosEvent('kytos/of_core.v0x04.messages.in.ofpt_packet_in', {'message': PacketIn(xid=UBInt32(0)), 'source': Connection('127.0.0.1', 41712, <asyncio.TransportSocket fd=112, famil
y=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 41712)>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLISHED: 2
>)}, 0)), exception: <class 'AttributeError'>: 'int' object has no attribute 'value'
```

- after (with this branch), notice that you can narrow down the line 47 that generated the exception right away, the traceback has been flattened just so Elastic filebeat [tonekizer](https://github.com/kytos-ng/kytos/blob/master/docker/filebeat/config/filebeat.yml#L14) matches easily and efficiently a single line:

![2022-06-16-180911_1587x717_scrot](https://user-images.githubusercontent.com/1010796/174164155-4462098f-07d9-48e2-a570-25e4faa04ecf.png)


```
kytos $> 2022-06-16 18:05:07,922 - ERROR [kytos.core.helpers] (thread_pool_sb_0) listen_to handler: <function Main.handle_packet_in at 0x7f5f22f54ee0>, args: (<Main(of_l3ls, stopped 1400
46567073344)>, KytosEvent('kytos/of_core.v0x04.messages.in.ofpt_packet_in', {'message': PacketIn(xid=UBInt32(0)), 'source': Connection('127.0.0.1', 42252, <asyncio.TransportSocket fd=113
, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 42252)>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLIS
HED: 2>)}, 0)) traceback: Traceback (most recent call last):,   File "/home/viniarck/repos/kytos/kytos/core/helpers.py", line 146, in handler_context_apm,     result = handler(*args),
File "/home/viniarck/repos/napps/napps/krishna4041/of_l3ls/main.py", line 47, in handle_packet_in,     in_port = packet_in.in_port.value, AttributeError: 'int' object has no attribute 'v
alue',
2022-06-16 18:05:08,948 - ERROR [kytos.core.helpers] (thread_pool_sb_0) listen_to handler: <function Main.handle_packet_in at 0x7f5f22f54ee0>, args: (<Main(of_l3ls, stopped 1400465670733
44)>, KytosEvent('kytos/of_core.v0x04.messages.in.ofpt_packet_in', {'message': PacketIn(xid=UBInt32(0)), 'source': Connection('127.0.0.1', 42252, <asyncio.TransportSocket fd=113, family=
AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 42252)>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLISHED: 2>)}
, 0)) traceback: Traceback (most recent call last):,   File "/home/viniarck/repos/kytos/kytos/core/helpers.py", line 146, in handler_context_apm,     result = handler(*args),   File "/ho
me/viniarck/repos/napps/napps/krishna4041/of_l3ls/main.py", line 47, in handle_packet_in,     in_port = packet_in.in_port.value, AttributeError: 'int' object has no attribute 'value',
2022-06-16 18:05:09,950 - ERROR [kytos.core.helpers] (thread_pool_sb_3) listen_to handler: <function Main.handle_packet_in at 0x7f5f22f54ee0>, args: (<Main(of_l3ls, stopped 1400465670733
44)>, KytosEvent('kytos/of_core.v0x04.messages.in.ofpt_packet_in', {'message': PacketIn(xid=UBInt32(0)), 'source': Connection('127.0.0.1', 42252, <asyncio.TransportSocket fd=113, family=
AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 42252)>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLISHED: 2>)}
, 0)) traceback: Traceback (most recent call last):,   File "/home/viniarck/repos/kytos/kytos/core/helpers.py", line 146, in handler_context_apm,     result = handler(*args),   File "/ho
me/viniarck/repos/napps/napps/krishna4041/of_l3ls/main.py", line 47, in handle_packet_in,     in_port = packet_in.in_port.value, AttributeError: 'int' object has no attribute 'value',


```

Another example on `flow_manager/main.py` at line 233:

```
2022-06-16 18:03:49,776 - ERROR [kytos.core.helpers] (thread_pool_sb_0) listen_to handler: <function Main.on_ofpt_barrier_reply at 0x7f4b46cc98b0>, args: (<Main(flow_manager, stopped 13
9961297069632)>, KytosEvent('kytos/of_core.v0x04.messages.in.ofpt_barrier_reply', {'message': BarrierReply(xid=UBInt32(1442156339)), 'source': Connection('127.0.0.1', 42244, <asyncio.Tr
ansportSocket fd=113, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 42244)>, Switch('00:00:00:00:00:00:00:01'), <Con
nectionState.ESTABLISHED: 2>)}, 0)) traceback: Traceback (most recent call last):,   File "/home/viniarck/repos/kytos/kytos/core/helpers.py", line 146, in handler_context_apm,     resul
t = handler(*args),   File "/home/viniarck/repos/napps/napps/kytos/flow_manager/main.py", line 233, in on_ofpt_barrier_reply,     x = a, NameError: name 'a' is not defined,
```