### PR TITLE
[Fix] Unload napps in reverse order to facilitate graceful shutdown

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changed
 - Upstream core dependencies have been upgraded: ``ipython==8.1.1, flask-socketio==5.2.0, flask_cors==3.0.10, flask[async]==2.1.3, janus==1.0.0, jinja2==3.1.2, watchdog==2.1.9, pyjwt==2.4.0, pylint==2.15.0``
 - Flask/Werkzeug 2.0.0+ now provide ``async`` support, so NApps can leverage ``asyncio`` and its ecosystem when applicable using the same ``rest`` decorator
 - Replaced ``get_event_loop`` with ``get_running_loop`` when applicable to be compatible with python 3.9+ in the future
+- NApps are unloaded in the reverse order that they are enabled to facilitate to shutdown gracefully.
 
 Deprecated
 ==========

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -941,13 +941,13 @@ class Controller:
             # pylint: enable=protected-access
 
     def unload_napps(self):
-        """Unload all loaded NApps that are not core NApps."""
-        # list() is used here to avoid the error:
-        # 'RuntimeError: dictionary changed size during iteration'
-        # This is caused by looping over an dictionary while removing
-        # items from it.
-        for (username, napp_name) in list(self.napps.keys()):  # noqa
-            self.unload_napp(username, napp_name)
+        """Unload all loaded NApps that are not core NApps
+
+        NApps are unloaded in the reverse order that they are enabled to
+        facilitate to shutdown gracefully.
+        """
+        for napp in reversed(self.napps_manager.get_enabled_napps()):
+            self.unload_napp(napp.username, napp.name)
 
     def reload_napp_module(self, username, napp_name, napp_file):
         """Reload a NApp Module."""

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -590,6 +590,24 @@ class TestController(TestCase):
 
         mock_load.assert_called_with('kytos', 'name')
 
+    @patch('kytos.core.controller.Controller.unload_napp')
+    def test_unload_napps(self, mock_unload):
+        """Test un_load_napps method."""
+        napp_tuples = [("kytos", "of_core"), ("kytos", "mef_eline")]
+        enabled_napps = []
+        expected_calls = []
+        for username, napp_name in napp_tuples:
+            mock = MagicMock()
+            mock.username = username
+            mock.name = napp_name
+            enabled_napps.append(mock)
+            expected_calls.append(call(mock.username, mock.name))
+        self.napps_manager.get_enabled_napps.return_value = enabled_napps
+
+        self.controller.unload_napps()
+        assert mock_unload.call_count == len(enabled_napps)
+        assert mock_unload.mock_calls == list(reversed(expected_calls))
+
     @patch('kytos.core.controller.import_module')
     def test_reload_napp_module__module_not_found(self, mock_import_module):
         """Test reload_napp_module method when module is not found."""


### PR DESCRIPTION
Fixes #283 

- NApps are unloaded in the reverse order that they are enabled to facilitate to shutdown gracefully.

## Before

