### PR TITLE
Cache Link, Interface, and Swtich ID properties with New ID types

### DIFF
--- a/kytos/core/id.py
+++ b/kytos/core/id.py
@@ -1,11 +1,8 @@
-class SwitchID(str):
-    pass
-
 class InterfaceID(str):
     __slots__ = ("switch", "port")
-    def __new__(cls, switch:SwitchID, port:int):
+    def __new__(cls, switch:str, port:int):
         return super().__new__(cls, f"{switch}:{port}")
-    def __init__(self, switch:SwitchID, port:int):
+    def __init__(self, switch:str, port:int):
         #Used for sorting, but can be accessed
         self.switch = switch
         self.port = port

--- a/kytos/core/id.py
+++ b/kytos/core/id.py
@@ -2,8 +2,27 @@ class SwitchID(str):
     pass
 
 class InterfaceID(str):
+    __slots__ = ("switch", "port")
     def __new__(cls, switch:SwitchID, port:int):
         return super().__new__(cls, f"{switch}:{port}")
+    def __init__(self, switch:SwitchID, port:int):
+        #Used for sorting, but can be accessed
+        self.switch = switch
+        self.port = port
+
+    def __lt__(self, other):
+        # Ensures that instances are sortable in a way that maintains backwards
+        # compatibility when creating instances of LinkID
+        dpid_a = self.switch
+        port_a = self.port
+        dpid_b = other.switch
+        port_b = other.port
+        if dpid_a < dpid_b:
+            return True
+        elif dpid_a == dpid_b and port_a < port_b:
+            return True
+        else:
+            return False
 
 class LinkID(str):
     def __new__(cls, interface_1:InterfaceID, interface_2:InterfaceID):

--- a/kytos/core/id.py
+++ b/kytos/core/id.py
@@ -1,3 +1,5 @@
+import hashlib
+
 class InterfaceID(str):
     __slots__ = ("switch", "port")
     def __new__(cls, switch:str, port:int):
@@ -23,4 +25,4 @@ class InterfaceID(str):
 
 class LinkID(str):
     def __new__(cls, interface_1:InterfaceID, interface_2:InterfaceID):
-        return super().__new__(cls, ":".join(sorted((interface_1, interface_2))))
+        return super().__new__(cls, hashlib.sha256(":".join(sorted((interface_1, interface_2))).encode('utf-8')).hexdigest())

--- a/kytos/core/id.py
+++ b/kytos/core/id.py
@@ -1,13 +1,21 @@
+"""Module with identifier types for Links and Interfaces"""
+
 import hashlib
 
+
 class InterfaceID(str):
+    """Interface Identifier"""
+
     __slots__ = ("switch", "port")
-    def __new__(cls, switch:str, port:int):
+
+    def __new__(cls, switch: str, port: int):
         return super().__new__(cls, f"{switch}:{port}")
-    def __init__(self, switch:str, port:int):
-        #Used for sorting, but can be accessed
+
+    def __init__(self, switch: str, port: int):
+        # Used for sorting, but can be accessed
         self.switch = switch
         self.port = port
+        super().__init__()
 
     def __lt__(self, other):
         # Ensures that instances are sortable in a way that maintains backwards
@@ -18,11 +26,13 @@ class InterfaceID(str):
         port_b = other.port
         if dpid_a < dpid_b:
             return True
-        elif dpid_a == dpid_b and port_a < port_b:
-            return True
-        else:
-            return False
+        return dpid_a == dpid_b and port_a < port_b
+
 
 class LinkID(str):
-    def __new__(cls, interface_1:InterfaceID, interface_2:InterfaceID):
-        return super().__new__(cls, hashlib.sha256(":".join(sorted((interface_1, interface_2))).encode('utf-8')).hexdigest())
+    """Link Identifier"""
+
+    def __new__(cls, interface_1: InterfaceID, interface_2: InterfaceID):
+        raw_str = ":".join(sorted((interface_1, interface_2)))
+        digest = hashlib.sha256(raw_str.encode('utf-8')).hexdigest()
+        return super().__new__(cls, digest)

--- a/kytos/core/id.py
+++ b/kytos/core/id.py
@@ -1,0 +1,10 @@
+class SwitchID(str):
+    pass
+
+class InterfaceID(str):
+    def __new__(cls, switch:SwitchID, port:int):
+        return super().__new__(cls, f"{switch}:{port}")
+
+class LinkID(str):
+    def __new__(cls, interface_1:InterfaceID, interface_2:InterfaceID):
+        return super().__new__(cls, ":".join(sorted((interface_1, interface_2))))

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -3,6 +3,7 @@ import json
 import logging
 from enum import IntEnum
 from threading import Lock
