### PR TITLE
Updated hashing

### DIFF
--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -94,10 +94,14 @@ class UserController:
             utc_now = datetime.datetime.utcnow()
             result = self.db.users.insert_one(UserDoc(**{
                 **{"_id": str(uuid.uuid4())},
-                **user_data,
+                **{"username": user_data['username']},
+                **{"password": user_data["password"]},
+                **{"email": user_data["email"]},
                 **{"inserted_at": utc_now},
                 **{"updated_at": utc_now},
             }).dict())
+        except KeyError as err:
+            raise err
         except DuplicateKeyError as err:
             raise err
         except ValidationError as err:
@@ -246,6 +250,8 @@ class Auth:
             print("Inputs could not be validated.")
         except DuplicateKeyError:
             print(f"{username} already exist.")
+        except KeyError:
+            print("There is a missing field.")
 
         return "User successfully created"
 
@@ -341,6 +347,8 @@ class Auth:
         """Save a user using MongoDB."""
         try:
             self.user_controller.create_user(self._get_request())
+        except KeyError as err:
+            raise BadRequest from err
         except ValidationError as err:
             raise BadRequest from err
         except DuplicateKeyError as err:

--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -23,7 +23,7 @@ from werkzeug.exceptions import (BadRequest, Conflict, NotFound, Unauthorized,
 from kytos.core.config import KytosConfig
 from kytos.core.db import Mongo
 from kytos.core.retry import before_sleep, for_all_methods, retries
-from kytos.core.user import UserDoc, UserDocUpdate
+from kytos.core.user import HashSubDoc, UserDoc, UserDocUpdate
 
 __all__ = ['authenticated']
 
@@ -94,14 +94,13 @@ class UserController:
             utc_now = datetime.datetime.utcnow()
             result = self.db.users.insert_one(UserDoc(**{
                 **{"_id": str(uuid.uuid4())},
-                **{"username": user_data['username']},
-                **{"password": user_data["password"]},
-                **{"email": user_data["email"]},
+                **{"username": user_data.get('username')},
+                **{"hash": HashSubDoc()},
+                **{"password": user_data.get('password')},
+                **{"email": user_data.get('email')},
                 **{"inserted_at": utc_now},
                 **{"updated_at": utc_now},
             }).dict())
-        except KeyError as err:
-            raise err
         except DuplicateKeyError as err:
             raise err
         except ValidationError as err:
@@ -246,12 +245,11 @@ class Auth:
         }
         try:
             self.user_controller.create_user(user)
-        except ValidationError:
-            print("Inputs could not be validated.")
+        except ValidationError as err:
+            msg = self.error_msg(err.errors())
+            return f"Error: {msg}"
         except DuplicateKeyError:
-            print(f"{username} already exist.")
-        except KeyError:
-            print("There is a missing field.")
+            return f"Error: {username} already exist."
 
         return "User successfully created"
 
@@ -342,17 +340,29 @@ class Auth:
             raise UnsupportedMediaType(result)
         return metadata
 
+    @staticmethod
+    def error_msg(error_list: list) -> str:
+        """Return a more request friendly error message from ValidationError"""
+        msg = ""
+        for err in error_list:
+            for value in err['loc']:
+                msg += value + ", "
+            msg = msg[:-2]
+            msg += ": " + err["msg"] + "; "
+        return msg[:-2]
+
     @authenticated
     def _create_user(self):
         """Save a user using MongoDB."""
         try:
-            self.user_controller.create_user(self._get_request())
-        except KeyError as err:
-            raise BadRequest from err
+            user_data = self._get_request()
+            self.user_controller.create_user(user_data)
         except ValidationError as err:
-            raise BadRequest from err
+            msg = self.error_msg(err.errors())
+            raise BadRequest(msg) from err
         except DuplicateKeyError as err:
-            raise Conflict from err
+            msg = user_data.get("username") + " already exists."
+            raise Conflict(msg) from err
         return jsonify("User successfully created"), 201
 
     @authenticated
@@ -374,8 +384,10 @@ class Auth:
         try:
             updated = self.user_controller.update_user(username, data)
         except ValidationError as err:
-            raise BadRequest from err
+            msg = self.error_msg(err.errors())
+            raise BadRequest(msg) from err
         except DuplicateKeyError as err:
+            msg = username + " already exists."
             raise Conflict from err
         if not updated:
             raise NotFound(f"User {username} not found")

--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -123,6 +123,8 @@ class UserController:
     def update_user(self, username: str, data: dict) -> dict:
         """Update user from database"""
         utc_now = datetime.datetime.utcnow()
+        if "password" in data:
+            data["hash"] = HashSubDoc()
         try:
             result = self.db.users.find_one_and_update(
                 {"username": username},

--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -289,6 +289,8 @@ class Auth:
         except TypeError as err:
             raise BadRequest("Credentials were not sent.") from err
         user = self._find_user(username)
+        if user["state"] != 'active':
+            raise Unauthorized('This user is not active')
         password_hashed = UserDoc.hashing(password, user["hash"])
         if user["password"] != password_hashed:
             raise Unauthorized("Incorrect password")

--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -3,7 +3,6 @@
 # pylint: disable=invalid-name
 import datetime
 import getpass
-import hashlib
 import logging
 import os
 import uuid
@@ -96,7 +95,6 @@ class UserController:
             result = self.db.users.insert_one(UserDoc(**{
                 **{"_id": str(uuid.uuid4())},
                 **user_data,
-                **{"salt": os.urandom(16)},
                 **{"inserted_at": utc_now},
                 **{"updated_at": utc_now},
             }).dict())
@@ -285,7 +283,7 @@ class Auth:
         except TypeError as err:
             raise BadRequest("Credentials were not sent.") from err
         user = self._find_user(username)
-        password_hashed = UserDoc.hashing(password, user["salt"])
+        password_hashed = UserDoc.hashing(password, user["hash"])
         if user["password"] != password_hashed:
             raise Unauthorized("Incorrect password")
         time_exp = datetime.datetime.utcnow() + datetime.timedelta(

--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -93,13 +93,13 @@ class UserController:
         try:
             utc_now = datetime.datetime.utcnow()
             result = self.db.users.insert_one(UserDoc(**{
-                **{"_id": str(uuid.uuid4())},
-                **{"username": user_data.get('username')},
-                **{"hash": HashSubDoc()},
-                **{"password": user_data.get('password')},
-                **{"email": user_data.get('email')},
-                **{"inserted_at": utc_now},
-                **{"updated_at": utc_now},
+                "_id": str(uuid.uuid4()),
+                "username": user_data.get('username'),
+                "hash": HashSubDoc(),
+                "password": user_data.get('password'),
+                "email": user_data.get('email'),
+                "inserted_at": utc_now,
+                "updated_at": utc_now,
             }).dict())
         except DuplicateKeyError as err:
             raise err

--- a/kytos/core/user.py
+++ b/kytos/core/user.py
@@ -107,9 +107,11 @@ class UserDoc(DocumentBaseModel):
 class UserDocUpdate(DocumentBaseModel):
     "UserDocUpdate use to validate data before updating"
 
-    username: Optional[str]
-    password: Optional[constr(min_length=8)]
+    username: Optional[constr(min_length=1, max_length=64,
+                              regex="^[a-zA-Z0-9_-]+$")]
     email: Optional[EmailStr]
+    hash: Optional[HashSubDoc]
+    password: Optional[constr(min_length=8, max_length=64)]
 
     _validate_password = validator('password',
                                    allow_reuse=True)(UserDoc.validate_password)

--- a/tests/unit/test_core/test_auth.py
+++ b/tests/unit/test_core/test_auth.py
@@ -3,7 +3,8 @@ import base64
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
-from pydantic import ValidationError
+# pylint: disable=no-name-in-module
+from pydantic import BaseModel, ValidationError
 from pymongo.errors import DuplicateKeyError
 from werkzeug.exceptions import NotFound
 
@@ -162,7 +163,7 @@ class TestAuth(TestCase):
     def test_03_create_user_request_bad(self, mock_jwt_secret):
         """Test auth create user endpoint."""
         controller = self.auth.user_controller
-        controller.create_user.side_effect = ValidationError('', '')
+        controller.create_user.side_effect = ValidationError('', BaseModel)
         api = self.get_auth_test_client(self.auth)
         url = f"{API_URI}/auth/users/"
         error_response = api.open(url, method='POST', json=self.user_data,
@@ -219,7 +220,7 @@ class TestAuth(TestCase):
     def test_05_update_user_request_bad(self, mock_jwt_secret):
         """Test auth update user endpoint"""
         controller = self.auth.user_controller
-        controller.update_user.side_effect = ValidationError('', '')
+        controller.update_user.side_effect = ValidationError('', BaseModel)
         api = self.get_auth_test_client(self.auth)
         url = f"{API_URI}/auth/users/user5"
         error_response = api.open(url, method='PATCH', json={},
@@ -266,3 +267,12 @@ class TestAuth(TestCase):
         with self.assertRaises(NotFound):
             # pylint: disable=protected-access
             self.auth._find_user("name")
+
+    def test_08_error_msg(self):
+        """Test error_msg"""
+        # ValidationErro mocked response
+        error_list = [{'loc': ('username', ), 'msg': 'mock_msg_1'},
+                      {'loc': ('email', ), 'msg': 'mock_msg_2'}]
+        actual_msg = self.auth.error_msg(error_list)
+        expected_msg = 'username: mock_msg_1; email: mock_msg_2'
+        self.assertEqual(actual_msg, expected_msg)

--- a/tests/unit/test_core/test_auth.py
+++ b/tests/unit/test_core/test_auth.py
@@ -63,6 +63,7 @@ class TestAuth(TestCase):
     def _get_token(self, mock_hashing=None, mock_jwt_secret=None):
         """Make a request to get a token to be used in tests."""
         box = {
+            'state': 'active',
             'hash': '',
             # "password" digested
             'password': 'password_mocked'
@@ -114,9 +115,12 @@ class TestAuth(TestCase):
         mock_hashing.return_value = 'password_incorrect'
         error_response = api.open(url, method='GET', headers=invalid_header)
         fail_response = api.open(url, method='GET')
+        self.auth.user_controller.get_user.return_value = {'state': ''}
+        inactive_response = api.open(url, method='GET', headers=valid_header)
         self.assertEqual(success_response.status_code, 200)
         self.assertEqual(error_response.status_code, 401)
         self.assertEqual(fail_response.status_code, 400)
+        self.assertEqual(inactive_response.status_code, 401)
 
     @patch('kytos.core.auth.Auth.get_jwt_secret', return_value="abc")
     def test_02_list_users_request(self, mock_jwt_secret):

--- a/tests/unit/test_core/test_user_controller.py
+++ b/tests/unit/test_core/test_user_controller.py
@@ -50,12 +50,6 @@ class TestUserController(TestCase):
         self.assertEqual(arg1[0]["hash"]["r"], 8)
         self.assertEqual(arg1[0]["hash"]["p"], 1)
 
-    def test_create_user_key_error(self):
-        """Test create_user KeyError"""
-        wrong_data = {"username": "onlyname"}
-        with self.assertRaises(KeyError):
-            self.user.create_user(wrong_data)
-
     def test_create_user_key_duplicate(self):
         """Test create_user with DuplicateKeyError"""
         self.user.db.users.insert_one.side_effect = DuplicateKeyError(0)

--- a/tests/unit/test_core/test_user_controller.py
+++ b/tests/unit/test_core/test_user_controller.py
@@ -77,12 +77,13 @@ class TestUserController(TestCase):
 
     def test_update_user(self):
         """Test update_user"""
-        data = {'email': 'random@kytos.io'}
+        data = {'password': 'Mock_password1'}
         self.user.update_user('name', data)
         self.assertEqual(self.user.db.users.find_one_and_update.call_count, 1)
         arg1, arg2 = self.user.db.users.find_one_and_update.call_args[0]
         self.assertEqual(arg1, {"username": 'name'})
         self.assertEqual(type(arg2), dict)
+        self.assertIsNotNone(arg2["$set"]["hash"])
 
     def test_update_user_error(self):
         """Test update_user error handling"""

--- a/tests/unit/test_core/test_user_controller.py
+++ b/tests/unit/test_core/test_user_controller.py
@@ -36,18 +36,19 @@ class TestUserController(TestCase):
 
     def test_create_user(self):
         """Test create_user"""
-        pass_decoded = "20b0747eefcdc16fa4fb06bbf9284303645ecc3d2" \
-                       "c43927878bd513f06853191c104aebae6d7fca629" \
-                       "1f1e296c6af99ebf8a137cbd7a0d34f2e27b31cb4fecdb"
         self.user.create_user(self.user_data)
         self.assertEqual(self.user.db.users.insert_one.call_count, 1)
         arg1 = self.user.db.users.insert_one.call_args[0]
         self.assertEqual(arg1[0]['username'], "authtempuser")
         self.assertEqual(arg1[0]["email"], "temp@kytos.io")
-        self.assertEqual(arg1[0]["password"], pass_decoded)
+        self.assertIsNotNone(arg1[0]["password"])
         self.assertEqual(type(arg1[0]["inserted_at"]), datetime)
         self.assertEqual(type(arg1[0]["updated_at"]), datetime)
         self.assertEqual(arg1[0]["deleted_at"], None)
+        self.assertIsNotNone(arg1[0]["hash"]["salt"])
+        self.assertEqual(arg1[0]["hash"]["n"], 8192)
+        self.assertEqual(arg1[0]["hash"]["r"], 8)
+        self.assertEqual(arg1[0]["hash"]["p"], 1)
 
     def test_create_user_key_error(self):
         """Test create_user KeyError"""

--- a/tests/unit/test_core/test_user_controller.py
+++ b/tests/unit/test_core/test_user_controller.py
@@ -53,7 +53,7 @@ class TestUserController(TestCase):
     def test_create_user_key_error(self):
         """Test create_user KeyError"""
         wrong_data = {"username": "onlyname"}
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(KeyError):
             self.user.create_user(wrong_data)
 
     def test_create_user_key_duplicate(self):
@@ -61,6 +61,16 @@ class TestUserController(TestCase):
         self.user.db.users.insert_one.side_effect = DuplicateKeyError(0)
         with self.assertRaises(DuplicateKeyError):
             self.user.create_user(self.user_data)
+
+    def test_create_user_validation_error(self):
+        """Test create_user with ValidationError"""
+        wrong_pwd = {
+            'username': "mock_user",
+            'email': "email@mock.com",
+            'password': 'wrong_pwd'
+        }
+        with self.assertRaises(ValidationError):
+            self.user.create_user(wrong_pwd)
 
     def test_delete_user(self):
         """Test delete_user"""

--- a/tests/unit/test_core/test_users.py
+++ b/tests/unit/test_core/test_users.py
@@ -1,7 +1,6 @@
 """Testing of only DocumentBaseModel from user.py. UserDoc and
 UserDocUpdate have been indirectly tested in test_user_controller.py"""
 
-import os
 from datetime import datetime
 from unittest import TestCase
 
@@ -106,18 +105,12 @@ class TestUserDoc(TestCase):
 
     def test_user_doc_hashing(self):
         """Test UserDoc hashing of password"""
-        salt = os.urandom(16)
         user_data = {
             "username": "Test123-_",
             "password": "Password123",
             "email": "test@kytos.io",
-            "hash": {
-                "salt": salt,
-                "n": 2,
-                "r": 1,
-                "p": 1
-            }
         }
         user_doc = UserDoc(**user_data).dict()
-        pwd_hashed = UserDoc.hashing("Password123".encode(), user_data["hash"])
+        pwd_hashed = UserDoc.hashing("Password123".encode(),
+                                     user_doc["hash"])
         self.assertEqual(user_doc["password"], pwd_hashed)

--- a/tests/unit/test_core/test_users.py
+++ b/tests/unit/test_core/test_users.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from pydantic import ValidationError
 
-from kytos.core.user import DocumentBaseModel, UserDoc
+from kytos.core.user import DocumentBaseModel, HashSubDoc, UserDoc
 
 
 def test_document_base_model_dict():
@@ -22,22 +22,26 @@ def test_document_base_model_dict():
 class TestUserDoc(TestCase):
     """Test UserDoc"""
 
-    def test_user_doc_dict(self):
-        """Test UserDocModel.dict()"""
-        correct_load = {
+    def setUp(self):
+        """Initiate values for UserDoc testing"""
+        self.user_data = {
             "username": "Test123-_",
             "password": "Password123",
             "email": "test@kytos.io",
+            "hash": HashSubDoc()
         }
+
+    def test_user_doc_dict(self):
+        """Test UserDocModel.dict()"""
         correct_hash = {
             "n": 8192,
             "r": 8,
             "p": 1
         }
-        user_doc = UserDoc(**correct_load).dict()
+        user_doc = UserDoc(**self.user_data).dict()
         user_hash = user_doc["hash"]
-        self.assertEqual(user_doc["username"], correct_load["username"])
-        self.assertEqual(user_doc["email"], correct_load["email"])
+        self.assertEqual(user_doc["username"], self.user_data["username"])
+        self.assertEqual(user_doc["email"], self.user_data["email"])
         self.assertIsNotNone(user_hash["salt"])
         self.assertEqual(user_hash["n"], correct_hash["n"])
         self.assertEqual(user_hash["r"], correct_hash["r"])
@@ -45,33 +49,21 @@ class TestUserDoc(TestCase):
 
     def test_user_doc_dict_user_error(self):
         """Test UserDoc user validation error"""
-        incorrect_load = {
-            "username": "Test_error_@",
-            "password": "Password123",
-            "email": "test@kytos.io"
-        }
+        self.user_data['username'] = "Test_error_@"
         with self.assertRaises(ValidationError):
-            UserDoc(**incorrect_load)
+            UserDoc(**self.user_data)
 
     def test_user_doc_dict_pw_error(self):
         """Test UserDoc password validation error"""
-        incorrect_load = {
-            "username": "Test",
-            "password": "password_error",
-            "email": "test@kytos.io"
-        }
+        self.user_data['password'] = 'password_error'
         with self.assertRaises(ValidationError):
-            UserDoc(**incorrect_load)
+            UserDoc(**self.user_data)
 
     def test_user_doc_dict_email_error(self):
         """Test UserDoc email validation error"""
-        incorrect_load = {
-            "username": "Test",
-            "password": "Password123",
-            "email": "test_error"
-        }
+        self.user_data['email'] = 'test_error'
         with self.assertRaises(ValidationError):
-            UserDoc(**incorrect_load)
+            UserDoc(**self.user_data)
 
     def test_user_doc_projection(self):
         """Test UserDoc projection return"""
@@ -105,12 +97,7 @@ class TestUserDoc(TestCase):
 
     def test_user_doc_hashing(self):
         """Test UserDoc hashing of password"""
-        user_data = {
-            "username": "Test123-_",
-            "password": "Password123",
-            "email": "test@kytos.io",
-        }
-        user_doc = UserDoc(**user_data).dict()
+        user_doc = UserDoc(**self.user_data).dict()
         pwd_hashed = UserDoc.hashing("Password123".encode(),
                                      user_doc["hash"])
         self.assertEqual(user_doc["password"], pwd_hashed)


### PR DESCRIPTION
Closes #311 
- Changed hashing function to `hashlib.scrypt` using `n=8192, r=8, p=1`
- MongoDB index scan for user:
```
    op: 'command',
    ns: 'napps.users',
    command: {
      aggregate: 'users',
      pipeline: [
        { '$match': { username: 'user4' } },
        {
          '$project': {
            _id: 0,
            username: 1,
            email: 1,
            password: 1,
            state: 1,
            inserted_at: 1,
            updated_at: 1,
            deleted_at: 1,
            salt: 1
          }
        },
        { '$limit': 1 }
      ],
      cursor: {},
      lsid: { id: new UUID("6443f89b-421e-4038-96a2-328c79f48ddb") },
      '$clusterTime': {
        clusterTime: Timestamp({ t: 1670304072, i: 1 }),
        signature: {
          hash: Binary(Buffer.from("0000000000000000000000000000000000000000", "hex"), 0),
          keyId: Long("0")
        }
      },
      readConcern: { level: 'majority' },
      '$db': 'napps',
      '$readPreference': { mode: 'primaryPreferred' }
    },
    planSummary: 'IXSCAN { username: 1 }',
```