```
kytos $> controller.napps_manager.get_enabled_napps()
Out[1]:
[NApp(kytos/of_core),
 NApp(kytos/flow_manager),
 NApp(kytos/topology),
 NApp(kytos/of_lldp),
 NApp(kytos/pathfinder),
 NApp(kytos/maintenance),
 NApp(amlight/coloring),
 NApp(amlight/sdntrace),
 NApp(amlight/flow_stats),
 NApp(amlight/sdntrace_cp),
 NApp(kytos/mef_eline)]

kytos $>
Stopping Kytos daemon... Bye, see you!
2022-09-15 18:12:49,727 - INFO [kytos.core.controller] (MainThread) Stopping Kytos controller...
2022-09-15 18:12:49,727 - INFO [kytos.core.controller] (MainThread) Stopping Kytos
2022-09-15 18:12:49,727 - INFO [kytos.core.buffers] (MainThread) Stop signal received by Kytos buffers.
2022-09-15 18:12:49,727 - INFO [kytos.core.buffers] (MainThread) Sending KytosShutdownEvent to all apps.
2022-09-15 18:12:49,728 - INFO [kytos.core.buffers] (MainThread) [buffer: conn] Stop mode enabled. Rejecting new events.
2022-09-15 18:12:49,728 - INFO [kytos.core.buffers] (MainThread) [buffer: raw] Stop mode enabled. Rejecting new events.
2022-09-15 18:12:49,729 - INFO [kytos.core.buffers] (MainThread) [buffer: msg_in] Stop mode enabled. Rejecting new events.
2022-09-15 18:12:49,729 - INFO [kytos.core.buffers] (MainThread) [buffer: msg_out] Stop mode enabled. Rejecting new events.
2022-09-15 18:12:49,729 - INFO [kytos.core.buffers] (MainThread) [buffer: app] Stop mode enabled. Rejecting new events.
2022-09-15 18:12:49,737 - INFO [kytos.core.napps.napp_dir_listener] (MainThread) NAppDirListener Stopped...
2022-09-15 18:12:49,737 - INFO [kytos.core.controller] (MainThread) Stopping threadpool: sb
2022-09-15 18:12:49,737 - INFO [kytos.core.controller] (MainThread) Stopping threadpool: db
2022-09-15 18:12:49,737 - INFO [kytos.core.controller] (MainThread) Stopping threadpool: app
2022-09-15 18:12:49,740 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/of_core...
2022-09-15 18:12:49,742 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/of_core/ were disabled.
2022-09-15 18:12:49,743 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/flow_manager...
2022-09-15 18:12:49,764 - INFO [apscheduler.scheduler] (MainThread) Scheduler has been shut down
2022-09-15 18:12:49,743 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/delete - OPTIONS,POST
2022-09-15 18:12:49,744 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows - OPTIONS,POST
2022-09-15 18:12:49,744 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows - OPTIONS,DELETE
2022-09-15 18:12:49,744 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows - OPTIONS,HEAD,GET
/usr/local/lib/python3.9/dist-packages/flask_socketio/__init__.py:674: UserWarning: The 'environ['werkzeug.server.shutdown']' function is deprecated and will be removed in Werkzeug 2.1.
  func()
2022-09-15 18:12:49,744 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/delete/<dpid> - OPTIONS,POST
2022-09-15 18:12:49,745 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows/<dpid> - OPTIONS,POST
2022-09-15 18:12:49,745 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows/<dpid> - OPTIONS,DELETE
2022-09-15 18:12:49,778 - INFO [werkzeug] (Thread-81) 127.0.0.1 - - [15/Sep/2022 18:12:49] "GET /api/kytos/core/_shutdown HTTP/1.1" 200 -
2022-09-15 18:12:49,745 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows/<dpid> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,745 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/flow_manager/ were disabled.
2022-09-15 18:12:49,746 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/topology...
2022-09-15 18:12:49,747 - INFO [kytos.napps.kytos/topology] (MainThread) NApp kytos/topology shutting down.
2022-09-15 18:12:49,747 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces - OPTIONS,HEAD,GET
2022-09-15 18:12:49,747 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches - OPTIONS,HEAD,GET
2022-09-15 18:12:49,747 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links - OPTIONS,HEAD,GET
2022-09-15 18:12:49,748 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/ - OPTIONS,HEAD,GET
2022-09-15 18:12:49,748 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/switch/<dpid>/disable - OPTIONS,POST
2022-09-15 18:12:49,748 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/switch/<dpid>/enable - OPTIONS,POST
2022-09-15 18:12:49,748 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_id>/metadata/<key> - OPTIONS,DELETE
2022-09-15 18:12:49,748 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_id>/metadata - OPTIONS,POST
2022-09-15 18:12:49,748 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_id>/metadata - OPTIONS,HEAD,GET
2022-09-15 18:12:49,748 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_disable_id>/disable - OPTIONS,POST
2022-09-15 18:12:49,749 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_enable_id>/enable - OPTIONS,POST
2022-09-15 18:12:49,749 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/metadata/<key> - OPTIONS,DELETE
2022-09-15 18:12:49,749 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/metadata - OPTIONS,POST
2022-09-15 18:12:49,749 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/metadata - OPTIONS,HEAD,GET
2022-09-15 18:12:49,749 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/disable - OPTIONS,POST
2022-09-15 18:12:49,749 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/enable - OPTIONS,POST
2022-09-15 18:12:49,749 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/metadata/<key> - OPTIONS,DELETE
2022-09-15 18:12:49,750 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/metadata - OPTIONS,POST
2022-09-15 18:12:49,750 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/metadata - OPTIONS,HEAD,GET
2022-09-15 18:12:49,750 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/disable - OPTIONS,POST
2022-09-15 18:12:49,750 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/enable - OPTIONS,POST
2022-09-15 18:12:49,750 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/topology/ were disabled.
2022-09-15 18:12:49,750 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/of_lldp...
2022-09-15 18:12:49,751 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/interfaces/disable - OPTIONS,POST
2022-09-15 18:12:49,751 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/interfaces/enable - OPTIONS,POST
2022-09-15 18:12:49,751 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/liveness/disable - OPTIONS,POST
2022-09-15 18:12:49,751 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/liveness/enable - OPTIONS,POST
2022-09-15 18:12:49,751 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/liveness/pair - OPTIONS,HEAD,GET
2022-09-15 18:12:49,752 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/polling_time - OPTIONS,HEAD,GET
2022-09-15 18:12:49,753 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/polling_time - OPTIONS,POST
2022-09-15 18:12:49,754 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/interfaces - OPTIONS,HEAD,GET
2022-09-15 18:12:49,755 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/liveness/ - OPTIONS,HEAD,GET
2022-09-15 18:12:49,755 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/of_lldp/ were disabled.
2022-09-15 18:12:49,755 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/pathfinder...
2022-09-15 18:12:49,756 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/pathfinder/v2/ - OPTIONS,POST
2022-09-15 18:12:49,756 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/pathfinder/ were disabled.
2022-09-15 18:12:49,757 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/maintenance...
2022-09-15 18:12:49,757 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1 - OPTIONS,POST
2022-09-15 18:12:49,757 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1 - OPTIONS,HEAD,GET
2022-09-15 18:12:49,758 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id>/extend - OPTIONS,PATCH
2022-09-15 18:12:49,758 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id>/end - OPTIONS,PATCH
2022-09-15 18:12:49,758 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,759 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id> - OPTIONS,DELETE
2022-09-15 18:12:49,759 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id> - OPTIONS,PATCH
2022-09-15 18:12:49,759 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/maintenance/ were disabled.
2022-09-15 18:12:49,759 - INFO [kytos.core.controller] (MainThread) Shutting down NApp amlight/coloring...
2022-09-15 18:12:49,760 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/coloring/settings - OPTIONS,HEAD,GET
2022-09-15 18:12:49,760 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/coloring/colors - OPTIONS,HEAD,GET
2022-09-15 18:12:49,760 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/amlight/coloring/ were disabled.
2022-09-15 18:12:49,760 - INFO [kytos.core.controller] (MainThread) Shutting down NApp amlight/sdntrace...
2022-09-15 18:12:49,761 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/settings - OPTIONS,HEAD,GET
2022-09-15 18:12:49,761 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/trace - OPTIONS,HEAD,GET
2022-09-15 18:12:49,761 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/stats - OPTIONS,HEAD,GET
2022-09-15 18:12:49,761 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/trace - PUT,OPTIONS
2022-09-15 18:12:49,761 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/trace/<trace_id> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,761 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/amlight/sdntrace/ were disabled.
2022-09-15 18:12:49,761 - INFO [kytos.core.controller] (MainThread) Shutting down NApp amlight/flow_stats...
2022-09-15 18:12:49,762 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/packet_count/per_flow/<dpid> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,762 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/packet_count/sum/<dpid> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,762 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/bytes_count/per_flow/<dpid> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,762 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/bytes_count/sum/<dpid> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,762 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/flow/match/<dpid> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,763 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/flow/stats/<dpid> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,763 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/packet_count/<flow_id> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,763 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/bytes_count/<flow_id> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,763 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/amlight/flow_stats/ were disabled.
2022-09-15 18:12:49,763 - INFO [kytos.core.controller] (MainThread) Shutting down NApp amlight/sdntrace_cp...
2022-09-15 18:12:49,764 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace_cp/trace - PUT,OPTIONS
2022-09-15 18:12:49,764 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/amlight/sdntrace_cp/ were disabled.
2022-09-15 18:12:49,764 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/mef_eline...
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/schedule/ - OPTIONS,POST
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/schedule - OPTIONS,HEAD,GET
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/ - OPTIONS,POST
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/ - OPTIONS,HEAD,GET
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/schedule/<schedule_id> - OPTIONS,DELETE
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/schedule/<schedule_id> - OPTIONS,PATCH
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id>/metadata/<key> - OPTIONS,DELETE
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id>/metadata - OPTIONS,POST
2022-09-15 18:12:49,765 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id>/metadata - OPTIONS,HEAD,GET
2022-09-15 18:12:49,766 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id>/redeploy - OPTIONS,PATCH
2022-09-15 18:12:49,766 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id> - OPTIONS,DELETE
2022-09-15 18:12:49,766 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id> - OPTIONS,HEAD,GET
2022-09-15 18:12:49,766 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id> - OPTIONS,PATCH
2022-09-15 18:12:49,766 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/mef_eline/ were disabled.
2022-09-15 18:12:49,773 - INFO [kytos.core.controller] (MainThread) Stopping API Server: <concurrent.futures.thread.ThreadPoolExecutor object at 0x7f77e5cb9a90>
2022-09-15 18:12:49,779 - INFO [kytos.core.controller] (MainThread) Stopping API Server threadpool: <concurrent.futures.thread.ThreadPoolExecutor object at 0x7f77e5cb9a90>
```

