### PR TITLE
[Feature] `Link` status support for liveness detection through internal reserved metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,7 @@ Changed
 
 - ``msg_out`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
 - ``msg_in`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
+- ``Link.status`` is considered ``EntityStatus.DOWN`` if ``liveness_status`` metadata is set and different than ``up``.
 
 Deprecated
 ==========

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -8,7 +8,7 @@ import hashlib
 import json
 import random
 
-from kytos.core.common import GenericEntity
+from kytos.core.common import EntityStatus, GenericEntity
 from kytos.core.exceptions import (KytosLinkCreationError,
                                    KytosNoTagAvailableError)
 from kytos.core.interface import TAGType
@@ -35,6 +35,18 @@ class Link(GenericEntity):
 
     def __repr__(self):
         return f"Link({self.endpoint_a!r}, {self.endpoint_b!r})"
+
+    @property
+    def status(self):
+        """Return the current status of the Entity."""
+        state = super().status
+        if (
+            state == EntityStatus.UP
+            and "liveness_status" in self.metadata
+            and self.metadata["liveness_status"] != "up"
+        ):
+            return EntityStatus.DOWN
+        return state
 
     def is_enabled(self):
         """Override the is_enabled method.

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -13,7 +13,7 @@ from kytos.core.switch import Switch
 logging.basicConfig(level=logging.CRITICAL)
 
 
-# pylint: disable=protected-access
+# pylint: disable=protected-access,too-many-public-methods
 class TestLink(unittest.TestCase):
     """Test Links."""
 


### PR DESCRIPTION
Augments #241, this PR implements this paragraph of the blueprint:


- When liveness goes down, ``Link.status`` must be ``EntityStatus.DOWN``, that way encapsulating this to keep compatible and minimize changes on existing NApps. No new actions such as shutdown will be needed on this iteration. In order to accomplish this, a link internal metadata ``liveness_status`` will be reserved.

Now that the core encapsulates this reserved internal metadata, `pathfinder` is already aligned with this change since it was relying on `Link.status`, and `mef_eline` will continue to react to `kytos/topology.link_down`, however, the reason in the event will be `liveness`, so `topology` will send the reason accordingly.

### Release notes


- ``Link.status`` is considered ``EntityStatus.DOWN`` if ``liveness_status`` metadata is set and different than ``up``.