### PR TITLE
Added `status_reason` to `Link`, `Interface`, and `Switch`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 - ``htppx`` is now shipped as a dependency, NApps can also leverage it instead of ``requests``
 - Added ``kytos.core.rest_api`` module exposing utilities for requests handlers
 - Added new kytos.conf option ``api_traceback_on_500``, which is True by default to provide a complete traceback on API responses if an internal server error ever happens
+- Added ``status_reason`` to ``Interface``, ``Switch``, and ``Link``.
+- Added ``register_status_reason_func`` to ``Interface``, ``Switch``, and ``Link``.
 
 Changed
 =======

--- a/kytos/core/common.py
+++ b/kytos/core/common.py
@@ -50,6 +50,16 @@ class GenericEntity:
             return EntityStatus.DISABLED
         return EntityStatus.DOWN
 
+    @property
+    def status_reason(self):
+        """Return the reason behind the current status of the entity."""
+        reasons = set()
+        if not self.is_enabled():
+            reasons.add('disabled')
+        if not self.is_active():
+            reasons.add('deactivated')
+        return reasons
+
     def is_administrative_down(self):
         """Return True for disabled Entities."""
         return not self.is_enabled()

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -451,21 +451,24 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             dict: Dictionary filled with interface attributes.
 
         """
-        iface_dict = {'id': self.id,
-                      'name': self.name,
-                      'port_number': self.port_number,
-                      'mac': self.address,
-                      'switch': self.switch.dpid,
-                      'type': 'interface',
-                      'nni': self.nni,
-                      'uni': self.uni,
-                      'speed': self.speed,
-                      'metadata': self.metadata,
-                      'lldp': self.lldp,
-                      'active': self.is_active(),
-                      'enabled': self.is_enabled(),
-                      'status': self.status.value,
-                      'link': self.link.id if self.link else ""}
+        iface_dict = {
+            'id': self.id,
+            'name': self.name,
+            'port_number': self.port_number,
+            'mac': self.address,
+            'switch': self.switch.dpid,
+            'type': 'interface',
+            'nni': self.nni,
+            'uni': self.uni,
+            'speed': self.speed,
+            'metadata': self.metadata,
+            'lldp': self.lldp,
+            'active': self.is_active(),
+            'enabled': self.is_enabled(),
+            'status': self.status.value,
+            'status_reason': list(self.status_reason),
+            'link': self.link.id if self.link else ""
+        }
         if self.stats:
             iface_dict['stats'] = self.stats.as_dict()
         return iface_dict

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -466,8 +466,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             'active': self.is_active(),
             'enabled': self.is_enabled(),
             'status': self.status.value,
-            'status_reason': list(self.status_reason),
-            'link': self.link.id if self.link else ""
+            'status_reason': sorted(self.status_reason),
+            'link': self.link.id if self.link else "",
         }
         if self.stats:
             iface_dict['stats'] = self.stats.as_dict()

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -4,7 +4,9 @@ Links are low level abstractions representing connections between two
 interfaces.
 """
 import json
+import operator
 from collections import OrderedDict
+from functools import reduce
 from threading import Lock
 
 from kytos.core.common import EntityStatus, GenericEntity
@@ -18,6 +20,7 @@ class Link(GenericEntity):
     """Define a link between two Endpoints."""
 
     status_funcs = OrderedDict()
+    status_reason_funcs = OrderedDict()
     _get_available_vlans_lock = Lock()
 
     def __init__(self, endpoint_a, endpoint_b):
@@ -56,6 +59,24 @@ class Link(GenericEntity):
             if status_func(self) == EntityStatus.DOWN:
                 return EntityStatus.DOWN
         return state
