### PR TITLE
Modified how logger is provided to napps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,7 @@ Changed
 
 - ``msg_out`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
 - ``msg_in`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
+- ``kytos.core.log`` now directly provides the appropriate logger to the NAPP, rather than a facade
 
 Deprecated
 ==========

--- a/kytos/core/__init__.py
+++ b/kytos/core/__init__.py
@@ -1,8 +1,10 @@
 """Kytos.core is the module with main classes used in Kytos."""
+import sys
+
 from kytos.core.auth import authenticated
 from kytos.core.controller import Controller
 from kytos.core.events import KytosEvent
-from kytos.core.logs import NAppLog
+from kytos.core.logs import get_napp_logger
 from kytos.core.napps import KytosNApp, rest
 
 from .metadata import __version__
@@ -18,4 +20,5 @@ __all__ = (
 )
 
 # Kept lowercase to be more user friendly.
-log = NAppLog()  # pylint: disable=invalid-name
+log = property(lambda self: self.get_napp_logger()) \
+              .__get__(sys.modules[__name__])

--- a/kytos/core/__init__.py
+++ b/kytos/core/__init__.py
@@ -19,6 +19,26 @@ __all__ = (
     "__version__",
 )
 
-# Kept lowercase to be more user friendly.
-log = property(lambda self: self.get_napp_logger()) \
-              .__get__(sys.modules[__name__])
+
+def extend_descriptors(inst, **kwargs):
+    """Creates wrapper of instance with descriptors"""
+
+    class MFacade:
+        """Wrapper class for provided instance"""
+
+        def __getattr__(self, name):
+            return getattr(inst, name)
+
+    for (key, value) in kwargs.items():
+        setattr(MFacade, key, value)
+    return MFacade()
+
+
+@property
+def log(self):
+    """Get appropriate napp logger at module import time,
+    rather than module initialization time"""
+    return self.get_napp_logger()
+
+
+sys.modules[__name__] = extend_descriptors(sys.modules[__name__], log=log)

--- a/kytos/core/logs.py
+++ b/kytos/core/logs.py
@@ -141,14 +141,18 @@ class NAppLog:
 
     def __getattribute__(self, name):
         """Detect NApp ID and use its logger."""
-        napp_id = _detect_napp_id()
-        logger = getLogger("kytos.napps")
+        return get_napp_logger().__getattribute__(name)
 
-        # if napp_id is detected, get the napp logger.
-        if napp_id:
-            logger = logger.getChild(napp_id)
+def get_napp_logger():
+    """Detect NApp ID and get its logger."""
+    napp_id = _detect_napp_id()
+    logger = getLogger("kytos.napps")
 
-        return logger.__getattribute__(name)
+    # if napp_id is detected, get the napp logger.
+    if napp_id:
+        logger = logger.getChild(napp_id)
+
+    return logger
 
 
 #: Detect NApp ID from filename

--- a/kytos/core/logs.py
+++ b/kytos/core/logs.py
@@ -143,6 +143,7 @@ class NAppLog:
         """Detect NApp ID and use its logger."""
         return get_napp_logger().__getattribute__(name)
 
+
 def get_napp_logger():
     """Detect NApp ID and get its logger."""
     napp_id = _detect_napp_id()


### PR DESCRIPTION
This resolves issue #236, by making it so that importing the logger provided through `kytos.core.log` is the appropriate child logger for the given napp. Rather than providing a singleton facade which negotiates the appropriate logger at run time, the new implementation will retrieve the appropriate module at import through the use of a property decorated function.

# Notes

It should be noted that this process is not guaranteed to result in the same behaviour as before. I have yet to see an occasion where a log entry seems to come from the incorrect logger, but it may be a possibility.