### PR TITLE
feat: introduced `api_traceback_on_500` kytos config option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 - Added ``avalidate_openapi_request(spec, request)`` to validate OpenAPI ``async`` routes
 - ``htppx`` is now shipped as a dependency, NApps can also leverage it instead of ``requests``
 - Added ``kytos.core.rest_api`` module exposing utilities for requests handlers
+- Added new kytos.conf option ``api_traceback_on_500``, which is True by default to provide a complete traceback on API responses if an internal server error ever happens
 
 Changed
 =======

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -31,7 +31,6 @@ LOG = logging.getLogger(__name__)
 class APIServer:
     """Api server used to provide Kytos Controller routes."""
 
-    #: tuple: Default Flask HTTP methods.
     DEFAULT_METHODS = ('GET',)
     _NAPP_PREFIX = "/api/{napp.username}/{napp.name}/"
     _CORE_PREFIX = "/api/kytos/core/"
@@ -39,15 +38,11 @@ class APIServer:
 
     # pylint: disable=too-many-arguments
     def __init__(self, listen='0.0.0.0', port=8181,
-                 napps_manager=None, napps_dir=None):
-        """Start a Flask+SocketIO server.
+                 napps_manager=None, napps_dir=None,
+                 response_traceback_on_500=True):
+        """APIServer.
 
         Require controller to get NApps dir and NAppsManager
-
-        Args:
-            listen (string): host name used by api server instance
-            port (int): Port number used by api server instance
-            controller(kytos.core.controller): A controller instance.
         """
         dirname = os.path.dirname(os.path.abspath(__file__))
         self.napps_manager = napps_manager
@@ -56,6 +51,7 @@ class APIServer:
         self.port = port
         self.web_ui_dir = os.path.join(dirname, '../web-ui')
         self.app = Starlette(
+            debug=response_traceback_on_500,
             exception_handlers={HTTPException: self._http_exc_handler},
             middleware=[
                 Middleware(CORSMiddleware, allow_origins=["*"]),
@@ -304,7 +300,7 @@ class APIServer:
         APIServer and NApp instances.
         """
         def store_route_params(function):
-            """Store ``Flask`` ``@route`` parameters in a method attribute.
+            """Store ``@route`` parameters in a method attribute.
 
             There can be many @route decorators in a single function.
             """

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -139,6 +139,7 @@ class KytosConfig():
                         ["kytos.core.logger_decorators.queue_decorator"],
                     'listen': '0.0.0.0',
                     'port': 6653,
+                    'api_traceback_on_500': True,
                     'foreground': False,
                     'protocol_name': '',
                     'enable_entities_by_default': False,
@@ -189,6 +190,8 @@ class KytosConfig():
         options.daemon = options.daemon in ['True', True]
         options.port = int(options.port)
         options.api_port = int(options.api_port)
+        options.api_traceback_on_500 = options.api_traceback_on_500 in ['True',
+                                                                        True]
         options.protocol_name = str(options.protocol_name)
         options.token_expiration_minutes = int(options.
                                                token_expiration_minutes)

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -143,7 +143,9 @@ class Controller:
         #: API Server used to expose rest endpoints.
         self.api_server = APIServer(self.options.listen,
                                     self.options.api_port,
-                                    self.napps_manager, self.options.napps)
+                                    self.napps_manager,
+                                    self.options.napps,
+                                    self.options.api_traceback_on_500)
 
         self.auth = None
         self.dead_letter = DeadLetter(self)

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -45,6 +45,9 @@ connection_timeout = 130
 # Default is 8181.
 api_port = 8181
 
+# Whether to include a traceback response when a internal server error happens.
+api_traceback_on_500 = True
+
 # When a new entity (switch, interface or link) is created it is
 # administratively disabled by default. Change here to modify this behavior.
 # enable_entities_by_default = False

--- a/tests/unit/test_core/test_rest_api_routes.py
+++ b/tests/unit/test_core/test_rest_api_routes.py
@@ -50,6 +50,11 @@ async def test_aget_json_or_400(controller, api_client) -> None:
     assert response.json() == body
 
 
+def test_api_500_traceback_by_default(controller) -> None:
+    """Test api 500 traceback by default."""
+    assert controller.api_server.app.debug
+
+
 async def test_get_json_or_400(controller, api_client, event_loop) -> None:
     """Test get_json_or_400."""
 


### PR DESCRIPTION
Closes #379 

This PR is on top of PR #375

### Summary

See updated changelog file (also check out the issue description for more information why this is being introduced).

### Local Tests

- `api_traceback_on_500 = True` by default, simulating an unhanded exception on a API route to create an internal server error, notice that the client will also have the full traceback, which is very helpful for also reporting issues, and this doesn't create performance penalties nor vulnerabilities in our open source code:

```
❯ http http://localhost:8181/api/kytos/of_lldp/v1/polling_time
HTTP/1.1 500 Internal Server Error
content-length: 1570
content-type: text/plain; charset=utf-8
date: Tue, 02 May 2023 13:42:28 GMT
server: uvicorn

Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/.direnv/python-3.9.16/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9.16/lib/python3.9/site-packages/elasticapm/contrib/starlette/__init__.py", line 173, in __call__
    await self.app(scope, _receive, wrapped_send)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9.16/lib/python3.9/site-packages/starlette/middleware/cors.py", line 84, in __call__
    await self.app(scope, receive, send)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9.16/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/viniarck/repos/kytos/.direnv/python-3.9.16/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9.16/lib/python3.9/site-packages/starlette/routing.py", line 716, in __call__
    await route.handle(scope, receive, send)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9.16/lib/python3.9/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9.16/lib/python3.9/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/home/viniarck/repos/napps2/napps/kytos/of_lldp/main.py", line 621, in get_time
    a
NameError: name 'a' is not defined
```

- `api_traceback_on_500 = False`:

```
❯ http http://localhost:8181/api/kytos/of_lldp/v1/polling_time
HTTP/1.1 500 Internal Server Error
content-length: 21
content-type: text/plain; charset=utf-8
date: Tue, 02 May 2023 13:43:11 GMT
server: uvicorn

Internal Server Error
```

For both cases though, the traceback will always be in the logs, so the main benefit is really also that the traceback is included in the response, which has demonstrated to be very helpful for e2e tests too.

### End-to-End Tests

Not necessary in this case
