### PR TITLE
Changed KytosEvent into a dataclass with type annotations

### DIFF
--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -12,8 +12,24 @@ from kytos.core.helpers import now
 class KytosEvent:
     """Base Event class.
 
-    The event data will be passed in the `content` attribute, which should be a
-    dictionary.
+    Args:
+        `name`:
+            The name of the event. You should prepend it with
+            the name of the napp.
+
+        `content`:
+            Dictionary with any extra data for the event.
+
+        `trace_parent`:
+            APM TraceParent for distributed tracing,
+            if you have APM enabled, `@listen_to` will
+            set the root parent, and then you have to
+            pass the trace_parent to subsequent
+            correlated KytosEvent(s).
+
+        `priority`:
+            Priority of this event if a `PriorityQueue` is being
+            used, the lower the number the higher the priority.
     """
 
     name: str

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -7,7 +7,7 @@ from uuid import UUID, uuid4
 from kytos.core.helpers import now
 
 
-@dataclass(slots=True)
+@dataclass
 class KytosEvent:
     """Base Event class.
 

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -1,8 +1,9 @@
 """Module with Kytos Events."""
 import json
-from dataclasses import dataclass, field
 from datetime import datetime
 from uuid import UUID, uuid4
+
+from pydantic.dataclasses import Field, dataclass
 
 from kytos.core.helpers import now
 
@@ -16,15 +17,15 @@ class KytosEvent:
     """
 
     name: str
-    content: dict = field(default_factory=dict)
-    trace_parent: object = field(default=None)
-    priority: int = field(default=0)
+    content: dict = Field(default_factory=dict)
+    trace_parent: object = Field(default=None)
+    priority: int = Field(default=0)
 
     # pylint: disable=invalid-name
-    id: UUID = field(default_factory=uuid4)
+    id: UUID = Field(default_factory=uuid4)
     # pylint: enable=invalid-name
-    timestamp: datetime = field(default_factory=now)
-    reinjections: int = field(default=0)
+    timestamp: datetime = Field(default_factory=now)
+    reinjections: int = Field(default=0)
 
     def __str__(self):
         return self.name

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -1,11 +1,13 @@
 """Module with Kytos Events."""
 import json
+from dataclasses import dataclass, field
 from datetime import datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from kytos.core.helpers import now
 
 
+@dataclass(slots=True)
 class KytosEvent:
     """Base Event class.
 
@@ -13,30 +15,14 @@ class KytosEvent:
     dictionary.
     """
 
-    def __init__(self, name=None, content=None, trace_parent=None, priority=0):
-        """Create an event to be published.
+    name: str
+    content: dict = field(default_factory=dict)
+    trace_parent: object = field(default=None)
+    priority: int = field(default=0)
 
-        Args:
-            name (string): The name of the event. You should prepend it with
-                           the name of the napp.
-            content (dict): Dictionary with any extra data for the event.
-            trace_parent (object): APM TraceParent for distributed tracing,
-                                   if you have APM enabled, @listen_to will
-                                   set the root parent, and then you have to
-                                   pass the trace_parent to subsequent
-                                   correlated KytosEvent(s).
-            priority (int): Priority of this event if a PriorityQueue is being
-                            used, the lower the number the higher the priority.
-        """
-        self.name = name
-        self.content = content if content is not None else {}
-        self.timestamp = now()
-        self.reinjections = 0
-        self.priority = priority
-
-        # pylint: disable=invalid-name
-        self.id = uuid4()
-        self.trace_parent = trace_parent
+    id: UUID = field(default_factory=uuid4)
+    timestamp: datetime = field(default_factory=now)
+    reinjections: int = field(default=0)
 
     def __str__(self):
         return self.name

--- a/kytos/core/events.py
+++ b/kytos/core/events.py
@@ -20,7 +20,9 @@ class KytosEvent:
     trace_parent: object = field(default=None)
     priority: int = field(default=0)
 
+    # pylint: disable=invalid-name
     id: UUID = field(default_factory=uuid4)
+    # pylint: enable=invalid-name
     timestamp: datetime = field(default_factory=now)
     reinjections: int = field(default=0)
 

--- a/tests/unit/test_core/test_buffers.py
+++ b/tests/unit/test_core/test_buffers.py
@@ -16,7 +16,7 @@ async def test_priority_queues(queue_name):
     prios = [-10, 10, 0, -20]
     for prio in prios:
         queue = getattr(buffers, queue_name)
-        await queue.aput(KytosEvent(priority=prio))
+        await queue.aput(KytosEvent('test', priority=prio))
     for prio in sorted(prios):
         event = await queue.aget()
         assert event.priority == prio

