### PR TITLE
[Feature] Flask custom datetime encoder

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,7 @@ Changed
 - ``msg_out`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
 - ``msg_in`` core queue now leverages a PriorityQueue instead of a FIFO Queue.
 - ``kytos.core.log`` now directly provides the appropriate logger to the NAPP, rather than a facade
+- Flask will encode datetime objects format as ``%Y-%m-%dT%H:%M:%S`` str
 
 Deprecated
 ==========

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -13,12 +13,23 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlopen, urlretrieve
 
 from flask import Blueprint, Flask, jsonify, request, send_file
+from flask.json import JSONEncoder
 from flask_cors import CORS
 from flask_socketio import SocketIO, join_room, leave_room
 from werkzeug.exceptions import HTTPException
 
 from kytos.core.auth import authenticated
 from kytos.core.config import KytosConfig
+
+
+# pylint: disable=method-hidden,arguments-differ
+class CustomJSONEncoder(JSONEncoder):
+    """CustomJSONEncoder."""
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.strftime("%Y-%m-%dT%H:%M:%S")
+        return JSONEncoder.default(self, obj)
 
 
 class APIServer:
@@ -54,6 +65,7 @@ class APIServer:
 
         self.app = Flask(app_name, root_path=self.flask_dir,
                          static_folder="dist", static_url_path="/dist")
+        self.app.json_encoder = CustomJSONEncoder
         self.server = SocketIO(self.app, async_mode='threading')
         self._enable_websocket_rooms()
         # ENABLE CROSS ORIGIN RESOURCE SHARING

--- a/tests/unit/test_core/test_api_server.py
+++ b/tests/unit/test_core/test_api_server.py
@@ -2,16 +2,24 @@
 import json
 import unittest
 import warnings
+from datetime import datetime
 # Disable not-grouped imports that conflicts with isort
 from unittest.mock import (MagicMock, Mock, patch,  # pylint: disable=C0412
                            sentinel)
 from urllib.error import HTTPError
 
-from kytos.core.api_server import APIServer
+from kytos.core.api_server import APIServer, CustomJSONEncoder
 from kytos.core.napps import rest
 
 KYTOS_CORE_API = "http://127.0.0.1:8181/api/kytos/"
 API_URI = KYTOS_CORE_API+"core"
+
+
+def test_custom_encoder() -> None:
+    """Test CustomJSONEncoder."""
+    encoder = CustomJSONEncoder()
+    some_datetime = datetime(year=2022, month=1, day=30)
+    assert encoder.default(some_datetime) == "2022-01-30T00:00:00"
 
 
 # pylint: disable=protected-access, too-many-public-methods


### PR DESCRIPTION
Fixes #244 

#### Changelog

Flask will encode datetime objects format as ``%Y-%m-%dT%H:%M:%S`` str

- Before:

```
{
    "interfaces": [
        {
            "id": "00:00:00:00:00:00:00:02:3",
            "last_hello_at": "Fri, 22 Jul 2022 21:53:38 GMT",
            "status": "up"
        },
        {
            "id": "00:00:00:00:00:00:00:03:2",
            "last_hello_at": "Fri, 22 Jul 2022 21:53:38 GMT",
            "status": "up"
        }
    ]
}
```

- After:
```
{
    "interfaces": [
        {
            "id": "00:00:00:00:00:00:00:03:2",
            "last_hello_at": "2022-07-22T21:52:47",
            "status": "up"
        },
        {
            "id": "00:00:00:00:00:00:00:02:3",
            "last_hello_at": "2022-07-22T21:52:47",
            "status": "up"
        }
    ]
}
```