### PR TITLE
alisten_to unhandled exceptions log error includes the traceback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,8 +32,8 @@ Added
 - Augmented docker-compose to also spin up Filebeat, integrating log file as input
 - The ``listen_to`` decorator now supports a ``pool`` keyword argument to specify which thread pool the execution should be submitted
 - New core ``kytos.core.retry`` module provides decorators for retries based on ``tenacity``
-- Unhandled exceptions on ``@listen_to`` decorator now also include a traceback
 - Added ``@alisten_to`` decorator for ``async`` methods. NApps can subscribe to events asynchronously with this decorator as needed.
+- Unhandled exceptions on ``@listen_to`` and ``@alisten_to`` decorators now also include a traceback
 
 Changed
 =======

--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -214,11 +214,11 @@ def alisten_to(event, *events):
             cls, kytos_event = args[0], args[1]
             try:
                 result = await handler(*args)
-            except Exception as exc:
+            except Exception:
                 result = None
-                exc_str = f"{type(exc)}: {str(exc)}"
+                traceback_str = traceback.format_exc().replace("\n", ", ")
                 LOG.error(f"alisten_to handler: {handler}, "
-                          f"args: {args}, exception: {exc_str}")
+                          f"args: {args} traceback: {traceback_str}")
                 if hasattr(cls, "controller"):
                     cls.controller.dead_letter.add_event(kytos_event)
             return result
@@ -237,9 +237,9 @@ def alisten_to(event, *events):
                 tx.result = result
             except Exception as exc:
                 result = None
-                exc_str = f"{type(exc)}: {str(exc)}"
+                traceback_str = traceback.format_exc().replace("\n", ", ")
                 LOG.error(f"alisten_to handler: {handler}, "
-                          f"args: {args}, exception: {exc_str}")
+                          f"args: {args} traceback: {traceback_str}")
                 if hasattr(cls, "controller"):
                     cls.controller.dead_letter.add_event(kytos_event)
                 apm_client.capture_exception(


### PR DESCRIPTION
Same as PR #232 but for `alisten_to` now. 

## Examples

- Before:

```
2022-07-18 11:02:37,483 - ERROR [kytos.core.helpers] (MainThread) alisten_to handler: <function Main.on_raw_in at 0x7f586c54f430>, args: (<Main(of_core, started 140017276024384)>, KytosEvent('kytos/core.openflow.raw.in', {'source': Connection('127.0.0.1', 40296, <asyncio.TransportSocket fd=114, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 40296)>, None, <ConnectionState.NEW: 0>), 'new_data': b'\x04\x00\x00\x10\x00\x00\x00\x04\x00\x01\x00\x08\x00\x00\x00\x10'}, 0)), exception: <class'AttributeError'>: 'Connection' object has no attribute 'switchx'
```

- After:

```
2022-07-18 11:05:33,930 - ERROR [kytos.core.helpers] (MainThread) alisten_to handler: <function Main.on_raw_in at 0x7f0ca028b430>, args: (<Main(of_core, started 139691311486528)>, KytosEvent('kytos/core.openflow.raw.in', {'source': Connection('127.0.0.1', 40432, <asyncio.TransportSocket fd=83, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 40432)>, None, <ConnectionState.NEW: 0>), 'new_data': b'\x04\x00\x00\x10\x00\x00\x00\n\x00\x01\x00\x08\x00\x00\x00\x10'}, 0)) traceback: Traceback (most recent call last):,   File "/home/viniarck/repos/kytos/kytos/core/helpers.py", line 236, in handler_context_apm,     result = await handler(*args),   File "/home/viniarck/repos/napps/napps/kytos/of_core/main.py", line 286, in on_raw_in,     switch = event.source.switchx, AttributeError: 'Connection' object has no attribute 'switchx',
```