### PR TITLE
feat: included link.id on its `__repr__ `

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed
 - HTTP API exceptions responses no longer include the ``"name"`` key name in the response, only ``"code"``  and ``"description"`` still remain
 - Development ``get_test_client`` now uses a ``htppx.AsyncClient`` instance
 - Moved ``error_msg()`` to ``kytos.core.rest_api`` so it can be used in any NApp
+- ``Link`` now includes its ``id`` on its string format representation to facilitate correlating events in the logs
 
 Fixed
 =====

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -38,7 +38,7 @@ class Link(GenericEntity):
         return hash(self.id)
 
     def __repr__(self):
-        return f"Link({self.endpoint_a!r}, {self.endpoint_b!r})"
+        return f"Link({self.endpoint_a!r}, {self.endpoint_b!r}, {self.id})"
 
     @classmethod
     def register_status_func(cls, name: str, func):

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -49,7 +49,8 @@ class TestLink(unittest.TestCase):
         """Test __repr__ method."""
         link = Link(self.iface1, self.iface2)
         expected = ("Link(Interface('interface1', 41, Switch('dpid1')), "
-                    "Interface('interface2', 42, Switch('dpid2')))")
+                    "Interface('interface2', 42, Switch('dpid2')), "
+                    f"{link.id})")
         self.assertEqual(repr(link), expected)
 
     def test_id(self):


### PR DESCRIPTION
Closes https://github.com/kytos-ng/topology/issues/120

### Summary

See updated changelog file

### Local Tests

- Simulated `link` up and down, and also enabled liveness to confirm the new `__repr__` would should up as expected:

```
2023-05-26 14:42:41,318 - INFO [kytos.napps.kytos/topology] [main.py:591:handle_link_liveness_status] (thread_pool_app_21) Link liveness up: Link(Interface('s3-eth2', 2, Switch('00:00:00:00:00:00:00:03')), Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
2023-05-26 14:42:41,324 - INFO [kytos.napps.kytos/topology] [main.py:591:handle_link_liveness_status] (thread_pool_app_14) Link liveness up: Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2023-05-26 14:42:41,326 - INFO [kytos.napps.kytos/topology] [main.py:591:handle_link_liveness_status] (thread_pool_app_8) Link liveness up: Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01')), Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)

2023-05-26 14:42:51,143 - INFO [kytos.napps.kytos/mef_eline] [main.py:706:handle_link_down] (thread_pool_app_13) Event handle_link_down Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2023-05-26 14:42:52,355 - INFO [kytos.napps.kytos/of_core] [main.py:705:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE
2023-05-26 14:42:52,356 - INFO [kytos.napps.kytos/of_core] [main.py:705:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2023-05-26 14:42:54,387 - INFO [kytos.napps.kytos/mef_eline] [main.py:692:handle_link_up] (thread_pool_app_8) Event handle_link_up Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)


```

### End-to-End Tests

Not needed