### PR TITLE
Added new Kytos-ng logo on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,10 @@
 .. raw:: html
 
   <div align="center">
+    <h1><code>kytos-ng/kytos</code></h1>
+
     <img src="https://github.com/kytos-ng/ui/blob/master/src/assets/kytosng_logo_color.svg" alt="Kytos-ng logo"></img>
   </div>
-
 
 `Kytos SDN Platform <https://kytos-ng.github.io/>`_ is the fastest way to deploy an SDN
 Network. With this you can deploy a basic OpenFlow controller or your own

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-Kytos SDN Platform
-##################
-
 |Stable| |Tag| |Release| |License| |Build| |Coverage| |Quality|
 
 .. raw:: html
@@ -8,6 +5,7 @@ Kytos SDN Platform
   <div align="center">
     <img src="https://github.com/kytos-ng/ui/blob/master/src/assets/kytosng_logo_color.svg" alt="Kytos-ng logo"></img>
   </div>
+
 
 `Kytos SDN Platform <https://kytos-ng.github.io/>`_ is the fastest way to deploy an SDN
 Network. With this you can deploy a basic OpenFlow controller or your own

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,12 @@ Kytos SDN Platform
 
 |Stable| |Tag| |Release| |License| |Build| |Coverage| |Quality|
 
+.. raw:: html
+
+  <div align="center">
+    <img src="https://github.com/kytos-ng/ui/blob/master/src/assets/kytosng_logo_color.svg" alt="Kytos-ng logo"></img>
+  </div>
+
 `Kytos SDN Platform <https://kytos-ng.github.io/>`_ is the fastest way to deploy an SDN
 Network. With this you can deploy a basic OpenFlow controller or your own
 controller. Kytos was designed to be easy to install, use, develop and share


### PR DESCRIPTION
I've added the new Kytos-ng logo on README.rst since PR https://github.com/kytos-ng/ui/pull/31 has landed. I've used the same HTML tags pattern that we're using on other NApps, so I remove the `Kytos SDN Platform` section used to be in the beginning of the document.

## Preview

- If you're using a light theme on your browser:

![20221004_153345](https://user-images.githubusercontent.com/1010796/193898247-43f4afcc-0cd0-4d11-9e14-c22ad3b30fa4.png)

- If you're using a dark theme on your browser:

![20221004_153357](https://user-images.githubusercontent.com/1010796/193898264-8f24fca2-63b0-45d8-80c3-42ddb53fbb2a.png)