+from kytos.core.id import InterfaceID
 
 from pyof.v0x01.common.phy_port import Port as PortNo01
 from pyof.v0x01.common.phy_port import PortFeatures as PortFeatures01
@@ -97,6 +98,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         self.stats = None
         self.link = None
         self.lldp = True
+        self._id = InterfaceID(switch.id, port_number)
         self._custom_speed = speed
         self._tag_lock = Lock()
         self.set_available_tags(range(1, 4096))
@@ -123,7 +125,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             string: Interface id.
 
         """
-        return "{}:{}".format(self.switch.dpid, self.port_number)
+        return self._id
 
     @property
     def uni(self):

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -3,7 +3,6 @@ import json
 import logging
 from enum import IntEnum
 from threading import Lock
-from kytos.core.id import InterfaceID
 
 from pyof.v0x01.common.phy_port import Port as PortNo01
 from pyof.v0x01.common.phy_port import PortFeatures as PortFeatures01
@@ -12,6 +11,7 @@ from pyof.v0x04.common.port import PortNo as PortNo04
 
 from kytos.core.common import GenericEntity
 from kytos.core.helpers import now
+from kytos.core.id import InterfaceID
 
 __all__ = ('Interface',)
 

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -4,7 +4,6 @@ Links are low level abstractions representing connections between two
 interfaces.
 """
 
-import hashlib
 import json
 import random
 

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -11,6 +11,7 @@ import random
 from kytos.core.common import GenericEntity
 from kytos.core.exceptions import (KytosLinkCreationError,
                                    KytosNoTagAvailableError)
+from kytos.core.id import LinkID
 from kytos.core.interface import TAGType
 
 
@@ -28,6 +29,7 @@ class Link(GenericEntity):
             raise KytosLinkCreationError("endpoint_b cannot be None")
         self.endpoint_a = endpoint_a
         self.endpoint_b = endpoint_b
+        self._id = LinkID(endpoint_a.id, endpoint_b.id)
         super().__init__()
 
     def __hash__(self):
@@ -72,21 +74,7 @@ class Link(GenericEntity):
             string: link id.
 
         """
-        dpid_a = self.endpoint_a.switch.dpid
-        port_a = self.endpoint_a.port_number
-        dpid_b = self.endpoint_b.switch.dpid
-        port_b = self.endpoint_b.port_number
-        if dpid_a < dpid_b:
-            elements = (dpid_a, port_a, dpid_b, port_b)
-        elif dpid_a > dpid_b:
-            elements = (dpid_b, port_b, dpid_a, port_a)
-        elif port_a < port_b:
-            elements = (dpid_a, port_a, dpid_b, port_b)
-        else:
-            elements = (dpid_b, port_b, dpid_a, port_a)
-
-        str_id = "%s:%s:%s:%s" % elements
-        return hashlib.sha256(str_id.encode('utf-8')).hexdigest()
+        return self._id
 
     @property
     def available_tags(self):

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -6,7 +6,6 @@ from threading import Lock
 from kytos.core.common import GenericEntity
 from kytos.core.constants import CONNECTION_TIMEOUT, FLOOD_TIMEOUT
 from kytos.core.helpers import get_time, now
-from kytos.core.id import SwitchID
 from kytos.core.interface import Interface
 
 __all__ = ('Switch',)
@@ -81,7 +80,7 @@ class Switch(GenericEntity):
         self.interfaces = {}
         self.flows = []
         self.description = {}
-        self._id = SwitchID(dpid)
+        self._id = dpid
         self._interface_lock = Lock()
 
         if connection:

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -6,6 +6,7 @@ from threading import Lock
 from kytos.core.common import GenericEntity
 from kytos.core.constants import CONNECTION_TIMEOUT, FLOOD_TIMEOUT
 from kytos.core.helpers import get_time, now
+from kytos.core.id import SwitchID
 from kytos.core.interface import Interface
 
 __all__ = ('Switch',)
@@ -80,6 +81,7 @@ class Switch(GenericEntity):
         self.interfaces = {}
         self.flows = []
         self.description = {}
+        self._id = SwitchID(dpid)
         self._interface_lock = Lock()
 
         if connection:
@@ -111,7 +113,7 @@ class Switch(GenericEntity):
             string: the switch id is the data_path_id from switch.
 
         """
-        return "{}".format(self.dpid)
+        return self._id
 
     @property
     def ofp_version(self):

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -288,7 +288,7 @@ class TestUNI(unittest.TestCase):
     def setUp(self):
         """Create UNI object."""
         switch = MagicMock()
-        switch.dpid = '00:00:00:00:00:00:00:01'
+        switch.id = '00:00:00:00:00:00:00:01'
         interface = Interface('name', 1, switch)
         user_tag = TAG(1, 123)
         self.uni = UNI(interface, user_tag)

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -18,32 +18,27 @@ class TestLink(unittest.TestCase):
 
     def setUp(self):
         """Create interface objects."""