+
+    @classmethod
+    def register_status_reason_func(cls, name: str, func):
+        """Register status reason func given its name
+        and a callable at setup time."""
+        cls.status_reason_funcs[name] = func
+
+    @property
+    def status_reason(self):
+        """Return the reason behind the current status of the entity."""
+        return reduce(
+            operator.or_,
+            map(
+                lambda x: x(self),
+                self.status_reason_funcs.values()
+            ),
+            super().status_reason
+        )
 
     def is_enabled(self):
         """Override the is_enabled method.

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -198,7 +198,7 @@ class Link(GenericEntity):
             'active': self.is_active(),
             'enabled': self.is_enabled(),
             'status': self.status.value,
-            'status_reason': list(self.status_reason),
+            'status_reason': sorted(self.status_reason),
         }
 
     def as_json(self):

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -190,13 +190,16 @@ class Link(GenericEntity):
 
     def as_dict(self):
         """Return the Link as a dictionary."""
-        return {'id': self.id,
-                'endpoint_a': self.endpoint_a.as_dict(),
-                'endpoint_b': self.endpoint_b.as_dict(),
-                'metadata': self.get_metadata_as_dict(),
-                'active': self.is_active(),
-                'enabled': self.is_enabled(),
-                'status': self.status.value}
+        return {
+            'id': self.id,
+            'endpoint_a': self.endpoint_a.as_dict(),
+            'endpoint_b': self.endpoint_b.as_dict(),
+            'metadata': self.get_metadata_as_dict(),
+            'active': self.is_active(),
+            'enabled': self.is_enabled(),
+            'status': self.status.value,
+            'status_reason': list(self.status_reason),
+        }
 
     def as_json(self):
         """Return the Link as a JSON string."""

--- a/kytos/core/rest_api.py
+++ b/kytos/core/rest_api.py
@@ -22,6 +22,8 @@ HTTPException = HTTPException
 def _json_serializer(obj):
     if isinstance(obj, datetime):
         return obj.isoformat()
+    if isinstance(obj, set):
+        return sorted(obj)
     raise TypeError(f"Type {type(obj)} not serializable")
 
 

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -1,7 +1,9 @@
 """Module with main classes related to Switches."""
 import json
 import logging
+import operator
 from collections import OrderedDict
+from functools import reduce
 from threading import Lock
 
 from kytos.core.common import EntityStatus, GenericEntity
@@ -49,6 +51,7 @@ class Switch(GenericEntity):
     """
 
     status_funcs = OrderedDict()
+    status_reason_funcs = OrderedDict()
 
     def __init__(self, dpid, connection=None, features=None):
         """Contructor of switches have the below parameters.
@@ -137,6 +140,24 @@ class Switch(GenericEntity):
     def register_status_func(cls, name: str, func):
         """Register status func given its name and a callable at setup time."""
         cls.status_funcs[name] = func
+
+    @classmethod
+    def register_status_reason_func(cls, name: str, func):
+        """Register status reason func given its name
+        and a callable at setup time."""
+        cls.status_reason_funcs[name] = func
+
+    @property
+    def status_reason(self):
+        """Return the reason behind the current status of the entity."""
+        return reduce(
+            operator.or_,
+            map(
+                lambda x: x(self),
+                self.status_reason_funcs.values()
+            ),
+            super().status_reason
+        )
 
     def disable(self):
         """Disable this switch instance.

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -403,7 +403,7 @@ class Switch(GenericEntity):
             'active': self.is_active(),
             'enabled': self.is_enabled(),
             'status': self.status.value,
-            'status_reason': list(self.status_reason),
+            'status_reason': sorted(self.status_reason),
         }
 
     def as_json(self):

--- a/kytos/core/switch.py
+++ b/kytos/core/switch.py
@@ -383,23 +383,28 @@ class Switch(GenericEntity):
             port = self.connection.port
             connection = f"{address}:{port}"
 
