### PR TITLE
feat: Add `uptime` in `status_api`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changed
 - Development ``get_test_client`` now uses a ``htppx.AsyncClient`` instance
 - Moved ``error_msg()`` to ``kytos.core.rest_api`` so it can be used in any NApp
 - ``Link`` now includes its ``id`` on its string format representation to facilitate correlating events in the logs
+- Updated ``status_api`` to include when the APIServer started and how much time has elapsed. 
 
 Fixed
 =====

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -150,7 +150,7 @@ class APIServer:
         response = {
             "response": "running",
             "started_at": self.napps_manager._controller.started_at,
-            "uptime_seconds": uptime.second if uptime else 0,
+            "uptime_seconds": uptime.seconds if uptime else 0,
         }
         return JSONResponse(response)
 

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -146,10 +146,11 @@ class APIServer:
 
     def status_api(self, _request: Request):
         """Display kytos status using the route ``/kytos/status/``."""
+        uptime = self.napps_manager._controller.uptime()
         response = {
             "response": "running",
             "started_at": self.napps_manager._controller.started_at,
-            "uptime_seconds": self.napps_manager._controller.uptime()
+            "uptime_seconds": uptime.second if uptime else 0,
         }
         return JSONResponse(response)
 

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -146,7 +146,12 @@ class APIServer:
 
     def status_api(self, _request: Request):
         """Display kytos status using the route ``/kytos/status/``."""
-        return JSONResponse({"response": "running"})
+        response = {
+            "response": "running",
+            "started_at": self.napps_manager._controller.started_at,
+            "uptime_seconds": self.napps_manager._controller.uptime()
+        }
+        return JSONResponse(response)
 
     def static_web_ui(self,
                       request: Request) -> Union[FileResponse, JSONResponse]:

--- a/tests/unit/test_core/test_api_server.py
+++ b/tests/unit/test_core/test_api_server.py
@@ -60,8 +60,9 @@ class TestAPIServer:
 
     async def test_status_api(self):
         """Test status_api method."""
-        started_at = 1.0
-        uptime = datetime.now(timezone.utc)
+        started_at = datetime.fromtimestamp(1.0, timezone.utc)
+        now = datetime.now(timezone.utc)
+        uptime = now - started_at
         self.napps_manager._controller.uptime.return_value = uptime
         self.napps_manager._controller.started_at = started_at
         response = await self.client.get("status/")
@@ -69,8 +70,8 @@ class TestAPIServer:
         response = response.json()
         expected = {
             "response": "running",
-            "started_at": started_at,
-            "uptime_seconds": uptime.second,
+            "started_at": started_at.isoformat(),
+            "uptime_seconds": uptime.seconds,
         }
         assert response == expected
 

--- a/tests/unit/test_core/test_api_server.py
+++ b/tests/unit/test_core/test_api_server.py
@@ -60,9 +60,18 @@ class TestAPIServer:
 
     async def test_status_api(self):
         """Test status_api method."""
+        self.napps_manager._controller.uptime.return_value = 1
+        self.napps_manager._controller.started_at = 0.1
         response = await self.client.get("status/")
-        assert response.status_code == 200
-        assert response.json() == {"response": "running"}
+
+        assert response.status_code == 200, response.text
+        response = response.json()
+        expected = {
+            "response": "running",
+            "started_at": 0.1,
+            "uptime_seconds": 1
+        }
+        assert response == expected
 
     def test_stop(self):
         """Test stop method."""

--- a/tests/unit/test_core/test_api_server.py
+++ b/tests/unit/test_core/test_api_server.py
@@ -2,7 +2,7 @@
 import asyncio
 import json
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 # Disable not-grouped imports that conflicts with isort
 from unittest.mock import AsyncMock, MagicMock
 from urllib.error import HTTPError, URLError
@@ -60,16 +60,17 @@ class TestAPIServer:
 
     async def test_status_api(self):
         """Test status_api method."""
-        self.napps_manager._controller.uptime.return_value = 1
-        self.napps_manager._controller.started_at = 0.1
+        started_at = 1.0
+        uptime = datetime.now(timezone.utc)
+        self.napps_manager._controller.uptime.return_value = uptime
+        self.napps_manager._controller.started_at = started_at
         response = await self.client.get("status/")
-
         assert response.status_code == 200, response.text
         response = response.json()
         expected = {
             "response": "running",
-            "started_at": 0.1,
-            "uptime_seconds": 1
+            "started_at": started_at,
+            "uptime_seconds": uptime.second,
         }
         assert response == expected
 


### PR DESCRIPTION
Closes [issue #7 of `kytos_stats](https://github.com/kytos-ng/kytos_stats/issues/7#issuecomment-1608114648)

### Summary

This PR augments the core endpoint GET `/status` to include when the APIServer started and how much time has elapsed.

### Local Tests


### End-to-End Tests

N/A