## After (with this PR)

- Notice that they're unloaded in the reverse order, facilitating and giving a chance for NApps who might need to tear something down during `shutdown` to have a chance before their dependencies gets shutdown. This assumes the current guarantees in place that NApps are installed/enabled based on f.stat.st_mtime.

```
kytos $> controller.napps_manager.get_enabled_napps()
Out[1]:
[NApp(kytos/of_core),
 NApp(kytos/flow_manager),
 NApp(kytos/topology),
 NApp(kytos/of_lldp),
 NApp(kytos/pathfinder),
 NApp(kytos/maintenance),
 NApp(amlight/coloring),
 NApp(amlight/sdntrace),
 NApp(amlight/flow_stats),
 NApp(amlight/sdntrace_cp),
 NApp(kytos/mef_eline)]

kytos $>
Stopping Kytos daemon... Bye, see you!
2022-09-15 18:26:19,676 - INFO [kytos.core.controller] (MainThread) Stopping Kytos controller...
2022-09-15 18:26:19,676 - INFO [kytos.core.controller] (MainThread) Stopping Kytos
2022-09-15 18:26:19,677 - INFO [kytos.core.buffers] (MainThread) Stop signal received by Kytos buffers.
2022-09-15 18:26:19,677 - INFO [kytos.core.buffers] (MainThread) Sending KytosShutdownEvent to all apps.
2022-09-15 18:26:19,677 - INFO [kytos.core.buffers] (MainThread) [buffer: conn] Stop mode enabled. Rejecting new events.
2022-09-15 18:26:19,678 - INFO [kytos.core.buffers] (MainThread) [buffer: raw] Stop mode enabled. Rejecting new events.
2022-09-15 18:26:19,678 - INFO [kytos.core.buffers] (MainThread) [buffer: msg_in] Stop mode enabled. Rejecting new events.
2022-09-15 18:26:19,678 - INFO [kytos.core.buffers] (MainThread) [buffer: msg_out] Stop mode enabled. Rejecting new events.
2022-09-15 18:26:19,678 - INFO [kytos.core.buffers] (MainThread) [buffer: app] Stop mode enabled. Rejecting new events.
2022-09-15 18:26:19,694 - INFO [kytos.core.napps.napp_dir_listener] (MainThread) NAppDirListener Stopped...
2022-09-15 18:26:19,694 - INFO [kytos.core.controller] (MainThread) Stopping threadpool: sb
2022-09-15 18:26:19,694 - INFO [kytos.core.controller] (MainThread) Stopping threadpool: db
2022-09-15 18:26:19,694 - INFO [kytos.core.controller] (MainThread) Stopping threadpool: app
2022-09-15 18:26:19,700 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/mef_eline...
2022-09-15 18:26:19,701 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/schedule/ - OPTIONS,POST
2022-09-15 18:26:19,704 - INFO [apscheduler.scheduler] (MainThread) Scheduler has been shut down
2022-09-15 18:26:19,702 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/schedule - GET,HEAD,OPTIONS
2022-09-15 18:26:19,702 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/ - OPTIONS,POST
2022-09-15 18:26:19,702 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/ - GET,HEAD,OPTIONS
2022-09-15 18:26:19,702 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/schedule/<schedule_id> - OPTIONS,DELETE
2022-09-15 18:26:19,702 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/schedule/<schedule_id> - PATCH,OPTIONS
2022-09-15 18:26:19,702 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id>/metadata/<key> - OPTIONS,DELETE
2022-09-15 18:26:19,703 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id>/metadata - OPTIONS,POST
2022-09-15 18:26:19,703 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id>/metadata - GET,HEAD,OPTIONS
2022-09-15 18:26:19,703 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id>/redeploy - PATCH,OPTIONS
/usr/local/lib/python3.9/dist-packages/flask_socketio/__init__.py:674: UserWarning: The 'environ['werkzeug.server.shutdown']' function is deprecated and will be removed in Werkzeug 2.1.
  func()
2022-09-15 18:26:19,703 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id> - OPTIONS,DELETE
2022-09-15 18:26:19,744 - INFO [werkzeug] (Thread-81) 127.0.0.1 - - [15/Sep/2022 18:26:19] "GET /api/kytos/core/_shutdown HTTP/1.1" 200 -
2022-09-15 18:26:19,703 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,703 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/mef_eline/v2/evc/<circuit_id> - PATCH,OPTIONS
2022-09-15 18:26:19,704 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/mef_eline/ were disabled.
2022-09-15 18:26:19,704 - INFO [kytos.core.controller] (MainThread) Shutting down NApp amlight/sdntrace_cp...
2022-09-15 18:26:19,705 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace_cp/trace - OPTIONS,PUT
2022-09-15 18:26:19,705 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/amlight/sdntrace_cp/ were disabled.
2022-09-15 18:26:19,706 - INFO [kytos.core.controller] (MainThread) Shutting down NApp amlight/flow_stats...
2022-09-15 18:26:19,706 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/packet_count/per_flow/<dpid> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,706 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/packet_count/sum/<dpid> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,706 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/bytes_count/per_flow/<dpid> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,707 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/bytes_count/sum/<dpid> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,707 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/flow/match/<dpid> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,707 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/flow/stats/<dpid> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,707 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/packet_count/<flow_id> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,707 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/flow_stats/bytes_count/<flow_id> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,707 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/amlight/flow_stats/ were disabled.
2022-09-15 18:26:19,708 - INFO [kytos.core.controller] (MainThread) Shutting down NApp amlight/sdntrace...
2022-09-15 18:26:19,708 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/settings - GET,HEAD,OPTIONS
2022-09-15 18:26:19,708 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/trace - GET,HEAD,OPTIONS
2022-09-15 18:26:19,708 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/stats - GET,HEAD,OPTIONS
2022-09-15 18:26:19,708 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/trace - OPTIONS,PUT
2022-09-15 18:26:19,708 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/sdntrace/trace/<trace_id> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,709 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/amlight/sdntrace/ were disabled.
2022-09-15 18:26:19,709 - INFO [kytos.core.controller] (MainThread) Shutting down NApp amlight/coloring...
2022-09-15 18:26:19,709 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/coloring/settings - GET,HEAD,OPTIONS
2022-09-15 18:26:19,709 - INFO [kytos.core.api_server] (MainThread) Stopped /api/amlight/coloring/colors - GET,HEAD,OPTIONS
2022-09-15 18:26:19,709 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/amlight/coloring/ were disabled.
2022-09-15 18:26:19,710 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/maintenance...
2022-09-15 18:26:19,710 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1 - OPTIONS,POST
2022-09-15 18:26:19,710 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1 - GET,HEAD,OPTIONS
2022-09-15 18:26:19,710 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id>/extend - PATCH,OPTIONS
2022-09-15 18:26:19,710 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id>/end - PATCH,OPTIONS
2022-09-15 18:26:19,710 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,711 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id> - OPTIONS,DELETE
2022-09-15 18:26:19,711 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/maintenance/v1/<mw_id> - PATCH,OPTIONS
2022-09-15 18:26:19,711 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/maintenance/ were disabled.
2022-09-15 18:26:19,711 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/pathfinder...
2022-09-15 18:26:19,714 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/pathfinder/v2/ - OPTIONS,POST
2022-09-15 18:26:19,714 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/pathfinder/ were disabled.
2022-09-15 18:26:19,715 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/of_lldp...
2022-09-15 18:26:19,715 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/interfaces/disable - OPTIONS,POST
2022-09-15 18:26:19,715 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/interfaces/enable - OPTIONS,POST
2022-09-15 18:26:19,715 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/liveness/disable - OPTIONS,POST
2022-09-15 18:26:19,715 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/liveness/enable - OPTIONS,POST
2022-09-15 18:26:19,716 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/liveness/pair - GET,HEAD,OPTIONS
2022-09-15 18:26:19,716 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/polling_time - GET,HEAD,OPTIONS
2022-09-15 18:26:19,716 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/polling_time - OPTIONS,POST
2022-09-15 18:26:19,716 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/interfaces - GET,HEAD,OPTIONS
2022-09-15 18:26:19,716 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/of_lldp/v1/liveness/ - GET,HEAD,OPTIONS
2022-09-15 18:26:19,716 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/of_lldp/ were disabled.
2022-09-15 18:26:19,717 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/topology...
2022-09-15 18:26:19,717 - INFO [kytos.napps.kytos/topology] (MainThread) NApp kytos/topology shutting down.
2022-09-15 18:26:19,717 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces - GET,HEAD,OPTIONS
2022-09-15 18:26:19,717 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches - GET,HEAD,OPTIONS
2022-09-15 18:26:19,718 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links - GET,HEAD,OPTIONS
2022-09-15 18:26:19,718 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/ - GET,HEAD,OPTIONS
2022-09-15 18:26:19,718 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/switch/<dpid>/disable - OPTIONS,POST
2022-09-15 18:26:19,718 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/switch/<dpid>/enable - OPTIONS,POST
2022-09-15 18:26:19,718 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_id>/metadata/<key> - OPTIONS,DELETE
2022-09-15 18:26:19,718 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_id>/metadata - OPTIONS,POST
2022-09-15 18:26:19,718 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_id>/metadata - GET,HEAD,OPTIONS
2022-09-15 18:26:19,718 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_disable_id>/disable - OPTIONS,POST
2022-09-15 18:26:19,719 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/interfaces/<interface_enable_id>/enable - OPTIONS,POST
2022-09-15 18:26:19,719 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/metadata/<key> - OPTIONS,DELETE
2022-09-15 18:26:19,719 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/metadata - OPTIONS,POST
2022-09-15 18:26:19,722 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/metadata - GET,HEAD,OPTIONS
2022-09-15 18:26:19,722 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/disable - OPTIONS,POST
2022-09-15 18:26:19,722 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/switches/<dpid>/enable - OPTIONS,POST
2022-09-15 18:26:19,722 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/metadata/<key> - OPTIONS,DELETE
2022-09-15 18:26:19,723 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/metadata - OPTIONS,POST
2022-09-15 18:26:19,723 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/metadata - GET,HEAD,OPTIONS
2022-09-15 18:26:19,723 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/disable - OPTIONS,POST
2022-09-15 18:26:19,723 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/topology/v3/links/<link_id>/enable - OPTIONS,POST
2022-09-15 18:26:19,723 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/topology/ were disabled.
2022-09-15 18:26:19,723 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/flow_manager...
2022-09-15 18:26:19,724 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/delete - OPTIONS,POST
2022-09-15 18:26:19,724 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows - OPTIONS,POST
2022-09-15 18:26:19,724 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows - OPTIONS,DELETE
2022-09-15 18:26:19,724 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows - GET,HEAD,OPTIONS
2022-09-15 18:26:19,724 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/delete/<dpid> - OPTIONS,POST
2022-09-15 18:26:19,725 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows/<dpid> - OPTIONS,POST
2022-09-15 18:26:19,725 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows/<dpid> - OPTIONS,DELETE
2022-09-15 18:26:19,725 - INFO [kytos.core.api_server] (MainThread) Stopped /api/kytos/flow_manager/v2/flows/<dpid> - GET,HEAD,OPTIONS
2022-09-15 18:26:19,725 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/flow_manager/ were disabled.
2022-09-15 18:26:19,725 - INFO [kytos.core.controller] (MainThread) Shutting down NApp kytos/of_core...
2022-09-15 18:26:19,725 - INFO [kytos.core.api_server] (MainThread) The Rest endpoints from /api/kytos/of_core/ were disabled.
2022-09-15 18:26:19,735 - INFO [kytos.core.controller] (MainThread) Stopping API Server: <concurrent.futures.thread.ThreadPoolExecutor object at 0x7f5c48256a90>
2022-09-15 18:26:19,746 - INFO [kytos.core.controller] (MainThread) Stopping API Server threadpool: <concurrent.futures.thread.ThreadPoolExecutor object at 0x7f5c48256a90>
root@bf22958c8171:/#

```