-        return {'id': self.id,
-                'name': self.id,
-                'dpid': self.dpid,
-                'connection': connection,
-                'ofp_version': self.ofp_version,
-                'type': 'switch',
-                'manufacturer': self.description.get('manufacturer', ''),
-                'serial': self.description.get('serial', ''),
-                'hardware': self.description.get('hardware', ''),
-                'software': self.description.get('software'),
-                'data_path': self.description.get('data_path', ''),
-                'interfaces': {i.id: i.as_dict()
-                               for i in self.interfaces.values()},
-                'metadata': self.metadata,
-                'active': self.is_active(),
-                'enabled': self.is_enabled(),
-                'status': self.status.value}
+        return {
+            'id': self.id,
+            'name': self.id,
+            'dpid': self.dpid,
+            'connection': connection,
+            'ofp_version': self.ofp_version,
+            'type': 'switch',
+            'manufacturer': self.description.get('manufacturer', ''),
+            'serial': self.description.get('serial', ''),
+            'hardware': self.description.get('hardware', ''),
+            'software': self.description.get('software'),
+            'data_path': self.description.get('data_path', ''),
+            'interfaces': {
+                i.id: i.as_dict()
+                for i in self.interfaces.values()
+            },
+            'metadata': self.metadata,
+            'active': self.is_active(),
+            'enabled': self.is_enabled(),
+            'status': self.status.value,
+            'status_reason': list(self.status_reason),
+        }
 
     def as_json(self):
         """Return JSON with switch's attributes.

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -301,12 +301,26 @@ class TestInterface(unittest.TestCase):
         self.iface.enable()
         self.iface.activate()
         assert self.iface.is_active()
-        Interface.register_status_func("some_napp_some_func",
-                                       lambda iface: EntityStatus.DOWN)
+        Interface.register_status_func(
+            "some_napp_some_func",
+            lambda iface: EntityStatus.DOWN
+        )
+        Interface.register_status_reason_func(
+            "some_napp_some_func",
+            lambda iface: {'test_status'}
+        )
         assert self.iface.status == EntityStatus.DOWN
-        Interface.register_status_func("some_napp_some_func",
-                                       lambda iface: None)
+        assert self.iface.status_reason == {'test_status'}
+        Interface.register_status_func(
+            "some_napp_some_func",
+            lambda iface: None
+        )
+        Interface.register_status_reason_func(
+            "some_napp_some_func",
+            lambda iface: set()
+        )
         assert self.iface.status == EntityStatus.UP
+        assert self.iface.status_reason == set()
 
 
 class TestUNI(unittest.TestCase):

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -94,8 +94,14 @@ class TestLink(unittest.TestCase):
     def test_status_funcs(self) -> None:
         """Test status_funcs."""
         # If it's enabled and active but a func returns DOWN, then DOWN
-        Link.register_status_func("some_napp_some_func",
-                                  lambda link: EntityStatus.DOWN)
+        Link.register_status_func(
+            "some_napp_some_func",
+            lambda link: EntityStatus.DOWN
+        )
+        Link.register_status_reason_func(
+            "some_napp_some_func",
+            lambda link: {'test_status'}
+        )
         for intf in (self.iface1, self.iface2):
             intf.enable()
             intf.activate()
@@ -103,34 +109,69 @@ class TestLink(unittest.TestCase):
         link.enable()
         link.activate()
         assert link.status == EntityStatus.DOWN
+        assert link.status_reason == {'test_status'}
 
         # No changes in status if it returns None
-        Link.register_status_func("some_napp_some_func",
-                                  lambda link: None)
+        Link.register_status_func(
+            "some_napp_some_func",
+            lambda link: None
+        )
+        Link.register_status_reason_func(
+            "some_napp_some_func",
+            lambda link: set()
+        )
         assert link.status == EntityStatus.UP
+        assert link.status_reason == set()
 
         # If it's deactivated then it shouldn't be able to make it go UP
         link.deactivate()
         assert link.status == EntityStatus.DOWN
-        Link.register_status_func("some_napp_some_func",
-                                  lambda link: EntityStatus.UP)
+        Link.register_status_func(
+            "some_napp_some_func",
+            lambda link: EntityStatus.UP
+        )
+        Link.register_status_reason_func(
+            "some_napp_some_func",
+            lambda link: set()
+        )
         assert link.status == EntityStatus.DOWN
+        assert link.status_reason == {'deactivated'}
         link.activate()
         assert link.status == EntityStatus.UP
+        assert link.status_reason == set()
 
         # If it's disabled, then it shouldn't be considered DOWN
         link.disable()
-        Link.register_status_func("some_napp_some_func",
-                                  lambda link: EntityStatus.DOWN)
+        Link.register_status_func(
+            "some_napp_some_func",
+            lambda link: EntityStatus.DOWN
+        )
+        Link.register_status_reason_func(
+            "some_napp_some_func",
+            lambda link: {'test_status'}
+        )
         assert link.status == EntityStatus.DISABLED
+        assert link.status_reason == {'test_status', 'disabled'}
 
     def test_multiple_status_funcs(self) -> None:
         """Test multiple status_funcs."""
         # If it's enabled and active but a func returns DOWN, then DOWN
-        Link.register_status_func("some_napp_some_func",
-                                  lambda link: None)
-        Link.register_status_func("some_napp_another_func",
-                                  lambda link: EntityStatus.DOWN)
+        Link.register_status_func(
+            "some_napp_some_func",
+            lambda link: None
+        )
+        Link.register_status_reason_func(
+            'some_napp_some_func',
+            lambda link: set()
+        )
+        Link.register_status_func(
+            "some_napp_another_func",
+            lambda link: EntityStatus.DOWN
+        )
+        Link.register_status_reason_func(
+            'some_napp_another_func',
+            lambda link: {'test_status2'}
+        )
         for intf in (self.iface1, self.iface2):
             intf.enable()
             intf.activate()
@@ -138,11 +179,19 @@ class TestLink(unittest.TestCase):
         link.enable()
         link.activate()
         assert link.status == EntityStatus.DOWN
+        assert link.status_reason == {'test_status2'}
 
         # It should be UP if the func no longer returns DOWN
-        Link.register_status_func("some_napp_another_func",
-                                  lambda link: None)
+        Link.register_status_func(
+            "some_napp_another_func",
+            lambda link: None
+        )
+        Link.register_status_reason_func(
+            'some_napp_another_func',
+            lambda link: set()
+        )
         assert link.status == EntityStatus.UP
+        assert link.status_reason == set()
 
     def test_available_tags(self):
         """Test available_tags property."""

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -330,44 +330,30 @@ class TestSwitch(TestCase):
         self.assertIsNone(expected_ports_1)
         self.assertEqual(expected_ports_2, [1, 2, 3])
 
-    def test_as_dict(self):
-        """Test as_dict method."""
-        expected_dict = {'id': '00:00:00:00:00:00:00:01',
-                         'name': '00:00:00:00:00:00:00:01',
-                         'dpid': '00:00:00:00:00:00:00:01',
-                         'connection': 'addr:port',
-                         'ofp_version': '0x04',
-                         'type': 'switch',
-                         'manufacturer': '',
-                         'serial': '',
-                         'hardware': '',
-                         'software': None,
-                         'data_path': '',
-                         'interfaces': {},
-                         'metadata': {},
-                         'active': True,
-                         'enabled': True,
-                         'status': 'UP'}
+    def test_as_dict_as_json(self):
+        """Test as_dict and as_json method."""
+        expected_dict = {
+            'id': '00:00:00:00:00:00:00:01',
+            'name': '00:00:00:00:00:00:00:01',
+            'dpid': '00:00:00:00:00:00:00:01',
+            'connection': 'addr:port',
+            'ofp_version': '0x04',
+            'type': 'switch',
+            'manufacturer': '',
+            'serial': '',
+            'hardware': '',
+            'software': None,
+            'data_path': '',
+            'interfaces': {},
+            'metadata': {},
+            'active': True,
+            'enabled': True,
+            'status': 'UP',
+            'status_reason': []
+        }
         self.assertEqual(self.switch.as_dict(), expected_dict)
 
-    def test_as_json(self):
-        """Test as_json method."""
-        expected_json = json.dumps({'id': '00:00:00:00:00:00:00:01',
-                                    'name': '00:00:00:00:00:00:00:01',
-                                    'dpid': '00:00:00:00:00:00:00:01',
-                                    'connection': 'addr:port',
-                                    'ofp_version': '0x04',
-                                    'type': 'switch',
-                                    'manufacturer': '',
-                                    'serial': '',
-                                    'hardware': '',
-                                    'software': None,
-                                    'data_path': '',
-                                    'interfaces': {},
-                                    'metadata': {},
-                                    'active': True,
-                                    'enabled': True,
-                                    'status': 'UP'})
+        expected_json = json.dumps(expected_dict)
 
         self.assertEqual(self.switch.as_json(), expected_json)
 

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -385,9 +385,23 @@ class TestSwitch(TestCase):
         self.switch.enable()
         self.switch.activate()
         assert self.switch.is_active()
-        Switch.register_status_func("some_napp_some_func",
-                                    lambda switch: EntityStatus.DOWN)
+        Switch.register_status_func(
+            "some_napp_some_func",
+            lambda switch: EntityStatus.DOWN
+        )
+        Switch.register_status_reason_func(
+            "some_napp_some_func",
+            lambda iface: {'test_status'}
+        )
         assert self.switch.status == EntityStatus.DOWN
-        Switch.register_status_func("some_napp_some_func",
-                                    lambda iface: None)
+        assert self.switch.status_reason == {'test_status'}
+        Switch.register_status_func(
+            "some_napp_some_func",
+            lambda iface: None
+        )
+        Switch.register_status_reason_func(
+            "some_napp_some_func",
+            lambda iface: set()
+        )
         assert self.switch.status == EntityStatus.UP
+        assert self.switch.status_reason == set()


### PR DESCRIPTION
To comply with the blueprint being added by the kytos-ng/kytos#356, this PR adds in `status_reason` to `Link`, `Interface`, and `Switch`. Additionally, this PR updates all tests using `register_status_func` and `status` to also test `register_status_reason_func` and `status_reason`.