### PR TITLE
[Feature] Composable `GenericEntity` status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Added
 - New core ``kytos.core.retry`` module provides decorators for retries based on ``tenacity``
 - Added ``@alisten_to`` decorator for ``async`` methods. NApps can subscribe to events asynchronously with this decorator as needed.
 - Unhandled exceptions on ``@listen_to`` and ``@alisten_to`` decorators now also include a traceback
+- Added ``status_funcs`` on ``GenericEntity`` to allow NApps to register functions to compose ``status``.
 
 Changed
 =======

--- a/kytos/core/common.py
+++ b/kytos/core/common.py
@@ -1,4 +1,5 @@
 """Module with common classes for the controller."""
+from collections import OrderedDict
 from enum import Enum
 
 from kytos.core.config import KytosConfig
@@ -16,6 +17,8 @@ class EntityStatus(Enum):
 
 class GenericEntity:
     """Generic class that represents any Entity."""
+
+    status_funcs = OrderedDict()
 
     def __init__(self):
         """Create the GenericEntity object with empty metadata dictionary."""
@@ -40,6 +43,11 @@ class GenericEntity:
     def deactivate(self):
         """Deactivate the entity."""
         self._active = False
+
+    @classmethod
+    def register_status_func(cls, name: str, func):
+        """Register status func given its name and a callable at setup time."""
+        cls.status_funcs[name] = func
 
     @property
     def status(self):

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -7,7 +7,7 @@ interfaces.
 import json
 import random
 
-from kytos.core.common import GenericEntity
+from kytos.core.common import EntityStatus, GenericEntity
 from kytos.core.exceptions import (KytosLinkCreationError,
                                    KytosNoTagAvailableError)
 from kytos.core.id import LinkID
@@ -36,6 +36,18 @@ class Link(GenericEntity):
 
     def __repr__(self):
         return f"Link({self.endpoint_a!r}, {self.endpoint_b!r})"
+
+    @property
+    def status(self):
+        """Return the current status of the Entity."""
+        state = super().status
+        if state == EntityStatus.DISABLED:
+            return state
+
+        for status_func in self.status_funcs.values():
+            if status_func(self) == EntityStatus.DOWN:
+                return EntityStatus.DOWN
+        return state
 
     def is_enabled(self):
         """Override the is_enabled method.


### PR DESCRIPTION
Augments https://github.com/kytos-ng/kytos/pull/241. This supersedes PR #242, with this PR NApps will be able to register a callable that takes a `GenericEntity`, computes some business logic, and then it could decide to either return `EntityStatus.DOWN` or `None`. It should return `EntityStatus.DOWN` whenever its logic detects the protocol is down, that way whenever a protocol-related feature detects it's supposed to be `EntityStatus.DOWN` then other parts of the code can rely on checking the `status` property encapsulating the resulting status.

NApps that can influence status `EntityStatus.DOWN` should be responsible to have their internal states and eventually when it's not `EntityStatus.DOWN` anymore, then it's just a matter of returning `None`, typically, internal metadata will be reserved for this like `liveness_status`, (maintenance) and so on in the future. For more information check out this thread https://github.com/kytos-ng/kytos/pull/241#discussion_r922375008

#### Changelog

- Added ``status_funcs`` on ``GenericEntity`` to allow NApps to register functions to compose ``status``.



 