### PR TITLE
Moved env vars doc to README instead of kytos.conf.template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,8 @@ If you're developing locally and using the core MongoDB integration, you can use
    $ export MONGO_USERNAME=mymongouser
    $ export MONGO_PASSWORD=mymongopass
 
+Optionally, you can also set these environment variables: ``MONGO_HOST_SEEDS``, ``MONGO_DBNAME``, ``MONGO_MAX_POOLSIZE``, ``MONGO_MIN_POOLSIZE``, ``MONGO_TIMEOUTMS``.
+
 .. code-block:: shell
 
    $ docker-compose up -d
@@ -132,6 +134,7 @@ How to use with Elastic APM
 
    $ docker-compose up -d
 
+Optionally, you can also set the following environment variables:  ``ELASTIC_APM_URL``, ``ELASTIC_APM_SERVICE_NAME``, ``ELASTIC_APM_SECRET_TOKEN``.
 
 In order to enable the Elastic APM agent, you have to pass the ``--apm es`` option to ``kytosd``, for instance:
 

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -82,23 +82,9 @@ token_expiration_minutes = 180
 
 # NApps database. Supported values: mongodb (don't use quotes in the string)
 database =
-# The following environment variables should be accordingly if you're using mongodb:
-# MONGO_HOST_SEEDS=mongo1:27017,mongo2:27018,mongo3:27019
-# MONGO_USERNAME=
-# MONGO_PASSWORD=
-# Optionally, these environment variables can also be set:
-# MONGO_DBNAME=napps
-# MONGO_MAX_POOLSIZE=300
-# MONGO_MIN_POOLSIZE=30
-# MONGO_TIMEOUTMS=30000
 
 # APM backend. Supported values: es (elasticsearch, don't use quotes in the string)
 apm =
-# The following environment variables should be accordingly if you're using elasticsearch:
-# ELASTIC_APM_URL=http://localhost:8200
-# Optionally, these environment variables can also be set:
-# ELASTIC_APM_SERVICE_NAME=kytos
-# ELASTIC_APM_SECRET_TOKEN=
 
 # Define URLs that will require authentication
 #


### PR DESCRIPTION
Fixes #217 

I've moved the env vars doc to README instead of kytos.conf.template, this is to avoid confusion. In the future, as we make more progress in docs in general, I think we can move this to another page if folks need more specific information. 

cc'ing @italovalcy 