### PR TITLE
fix: pinned typing-extensions==4.5.0 to be compatible with pydantic

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -446,7 +446,7 @@ traitlets==5.3.0
     #   ipython
     #   kytos
     #   matplotlib-inline
-typing-extensions>=4.0.1
+typing-extensions==4.5.0
     # via
     #   -r requirements/run.txt
     #   astroid

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -161,7 +161,7 @@ traitlets==5.3.0
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions>=4.0.1
+typing-extensions==4.5.0
     # via
     #   janus
     #   jsonschema-spec

--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,8 @@ setup(name='kytos',
           'pycodestyle==2.10.0',
           'yala==3.2.0',
           'tox==3.28.0',
-          'virtualenv==20.21.0'
+          'virtualenv==20.21.0',
+          'typing-extensions==4.5.0'
       ]},
       cmdclass={
           'clean': Cleaner,


### PR DESCRIPTION
Closes #386 

### Summary

- Pinned `typing-extensions==4.5.0` to be compatible with pydantic, check out issue #386 for more information.
- Included `typing-extensions==4.5.0` on `setup.py` `[dev]` just so NApps also get this transitive dependency pinned too

### Local Tests

- `tox`:

```
  py39: commands succeeded
  coverage: commands succeeded
  lint: commands succeeded
  congratulations :)
```

- `tox` on `mef_eline` temporarily using this `kytos` branch of this PR:

```
________________________________________________________________________________________ summary _________________________________________________________________________________________
  coverage: commands succeeded
  lint: commands succeeded
  congratulations :)
```

### End-to-End Tests

Not needed for this change
