### PR TITLE
fix: Unexposed `jwt_secret` on `GET /api/kytos/core/config/` endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Changed
 - Changed ``UNI.is_valid`` to allow tags such as ``any`` and ``untagged``
 - Changed ``EntityStatus`` value from 1, 2 and 3 to ``UP``, ``DISABLED`` and ``DOWN`` respectively.
 
+Fixed
+=====
+- Unexposed ``jwt_secret`` on ``GET /api/kytos/core/config/`` endpoint
+
 
 [2022.3.1]  2023-02-17
 **********************

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -210,6 +210,14 @@ class KytosConfig():
 
         return options
 
+    @staticmethod
+    def options_exposed(daemon_options: dict) -> dict:
+        """Options exposed on API."""
+        options = dict(daemon_options)
+        for key in {"jwt_secret"}:
+            options.pop(key, None)
+        return options
+
 
 def _render_config_templates(templates,
                              destination=Path(__file__).parent,

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -452,7 +452,7 @@ class Controller:
             string: Json with current configurations used by kytos.
 
         """
-        return JSONResponse(self.options.__dict__)
+        return JSONResponse(KytosConfig.options_exposed(self.options.__dict__))
 
     def restart(self, graceful=True):
         """Restart Kytos SDN Controller.

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -772,6 +772,7 @@ class TestControllerAsync:
     async def test_configuration_endpoint(self, controller, api_client):
         """Should return the attribute options as json."""
         expected = vars(controller.options)
+        expected.pop("jwt_secret", None)
         resp = await api_client.get("kytos/core/config")
         assert resp.status_code == 200
         assert expected == resp.json()


### PR DESCRIPTION
Closes #370 

This PR is on top of #375 

### Summary

See updated changelog file

### Local Tests

Request body diff before and after:

```
❯ diff respb.md respa.md
3c3
< content-length: 1019
---
> content-length: 971
5c5
< date: Mon, 24 Apr 2023 19:36:38 GMT
---
> date: Mon, 24 Apr 2023 19:49:06 GMT
21d20
<     "jwt_secret": "8ece86b575c347e69bb8823936be9512",
```

### End-to-End Tests

N/A
