### PR TITLE
Added catching error from missing credentials

### DIFF
--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -278,8 +278,11 @@ class Auth:
 
     def _authenticate_user(self):
         """Authenticate a user using MongoDB."""
-        username = request.authorization["username"]
-        password = request.authorization["password"].encode()
+        try:
+            username = request.authorization["username"]
+            password = request.authorization["password"].encode()
+        except TypeError as err:
+            raise BadRequest("Credentials were not sent.") from err
         user = self._find_user(username)
         if user["password"] != hashlib.sha512(password).hexdigest():
             raise Unauthorized("Incorrect password")

--- a/tests/unit/test_core/test_auth.py
+++ b/tests/unit/test_core/test_auth.py
@@ -108,8 +108,10 @@ class TestAuth(TestCase):
         api = self.get_auth_test_client(self.auth)
         success_response = api.open(url, method='GET', headers=valid_header)
         error_response = api.open(url, method='GET', headers=invalid_header)
+        fail_response = api.open(url, method='GET')
         self.assertEqual(success_response.status_code, 200)
         self.assertEqual(error_response.status_code, 401)
+        self.assertEqual(fail_response.status_code, 400)
 
     @patch('kytos.core.auth.Auth.get_jwt_secret', return_value="abc")
     def test_02_list_users_request(self, mock_jwt_secret):


### PR DESCRIPTION
Closes Issue #298
Catching error which was trying to get values from nonexistent key `username` when header was empty.
Error message can change.