### PR TITLE
Moved error_msg to rest_api.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed
 - Updated APM to instrument ``starlette``
 - HTTP API exceptions responses no longer include the ``"name"`` key name in the response, only ``"code"``  and ``"description"`` still remain
 - Development ``get_test_client`` now uses a ``htppx.AsyncClient`` instance
+- Moved ``error_msg()`` to ``kytos.core.rest_api`` so it can be used in any NApp
 
 Fixed
 =====

--- a/kytos/core/rest_api.py
+++ b/kytos/core/rest_api.py
@@ -72,6 +72,17 @@ def content_type_json_or_415(request: Request) -> Optional[str]:
     return content_type
 
 
+def error_msg(error_list: list) -> str:
+    """Return a more request friendly error message from ValidationError"""
+    msg = ""
+    for err in error_list:
+        for value in err['loc']:
+            msg += str(value) + ", "
+        msg = msg[:-2]
+        msg += ": " + err["msg"] + "; "
+    return msg[:-2]
+
+
 class JSONResponse(StarletteJSONResponse):
     """JSONResponse with custom default serializer that supports datetime."""
 

--- a/tests/unit/test_core/test_auth.py
+++ b/tests/unit/test_core/test_auth.py
@@ -225,12 +225,3 @@ class TestAuth:
         with pytest.raises(HTTPException):
             # pylint: disable=protected-access
             auth._find_user("name")
-
-    def test_08_error_msg(self, auth):
-        """Test error_msg"""
-        # ValidationErro mocked response
-        error_list = [{'loc': ('username', ), 'msg': 'mock_msg_1'},
-                      {'loc': ('email', ), 'msg': 'mock_msg_2'}]
-        actual_msg = auth.error_msg(error_list)
-        expected_msg = 'username: mock_msg_1; email: mock_msg_2'
-        assert actual_msg == expected_msg

--- a/tests/unit/test_core/test_auth.py
+++ b/tests/unit/test_core/test_auth.py
@@ -4,8 +4,7 @@ import base64
 import pytest
 from httpx import AsyncClient
 # pylint: disable=no-name-in-module,attribute-defined-outside-init
-from pydantic import BaseModel, EmailError, ValidationError
-from pydantic.error_wrappers import ErrorWrapper
+from pydantic import BaseModel, ValidationError
 from pymongo.errors import DuplicateKeyError
 
 from kytos.core.auth import Auth
@@ -132,19 +131,12 @@ class TestAuth:
     ):
         """Test auth create user endpoint."""
         auth.controller.loop = event_loop
-        self.user_data["email"] = "wrong_email"
-        exc = ValidationError(
-            [ErrorWrapper(exc=EmailError(), loc=('email',))],
-            BaseModel
-        )
-        auth.user_controller.create_user.side_effect = exc
+        data = "wrong_json"
         endpoint = "kytos/core/auth/users"
         headers = await self.auth_headers(auth, api_client)
-        resp = await api_client.post(endpoint, json=self.user_data,
+        resp = await api_client.post(endpoint, json=data,
                                      headers=headers)
         assert resp.status_code == 400
-        description = resp.json()['description']
-        assert description == 'email: value is not a valid email address'
 
     async def test_04_list_user_request(self, auth, api_client):
         """Test auth list user endpoint."""

--- a/tests/unit/test_core/test_rest_api_routes.py
+++ b/tests/unit/test_core/test_rest_api_routes.py
@@ -1,6 +1,11 @@
 """Test kytos.core.rest_api routes."""
 import asyncio
+from unittest.mock import MagicMock
 
+import pytest
+from pydantic import ValidationError
+
+from kytos.core.auth import UserController
 from kytos.core.config import KytosConfig
 from kytos.core.rest_api import (JSONResponse, Request, aget_json_or_400,
                                  error_msg, get_body, get_json_or_400)
@@ -78,10 +83,18 @@ async def test_get_json_or_400(controller, api_client, event_loop) -> None:
 
 async def test_error_msg():
     """Test error message"""
-    error_list = [{'loc': ('username', ), 'msg': 'mock_msg_1'},
-                  {'loc': ('email', ), 'msg': 'mock_msg_2'}]
-    actual_msg = error_msg(error_list)
-    expected_msg = 'username: mock_msg_1; email: mock_msg_2'
+    user = UserController(MagicMock())
+    user_data = {
+        "username": "test",
+        "password": "password",
+        "email": "test@kytos.io"
+    }
+    with pytest.raises(ValidationError) as err:
+        user.create_user(user_data)
+    actual_msg = error_msg(err.value.errors())
+    expected_msg = 'password: value should contain minimun 8 characters, ' \
+                   'at least one upper case character, at least 1 ' \
+                   'numeric character [0-9]'
     assert actual_msg == expected_msg
 
 

--- a/tests/unit/test_core/test_rest_api_routes.py
+++ b/tests/unit/test_core/test_rest_api_routes.py
@@ -78,9 +78,10 @@ async def test_get_json_or_400(controller, api_client, event_loop) -> None:
 
 async def test_error_msg():
     """Test error message"""
-    error_list = [{'loc': ('table_id', ), 'msg': 'mock_msg_1'}]
+    error_list = [{'loc': ('username', ), 'msg': 'mock_msg_1'},
+                  {'loc': ('email', ), 'msg': 'mock_msg_2'}]
     actual_msg = error_msg(error_list)
-    expected_msg = 'table_id: mock_msg_1'
+    expected_msg = 'username: mock_msg_1; email: mock_msg_2'
     assert actual_msg == expected_msg
 
 

--- a/tests/unit/test_core/test_rest_api_routes.py
+++ b/tests/unit/test_core/test_rest_api_routes.py
@@ -3,7 +3,7 @@ import asyncio
 
 from kytos.core.config import KytosConfig
 from kytos.core.rest_api import (JSONResponse, Request, aget_json_or_400,
-                                 get_body, get_json_or_400)
+                                 error_msg, get_body, get_json_or_400)
 
 
 async def test_new_endpoint(controller, api_client) -> None:
@@ -74,6 +74,14 @@ async def test_get_json_or_400(controller, api_client, event_loop) -> None:
     response = await api_client.post(f"kytos/core/{endpoint}", json=body)
     assert response.status_code == 200
     assert response.json() == body
+
+
+async def test_error_msg():
+    """Test error message"""
+    error_list = [{'loc': ('table_id', ), 'msg': 'mock_msg_1'}]
+    actual_msg = error_msg(error_list)
+    expected_msg = 'table_id: mock_msg_1'
+    assert actual_msg == expected_msg
 
 
 async def test_get_body(controller, api_client, event_loop) -> None:


### PR DESCRIPTION
Closes #377 

### Summary

Moved `error_msg()` to `rest_api.py` so other NApps can use it.

### Local Tests
Recreate error when creating a user