-        self.iface1, self.iface2 = self._get_v0x04_ifaces()
+        self.switch1 = self._get_v0x04_switch('dpid1')
+        self.iface1 = Interface('interface1', 41, self.switch1)
+        self.switch2 = self._get_v0x04_switch('dpid2')
+        self.iface2 = Interface('interface2', 42, self.switch2)
 
     @staticmethod
-    def _get_v0x04_ifaces(*args, **kwargs):
-        """Create a pair of v0x04 interfaces with optional extra arguments."""
-        switch1 = Switch('dpid1')
-        switch1.connection = Mock()
-        switch1.connection.protocol.version = 0x04
-        iface1 = Interface('interface1', 41, switch1, *args, **kwargs)
-
-        switch2 = Switch('dpid2')
-        switch2.connection = Mock()
-        switch2.connection.protocol.version = 0x04
-        iface2 = Interface('interface2', 42, switch2, *args, **kwargs)
-
-        return iface1, iface2
+    def _get_v0x04_switch(name:str):
+        switch = Switch(name)
+        switch.connection = Mock()
+        switch.connection.protocol.version = 0x04
+        return switch
 
     def test__eq__(self):
         """Test __eq__ method."""
         link_1 = Link(self.iface1, self.iface2)
         link_2 = Link(self.iface2, self.iface1)
 
-        iface1, iface2 = self._get_v0x04_ifaces()
-        iface1.port_number = 1
-        iface2.port_number = 2
-        link_3 = Link(iface1, iface2)
+        iface3 = Interface('interface1', 1, self.switch1)
+        iface4 = Interface('interface2', 2, self.switch2)
+
+        link_3 = Link(iface3, iface4)
 
         self.assertTrue(link_1.__eq__(link_2))
         self.assertFalse(link_1.__eq__(link_3))
@@ -57,15 +52,13 @@ class TestLink(unittest.TestCase):
 
     def test_id(self):
         """Test id property."""
-        link = Link(self.iface1, self.iface2)
         ids = []
 
-        for value in [('A', 1, 'B', 2), ('B', 2, 'A', 1), ('A', 1, 'A', 2),
-                      ('A', 2, 'A', 1)]:
-            link.endpoint_a.switch.dpid = value[0]
-            link.endpoint_a.port_number = value[1]
-            link.endpoint_b.switch.dpid = value[2]
-            link.endpoint_b.port_number = value[3]
+        for value in [(self.switch1, 1, self.switch2, 2), (self.switch2, 2, self.switch1, 1), (self.switch1, 1, self.switch1, 2),
+                      (self.switch1, 2, self.switch1, 1)]:
+            iface1 = Interface('iface', value[1], value[0])
+            iface2 = Interface('iface', value[3], value[2])
+            link = Link(iface1, iface2)
 
             ids.append(link.id)
 

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -24,7 +24,8 @@ class TestLink(unittest.TestCase):
         self.iface2 = Interface('interface2', 42, self.switch2)
 
     @staticmethod
-    def _get_v0x04_switch(name:str):
+    def _get_v0x04_switch(name: str):
+        """Create a v0x04 Switch"""
         switch = Switch(name)
         switch.connection = Mock()
         switch.connection.protocol.version = 0x04
@@ -54,7 +55,9 @@ class TestLink(unittest.TestCase):
         """Test id property."""
         ids = []
 
-        for value in [(self.switch1, 1, self.switch2, 2), (self.switch2, 2, self.switch1, 1), (self.switch1, 1, self.switch1, 2),
+        for value in [(self.switch1, 1, self.switch2, 2),
+                      (self.switch2, 2, self.switch1, 1),
+                      (self.switch1, 1, self.switch1, 2),
                       (self.switch1, 2, self.switch1, 1)]:
             iface1 = Interface('iface', value[1], value[0])
             iface2 = Interface('iface', value[3], value[2])


### PR DESCRIPTION
This resolves issues #228 by caching the ID property of Switches, Interfaces, and Links. This removes the need to instantiate new strings every time an existing time the ID property is accessed. In addition, the creation of the these IDs has been encapsulated in a set of classes:  `LinkID`, `InterfaceID`, and `SwitchID`. These classes subclass the python `str` class, so as to maintain backwards compatibility with most napps.

# Notes

With the current implementation of the ID property, napps are instantiating `Link` objects in order to accesss its ID property to use for lookups such as in [topology](https://github.com/kytos-ng/topology/blob/cd4cbdfd22551f77e79f5bc29f42a48f2f1145d2/main.py#L82-L95). ID types offer a lighterweight alternative to this practice, and potentially can resolve performance [issues](https://github.com/kytos-ng/topology/issues/94).