### PR TITLE
[Feature] `alisten to` decorator and `msg_in` PriorityQueue

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 source = kytos
-omit = .eggs/*,.tox/*,*tests*,setup.py
+omit = .eggs/*,.tox/*,*tests*,setup.py,venv/*,.venv/*,.direnv/*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Added
 - The ``listen_to`` decorator now supports a ``pool`` keyword argument to specify which thread pool the execution should be submitted
 - New core ``kytos.core.retry`` module provides decorators for retries based on ``tenacity``
 - Unhandled exceptions on ``@listen_to`` decorator now also include a traceback
+- Added ``@alisten_to`` decorator for ``async`` methods. NApps can subscribe to events asynchronously with this decorator as needed.
 
 Changed
 =======
@@ -50,6 +51,7 @@ Changed
    db: it can be used by for higher priority db related tasks (need to be parametrized on decorator), it's also used automatically by kytos.storehouse.* events
 
 - ``msg_out`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
+- ``msg_in`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
 
 Deprecated
 ==========

--- a/kytos/core/atcp_server.py
+++ b/kytos/core/atcp_server.py
@@ -147,7 +147,7 @@ class KytosServerProtocol(asyncio.Protocol):
         event = KytosEvent(name=event_name,
                            content={'source': self.connection})
 
-        self._loop.create_task(self.server.controller.buffers.raw.aput(event))
+        self._loop.create_task(self.server.controller.buffers.conn.aput(event))
 
     def data_received(self, data):
         """Handle each request and place its data in the raw event buffer.
@@ -160,8 +160,8 @@ class KytosServerProtocol(asyncio.Protocol):
 
         data = self._rest + data
 
-        LOG.debug("New data from %s:%s (%s bytes)",
-                  self.connection.address, self.connection.port, len(data))
+        # LOG.debug("New data from %s:%s (%s bytes)",
+        #           self.connection.address, self.connection.port, len(data))
 
         # LOG.debug("New data from %s:%s (%s bytes): %s", self.addr, self.port,
         #           len(data), binascii.hexlify(data))
@@ -191,4 +191,4 @@ class KytosServerProtocol(asyncio.Protocol):
             f'kytos/core.{self.connection.protocol.name}.connection.lost'
         event = KytosEvent(name=event_name, content=content)
 
-        self._loop.create_task(self.server.controller.buffers.app.aput(event))
+        self._loop.create_task(self.server.controller.buffers.conn.aput(event))

--- a/kytos/core/atcp_server.py
+++ b/kytos/core/atcp_server.py
@@ -160,8 +160,9 @@ class KytosServerProtocol(asyncio.Protocol):
 
         data = self._rest + data
 
-        # LOG.debug("New data from %s:%s (%s bytes)",
-        #           self.connection.address, self.connection.port, len(data))
+        if logging.DEBUG >= LOG.getEffectiveLevel():
+            LOG.debug("New data from %s:%s (%s bytes)",
+                      self.connection.address, self.connection.port, len(data))
 
         # LOG.debug("New data from %s:%s (%s bytes): %s", self.addr, self.port,
         #           len(data), binascii.hexlify(data))

--- a/kytos/core/buffers.py
+++ b/kytos/core/buffers.py
@@ -133,7 +133,7 @@ class KytosBuffers:
     def __init__(self, loop=None):
         """Build four KytosEventBuffers.
 
-        :attr:`raw`: :class:`~kytos.core.buffers.KytosEventBuffer` with events
+        :attr:`conn`: :class:`~kytos.core.buffers.KytosEventBuffer` with events
         received from connection events.
 
         :attr:`raw`: :class:`~kytos.core.buffers.KytosEventBuffer` with events

--- a/kytos/core/buffers.py
+++ b/kytos/core/buffers.py
@@ -43,7 +43,8 @@ class KytosEventBuffer:
         """
         if not self._reject_new_events:
             self._queue.sync_q.put(event)
-            # LOG.debug('[buffer: %s] Added: %s', self.name, event.name)
+            if logging.DEBUG >= LOG.getEffectiveLevel():
+                LOG.debug('[buffer: %s] Added: %s', self.name, event.name)
 
         if event.name == "kytos/core.shutdown":
             LOG.info('[buffer: %s] Stop mode enabled. Rejecting new events.',
@@ -62,7 +63,8 @@ class KytosEventBuffer:
         """
         if not self._reject_new_events:
             await self._queue.async_q.put(event)
-            # LOG.debug('[buffer: %s] Added: %s', self.name, event.name)
+            if logging.DEBUG >= LOG.getEffectiveLevel():
+                LOG.debug('[buffer: %s] Added: %s', self.name, event.name)
 
         if event.name == "kytos/core.shutdown":
             LOG.info('[buffer: %s] Stop mode enabled. Rejecting new events.',
@@ -79,7 +81,8 @@ class KytosEventBuffer:
         """
         event = self._queue.sync_q.get()
 
-        # LOG.debug('[buffer: %s] Removed: %s', self.name, event.name)
+        if logging.DEBUG >= LOG.getEffectiveLevel():
+            LOG.debug('[buffer: %s] Removed: %s', self.name, event.name)
 
         return event
 
@@ -93,7 +96,8 @@ class KytosEventBuffer:
         """
         event = await self._queue.async_q.get()
 
-        # LOG.debug('[buffer: %s] Removed: %s', self.name, event.name)
+        if logging.DEBUG >= LOG.getEffectiveLevel():
+            LOG.debug('[buffer: %s] Removed: %s', self.name, event.name)
 
         return event
 

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -521,7 +521,9 @@ class Controller:
         Args:
             event (~kytos.core.KytosEvent): An instance of a KytosEvent.
         """
-        # self.log.debug("looking for listeners for %s", event)
+
+        if logging.DEBUG >= self.log.getEffectiveLevel():
+            self.log.debug("looking for listeners for %s", event)
         for event_regex, listeners in dict(self.events_listeners).items():
             # self.log.debug("listeners found for %s: %r => %s", event,
             #                event_regex, [l.__qualname__ for l in listeners])
@@ -530,7 +532,8 @@ class Controller:
             if event_regex[-1] != '$' or event_regex[-2] == '\\':
                 event_regex += '$'
             if re.match(event_regex, event.name):
-                # self.log.debug('Calling listeners for %s', event)
+                if logging.DEBUG >= self.log.getEffectiveLevel():
+                    self.log.debug('Calling listeners for %s', event)
                 for listener in listeners:
                     if asyncio.iscoroutinefunction(listener):
                         task = asyncio.create_task(listener(event))
@@ -583,13 +586,14 @@ class Controller:
                         not destination.state == ConnectionState.FINISHED):
                     packet = message.pack()
                     destination.send(packet)
-                    # self.log.debug('Connection %s: OUT OFP, '
-                    #                'version: %s, type: %s, xid: %s - %s',
-                    #                destination.id,
-                    #                message.header.version,
-                    #                message.header.message_type,
-                    #                message.header.xid,
-                    #                packet.hex())
+                    if logging.DEBUG >= self.log.getEffectiveLevel():
+                        self.log.debug('Connection %s: OUT OFP, '
+                                       'version: %s, type: %s, xid: %s - %s',
+                                       destination.id,
+                                       message.header.version,
+                                       message.header.message_type,
+                                       message.header.xid,
+                                       packet.hex())
                     self.notify_listeners(triggered_event)
                     continue
 

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -307,13 +307,15 @@ class Controller:
             log.debug('completed: %d, pending: %d',
                       len(completed), len(pending))
 
-        task = self._loop.create_task(self.raw_event_handler())
+        task = self._loop.create_task(self.event_handler("conn"))
         self._tasks.append(task)
-        task = self._loop.create_task(self.msg_in_event_handler())
+        task = self._loop.create_task(self.event_handler("raw"))
+        self._tasks.append(task)
+        task = self._loop.create_task(self.event_handler("msg_in"))
         self._tasks.append(task)
         task = self._loop.create_task(self.msg_out_event_handler())
         self._tasks.append(task)
-        task = self._loop.create_task(self.app_event_handler())
+        task = self._loop.create_task(self.event_handler("app"))
         self._tasks.append(task)
         task = self._loop.create_task(_run_api_server_thread(self._pool))
         task.add_done_callback(_stop_loop)
@@ -519,7 +521,7 @@ class Controller:
         Args:
             event (~kytos.core.KytosEvent): An instance of a KytosEvent.
         """
-        self.log.debug("looking for listeners for %s", event)
+        # self.log.debug("looking for listeners for %s", event)
         for event_regex, listeners in dict(self.events_listeners).items():
             # self.log.debug("listeners found for %s: %r => %s", event,
             #                event_regex, [l.__qualname__ for l in listeners])
@@ -537,36 +539,15 @@ class Controller:
                     else:
                         listener(event)
 
-    async def raw_event_handler(self):
-        """Handle raw events.
-
-        Listen to the raw_buffer and send all its events to the
-        corresponding listeners.
-        """
-        self.log.info("Raw Event Handler started")
+    async def event_handler(self, buffer_name: str):
+        """Default event handler that gets from an event buffer."""
+        event_buffer = getattr(self.buffers, buffer_name)
         while True:
-            event = await self.buffers.raw.aget()
+            event = await event_buffer.aget()
             self.notify_listeners(event)
-            self.log.debug("Raw Event handler called")
 
             if event.name == "kytos/core.shutdown":
                 self.log.debug("Raw Event handler stopped")
-                break
-
-    async def msg_in_event_handler(self):
-        """Handle msg_in events.
-
-        Listen to the msg_in buffer and send all its events to the
-        corresponding listeners.
-        """
-        self.log.info("Message In Event Handler started")
-        while True:
-            event = await self.buffers.msg_in.aget()
-            self.notify_listeners(event)
-            self.log.debug("Message In Event handler called")
-
-            if event.name == "kytos/core.shutdown":
-                self.log.debug("Message In Event handler stopped")
                 break
 
     async def publish_connection_error(self, event):
@@ -602,15 +583,14 @@ class Controller:
                         not destination.state == ConnectionState.FINISHED):
                     packet = message.pack()
                     destination.send(packet)
-                    self.log.debug('Connection %s: OUT OFP, '
-                                   'version: %s, type: %s, xid: %s - %s',
-                                   destination.id,
-                                   message.header.version,
-                                   message.header.message_type,
-                                   message.header.xid,
-                                   packet.hex())
+                    # self.log.debug('Connection %s: OUT OFP, '
+                    #                'version: %s, type: %s, xid: %s - %s',
+                    #                destination.id,
+                    #                message.header.version,
+                    #                message.header.message_type,
+                    #                message.header.xid,
+                    #                packet.hex())
                     self.notify_listeners(triggered_event)
-                    self.log.debug("Message Out Event handler called")
                     continue
 
             except (OSError, SocketError):
@@ -618,22 +598,6 @@ class Controller:
 
             await self.publish_connection_error(triggered_event)
             self.log.info("connection closed. Cannot send message")
-
-    async def app_event_handler(self):
-        """Handle app events.
-
-        Listen to the app buffer and send all its events to the
-        corresponding listeners.
-        """
-        self.log.info("App Event Handler started")
-        while True:
-            event = await self.buffers.app.aget()
-            self.notify_listeners(event)
-            self.log.debug("App Event handler called")
-
-            if event.name == "kytos/core.shutdown":
-                self.log.debug("App Event handler stopped")
-                break
 
     def get_interface_by_id(self, interface_id):
         """Find a Interface  with interface_id.

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -210,7 +210,7 @@ def alisten_to(event, *events):
         """
         # pylint: disable=unused-argument
         async def handler_context(*args, **kwargs):
-            """Handler's context for ThreadPool."""
+            """Async handler's execution context."""
             cls, kytos_event = args[0], args[1]
             try:
                 result = await handler(*args)
@@ -224,7 +224,7 @@ def alisten_to(event, *events):
             return result
 
         async def handler_context_apm(*args, apm_client=None):
-            """Handler's context for ThreadPool APM instrumentation."""
+            """Async handler's execution context with APM instrumentation."""
             cls, kytos_event = args[0], args[1]
             trace_parent = kytos_event.trace_parent
             tx_type = "kytos_event"

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -208,7 +208,7 @@ def alisten_to(event, *events):
             A method with an `events` attribute (list of events to be listened)
             and also decorated as an asyncio task.
         """
-        # pylint: disable=unused-argument
+        # pylint: disable=unused-argument,broad-except
         async def handler_context(*args, **kwargs):
             """Async handler's execution context."""
             cls, kytos_event = args[0], args[1]

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -197,6 +197,74 @@ def listen_to(event, *events, pool=None):
     return thread_decorator
 
 
+def alisten_to(event, *events):
+    """Decorate async subscribing methods."""
+
+    def decorator(handler):
+        """Decorate the handler method.
+
+        Returns:
+            A method with an `events` attribute (list of events to be listened)
+            and also decorated as an asyncio task.
+        """
+        # pylint: disable=unused-argument
+        async def handler_context(*args, **kwargs):
+            """Handler's context for ThreadPool."""
+            cls, kytos_event = args[0], args[1]
+            try:
+                result = await handler(*args)
+            except Exception as exc:
+                result = None
+                exc_str = f"{type(exc)}: {str(exc)}"
+                LOG.error(f"alisten_to handler: {handler}, "
+                          f"args: {args}, exception: {exc_str}")
+                if hasattr(cls, "controller"):
+                    cls.controller.dead_letter.add_event(kytos_event)
+            return result
+
+        async def handler_context_apm(*args, apm_client=None):
+            """Handler's context for ThreadPool APM instrumentation."""
+            cls, kytos_event = args[0], args[1]
+            trace_parent = kytos_event.trace_parent
+            tx_type = "kytos_event"
+            tx = apm_client.begin_transaction(transaction_type=tx_type,
+                                              trace_parent=trace_parent)
+            kytos_event.trace_parent = tx.trace_parent
+            tx.name = f"{kytos_event.name}@{cls.napp_id}"
+            try:
+                result = await handler(*args)
+                tx.result = result
+            except Exception as exc:
+                result = None
+                exc_str = f"{type(exc)}: {str(exc)}"
+                LOG.error(f"alisten_to handler: {handler}, "
+                          f"args: {args}, exception: {exc_str}")
+                if hasattr(cls, "controller"):
+                    cls.controller.dead_letter.add_event(kytos_event)
+                apm_client.capture_exception(
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                    context={"args": args},
+                    handled=False,
+                )
+            tx.end()
+            apm_client.tracer.queue_func("transaction", tx.to_dict())
+            return result
+
+        handler_func, kwargs = handler_context, {}
+        if get_apm_name() == "es":
+            handler_func = handler_context_apm
+            kwargs = dict(apm_client=ElasticAPM.get_client())
+
+        async def inner(*args):
+            """Inner decorated with events attribute."""
+            return await handler_func(*args, **kwargs)
+        inner.events = [event]
+        inner.events.extend(events)
+        return inner
+
+    return decorator
+
+
 def now(tzone=timezone.utc):
     """Return the current datetime (default to UTC).
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,4 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
 -e git+https://github.com/kytos-ng/sphinx-theme.git#egg=kytos-sphinx-theme
 -e .[dev]
+pytest-asyncio==0.18.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -219,7 +219,10 @@ pyparsing==2.4.6
 pytest==7.0.0
     # via
     #   kytos
+    #   pytest-asyncio
     #   pytest-cov
+pytest-asyncio==0.18.3
+    # via -r requirements/dev.in
 pytest-cov==3.0.0
     # via kytos
 python-daemon==2.2.4

--- a/tests/unit/test_core/test_atcp_server.py
+++ b/tests/unit/test_core/test_atcp_server.py
@@ -110,4 +110,4 @@ class TestKytosServerProtocol:
         expected_name = 'kytos/core.protocol.connection.lost'
         mock_kytos_event.assert_called_with(content=expected_content,
                                             name=expected_name)
-        buffers.app.aput.assert_called_with(mock_kytos_event.return_value)
+        buffers.conn.aput.assert_called_with(mock_kytos_event.return_value)

--- a/tests/unit/test_core/test_buffers.py
+++ b/tests/unit/test_core/test_buffers.py
@@ -1,10 +1,26 @@
 """Test kytos.core.buffers module."""
 import asyncio
+import pytest
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from kytos.core.buffers import KytosBuffers, KytosEventBuffer
 from kytos.core.events import KytosEvent
+
+
+@pytest.mark.parametrize("queue_name", ["msg_out", "msg_in"])
+def test_priority_queues(queue_name):
+    """Test KytosBuffers priority queues."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    buffers = KytosBuffers(loop=loop)
+
+    prios = [-10, 10, 0, -20]
+    for prio in prios:
+        queue = getattr(buffers, queue_name)
+        queue.put(KytosEvent(priority=prio))
+    for prio in sorted(prios):
+        assert queue.get().priority == prio
 
 
 # pylint: disable=protected-access
@@ -118,14 +134,6 @@ class TestKytosBuffers(TestCase):
         asyncio.set_event_loop(None)
 
         self.kytos_buffers = KytosBuffers(loop=self.loop)
-
-    def test_msg_out_queue_prio(self):
-        """Test msg_out queue priorities."""
-        prios = [-10, 10, 0, -20]
-        for prio in prios:
-            self.kytos_buffers.msg_out.put(KytosEvent(priority=prio))
-        for prio in sorted(prios):
-            assert self.kytos_buffers.msg_out.get().priority == prio
 
     def test_send_stop_signal(self):
         """Test send_stop_signal method."""

--- a/tests/unit/test_core/test_buffers.py
+++ b/tests/unit/test_core/test_buffers.py
@@ -1,8 +1,9 @@
 """Test kytos.core.buffers module."""
 import asyncio
-import pytest
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from kytos.core.buffers import KytosBuffers, KytosEventBuffer
 from kytos.core.events import KytosEvent

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -30,6 +30,7 @@ class TestController(TestCase):
         self.controller = Controller(self.options, loop=self.loop)
         self.controller.napps_manager = self.napps_manager
         self.controller.log = Mock()
+        self.controller.log.getEffectiveLevel.return_value = 20
 
     def test_configuration_endpoint(self):
         """Should return the attribute options as json."""

--- a/tests/unit/test_core/test_helpers.py
+++ b/tests/unit/test_core/test_helpers.py
@@ -2,8 +2,26 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from kytos.core.helpers import (executors, get_thread_pool_max_workers,
-                                get_time, listen_to, run_on_thread)
+from kytos.core.helpers import (alisten_to, executors,
+                                get_thread_pool_max_workers, get_time,
+                                listen_to, run_on_thread)
+
+
+async def test_alisten_to():
+    """Test alisten_to decorator."""
+
+    class SomeClass:
+        """SomeClass."""
+
+        @alisten_to("some_event")
+        async def on_some_event(self, event):
+            """On some event handler."""
+            _ = event
+            return "some_response"
+
+    assert SomeClass.on_some_event.__name__ == "inner"
+    result = await SomeClass().on_some_event(MagicMock())
+    assert result == "some_response"
 
 
 class TestHelpers(TestCase):


### PR DESCRIPTION
Fixes #172 

### Description of the change

This PR added a new `alisten to` decorator and changed `msg_in` to use a PriorityQueue. This PR is making infrastructure changes just so `of_core` (for now) and other NApps can leverage this decorator and use an set `msg_in` message priorities. This PR implements the proposed solution a) that was described on issue 172:

![cores_queues_alisten_to](https://user-images.githubusercontent.com/1010796/174632665-0d7983ed-717c-48b7-a128-b3804b82d083.png)


I've also commented out log statements from hot paths of the code (for more information check out issue #234). I've also had great results but I'll share them when I open a PR on `of_core` as I've been experimenting with this PR, in summary it enhanced the overall 95 percentile twice as faster and asyncio tasks should consume less resources in terms of memory too, and context switching is more efficient and explicit which should also help reduce lock wait times if structured correctly. 

### Release notes

#### Added

- Added ``@alisten_to`` decorator for ``async`` methods. NApps can subscribe to events asynchronously with this decorator as needed.

#### Changed

- ``msg_in`` core queue now leverages a PriorityQueue instead of a FIFO Queue.