### PR TITLE
Implemented __getnewargs__ for both InterfaceID and LinkID

### DIFF
--- a/kytos/core/id.py
+++ b/kytos/core/id.py
@@ -28,11 +28,23 @@ class InterfaceID(str):
             return True
         return dpid_a == dpid_b and port_a < port_b
 
+    def __getnewargs__(self):
+        """To make sure it's pickleable"""
+        return (self.switch, self.port)
+
 
 class LinkID(str):
     """Link Identifier"""
 
-    def __new__(cls, interface_1: InterfaceID, interface_2: InterfaceID):
-        raw_str = ":".join(sorted((interface_1, interface_2)))
+    def __new__(cls, interface_a: InterfaceID, interface_b: InterfaceID):
+        raw_str = ":".join(sorted((interface_a, interface_b)))
         digest = hashlib.sha256(raw_str.encode('utf-8')).hexdigest()
         return super().__new__(cls, digest)
+
+    def __init__(self, interface_a: InterfaceID, interface_b: InterfaceID):
+        self.interfaces = (interface_a, interface_b)
+        super().__init__()
+
+    def __getnewargs__(self):
+        """To make sure it's pickleable"""
+        return self.interfaces

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -1,5 +1,6 @@
 """Interface tests."""
 import logging
+import pickle
 import unittest
 from unittest.mock import MagicMock, Mock
 
@@ -280,6 +281,15 @@ class TestInterface(unittest.TestCase):
 
         self.assertEqual(self.iface.link, link)
         self.assertEqual(interface.link, link)
+
+    @staticmethod
+    def test_pickleable_id() -> None:
+        """Test to make sure the id is pickleable."""
+        switch = Switch("dpid1")
+        interface = Interface("s1-eth1", 1, switch)
+        pickled = pickle.dumps(interface.as_dict())
+        intf_dict = pickle.loads(pickled)
+        assert intf_dict["id"] == interface.id
 
 
 class TestUNI(unittest.TestCase):


### PR DESCRIPTION
Fixes #251

I indeed up implementing the first solution mentioned in the issue #251:

- Probably the safest and the one with least refactoring would be to cast again the type as a `str` and then the new introduced types InterfaceID and LinkID are used only internally when building the formatted `str`. As we deprecate storehouse completely and if there's any other benefit to avoid this cast then we can explore other ideas. @Ktmi let me know if you have any suggestion or other ideas. 

I also tried to maintain as they are,and only performing a cast to `str` on `as_dict` or when `id` was used but there were additional references that kept showing up, it was difficult to ensure correctness, and then we'd have to keep converting to `str` in multiple places, which would defeat the purpose of the cached pre-computed `id` 
