### PR TITLE
[Fix] Updated blueprints status

### DIFF
--- a/docs/blueprints/EP018.rst
+++ b/docs/blueprints/EP018.rst
@@ -3,7 +3,7 @@
 :Authors: Carlos Magno <cmagnobarbosa@gmail.com>; Gleyberson Andrade <gleybersonandrade@gmail.com>
 :Created: 2019-09-05
 :Kytos-Version: 2019.2
-:Status: Draft
+:Status: Finished
 :Type: Standards Track
 
 ********************************************

--- a/docs/blueprints/EP021.rst
+++ b/docs/blueprints/EP021.rst
@@ -8,7 +8,7 @@
     - José Mauro Ribeiro <zemauror@gmail.com>
 :Created: 2020-01-30
 :Kytos-Version: 2020.1
-:Status: Draft
+:Status: Accepted
 :Type: Informational
 
 

--- a/docs/blueprints/EP023-2.rst
+++ b/docs/blueprints/EP023-2.rst
@@ -6,8 +6,8 @@
     - Vinicius Arcanjo <vinicius@amlight.net>
     - Jeronimo Bezerra <jbezerra@fiu.edu>
 :Created: 2021-10-11
-:Kytos-Version:
-:Status: Draft
+:Kytos-Version: 2022.1
+:Status: Finished
 
 ************************************************************
 EP023-2 - Kytos pathfinder Filter Paths by Metadata - Part 2

--- a/docs/blueprints/EP024.rst
+++ b/docs/blueprints/EP024.rst
@@ -7,7 +7,7 @@
     - Vinicius Arcanjo <vindasil@fiu.edu>
 :Created: 2021-11-01
 :Kytos-Version:
-:Status: Draft
+:Status: Finished
 
 ********************************************
 EP024 - Managed resources consistency checks

--- a/docs/blueprints/EP025.rst
+++ b/docs/blueprints/EP025.rst
@@ -7,8 +7,8 @@
     - Jeronimo Bezerra <jbezerra AT fiu DOT edu>
     - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
 :Created: 2022-02-22
-:Kytos-Version:
-:Status: Draft
+:Kytos-Version: 2022.2
+:Status: Finished
 
 *****************************************
 EP025 - Interface loop detection via LLDP

--- a/docs/blueprints/EP026.rst
+++ b/docs/blueprints/EP026.rst
@@ -8,10 +8,10 @@
     - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
 :Created: 2022-03-03
 :Kytos-Version: 2022.2
-:Status: Draft
+:Status: Finished
 
 ****************************************
-EP025 - Document-oriented NoSQL database
+EP026 - Document-oriented NoSQL database
 ****************************************
 
 

--- a/docs/blueprints/EP027.rst
+++ b/docs/blueprints/EP027.rst
@@ -7,8 +7,8 @@
     - Jeronimo Bezerra <jbezerra AT fiu DOT edu>
     - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
 :Created: 2022-04-19
-:Kytos-Version:
-:Status: Draft
+:Kytos-Version: 2022.2
+:Status: Finished
 
 ***********************************************************
 EP027 - Application Performance and Monitoring (APM) client

--- a/docs/blueprints/EP028.rst
+++ b/docs/blueprints/EP028.rst
@@ -7,8 +7,8 @@
     - Jeronimo Bezerra <jbezerra AT fiu DOT edu>
     - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
 :Created: 2022-04-27
-:Kytos-Version:
-:Status: Draft
+:Kytos-Version: 2022.2
+:Status: Finished
 
 **********************************
 EP028 - Searchable structured logs

--- a/docs/blueprints/EP029.rst
+++ b/docs/blueprints/EP029.rst
@@ -7,8 +7,8 @@
     - Jeronimo Bezerra <jbezerra AT fiu DOT edu>
     - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
 :Created: 2022-06-27
-:Kytos-Version:
-:Status: Draft
+:Kytos-Version: 2022.2
+:Status: Finished
 
 ************************************************************
 EP029 - MEF E-Line EVC Service Protection

--- a/docs/blueprints/EP030.rst
+++ b/docs/blueprints/EP030.rst
@@ -7,8 +7,8 @@
     - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
     - Jeronimo Bezerra <jbezerra AT fiu DOT edu>
 :Created: 2022-06-28
-:Kytos-Version:
-:Status: Draft
+:Kytos-Version: 2022.2
+:Status: Finished
 
 ****************************************
 EP030 - Link Liveness Detection via LLDP

--- a/docs/blueprints/EP032.rst
+++ b/docs/blueprints/EP032.rst
@@ -8,8 +8,8 @@
     - David Ramirez <davramir AT fiu DOT edu>
     - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
 :Created: 2022-08-25
-:Kytos-Version:
-:Status: Draft
+:Kytos-Version: 2023.3
+:Status: Finished
 
 ***********************************
 EP032 - flow_stats stabilization v1

--- a/docs/blueprints/EP033.rst
+++ b/docs/blueprints/EP033.rst
@@ -6,7 +6,7 @@
     - Vinicius Arcanjo <vindasil AT fiu DOT edu>
 :Created: 2022-09-03
 :Kytos-Version: 2022.3
-:Status: Draft
+:Status: Accepted
 
 
 *******************************************************

--- a/docs/blueprints/EP034.rst
+++ b/docs/blueprints/EP034.rst
@@ -7,8 +7,8 @@
     - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
     - Antonio Francisco <ajoaoff AT gmail DOT com>
 :Created: 2022-09-26
-:Kytos-Version:
-:Status: Draft
+:Kytos-Version: 2022.3
+:Status: Finished
 
 ***********************************
 EP033 - MEF E-LINE CSPF integration


### PR DESCRIPTION
Updated blueprints status and kytos version information accordingly. 

It turns out that the status and version information on some blueprints weren't being updated, that wasn't a major problem, but when we start to compile the pages again in the future, it's worth to have this information coherent. 
