### PR TITLE
[Fix] Added coverage an lint on tox envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39
+envlist = py39,coverage,lint
 
 [gh-actions]
 python =
@@ -10,8 +10,13 @@ whitelist_externals=
     rm
     make
 
+deps=
+    -rrequirements/dev.txt
+
+[testenv:coverage]
 commands=
     python3 setup.py coverage {posargs}
 
-deps=
-    -rrequirements/dev.txt
+[testenv:lint]
+commands= 
+    python3 setup.py lint


### PR DESCRIPTION
I've made a mistake when I refactored `tox.ini` on this commit 08ed486ba3b404909e8b17624e565b9c1bd13838, I removed the `CITest` it was running both `coverage && lint`, so this PR fixes that to run lint again when the full `tox` is executed, now it's more flexible too, since you can target each `env` as you wish, same approach that we have on NApps' tox configuration.

For example, if you just want to run `coverage`, and perform a test selection on `controller` related tests:

```
tox -e coverage -- --k 'controller'
```