--- a/tests/unit/test_core/test_events.py
+++ b/tests/unit/test_core/test_events.py
@@ -64,7 +64,9 @@ class TestKytosEvent(TestCase):
     def test_init_attrs(self):
         """Test init attrs."""
         assert self.event.name == "kytos/core.any"
+        # pylint: disable=use-implicit-booleaness-not-comparison
         assert self.event.content == {}
+        # pylint: enable=use-implicit-booleaness-not-comparison
         assert self.event.timestamp <= datetime.now(timezone.utc)
         assert self.event.id and isinstance(self.event.id, UUID)
         assert self.event.reinjections == 0


### PR DESCRIPTION
### Summary

This converts KytosEvent into a dataclass with type annotations. Additionally it changes it so that it is now considered a bug for an event to not have a `name` set.

### Local Tests

Seems to work correctly. Can create evcs and have them interrupted by maintenance windows.

### End To End Tests

These seem to fail pretty badly, and I don't understand what's going on here.

```
kytos-end-to-end-tests-kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-end-to-end-tests-kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-end-to-end-tests-kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-end-to-end-tests-kytos-1  | Starting ovsdb-server.
kytos-end-to-end-tests-kytos-1  | Configuring Open vSwitch system IDs.
kytos-end-to-end-tests-kytos-1  | Starting ovs-vswitchd.
kytos-end-to-end-tests-kytos-1  | Enabling remote OVSDB managers.
kytos-end-to-end-tests-kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + kytosd --help
kytos-end-to-end-tests-kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-end-to-end-tests-kytos-1  | + test -z ''
kytos-end-to-end-tests-kytos-1  | + TESTS=tests/
kytos-end-to-end-tests-kytos-1  | + test -z ''
kytos-end-to-end-tests-kytos-1  | + RERUNS=2
kytos-end-to-end-tests-kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-end-to-end-tests-kytos-1  | Trying to run hello command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-end-to-end-tests-kytos-1  | + python3 -m pytest tests/ --reruns 2 -r fEr
kytos-end-to-end-tests-kytos-1  | ============================= test session starts ==============================
kytos-end-to-end-tests-kytos-1  | platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.2.0
kytos-end-to-end-tests-kytos-1  | rootdir: /tests
kytos-end-to-end-tests-kytos-1  | plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
kytos-end-to-end-tests-kytos-1  | collected 239 items
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_05_topology.py ..RRF.RRF.RRF.RRF.RRFRRFRRFRRF....         [  8%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_10_mef_eline.py .RRFRRFRRFRRFRRFRRFRRFRRFRRFssRRFRRF...x. [ 16%]
kytos-end-to-end-tests-kytos-1  | RRFRRFRRF.xRRFRRFRRFRRF.RRFRRFRRFRRFRRF..RRF...                          [ 25%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_11_mef_eline.py RRFRRFRRFRRF..                            [ 27%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_12_mef_eline.py ....RRFXxRRF                              [ 30%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.xxxxRRFxxxx.RRFXRRF.. [ 45%]
kytos-end-to-end-tests-kytos-1  | .........                                                                [ 49%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_14_mef_eline.py x                                         [ 49%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_15_mef_eline.py RRFRRF                                    [ 50%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_20_flow_manager.py RRFRRFRRF..RRFRRFRRFRRFRRFRRFRRFRRFRRF [ 56%]
kytos-end-to-end-tests-kytos-1  | RRFRRFRRFRRFRRFRRFRRF                                                    [ 59%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_21_flow_manager.py RRFRRFRRF                              [ 60%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_23_flow_manager.py RRFRRFRRFRRFRRFRRFRRFRRFRRFRRFRRFRRFRR [ 72%]
kytos-end-to-end-tests-kytos-1  | FRRF                                                                     [ 72%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_30_of_lldp.py .RRFRRF.                                    [ 74%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_31_of_lldp.py RRFRRFRRF                                   [ 75%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_32_of_lldp.py RRF..                                       [ 76%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_40_sdntrace.py RRERRERRERRERRERRERRERRERRERRERRE          [ 81%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_50_maintenance.py .RRF....RRF.RRFRRF..RRFRRFRRF.RRF.RRFRR [ 93%]
kytos-end-to-end-tests-kytos-1  | FRRFRRFRRFRRF                                                            [ 94%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_60_of_multi_table.py RRFRRFRRFRRF.                        [ 97%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_70_kytos_stats.py RRFRRFRRFRRFRRFRRFR                     [100%]R [100%]F [100%]
kytos-end-to-end-tests-kytos-1  | 
```