### PR TITLE
feature: Refactored `Interface.available_tags`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Changed
 
 Deprecated
 ==========
-- Deleted ``vlan_pool`` in favor of ``Interface.tag_ranges``
+- Deleted ``vlan_pool`` from ``kytos.conf`` in favor of ``Interface.tag_ranges`` which updates from ``kytos/topology`` API endpoint, ``v3/interfaces/{intf_id}/tag_ranges``.
 
 [2023.1.0] - 2023-06-05
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,19 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Added
+=====
+- Added ``Interface.tag_ranges`` as ``dict[str, list[list[int]]]`` as replacement for ``vlan_pool`` settings.
+- Added ``kytos/core.interface_tags`` event publication to notify any modification of ``Interface.tag_ranges`` or ``Interface.available_tags``.
+
+Changed
+=======
+- Change format for ``Interface.available_tags`` to ``dict[str, list[list[int]]]``. Storing ``tag_types`` as keys and a list of ranges for ``available_tags`` as values.
+
+Deprecated
+==========
+- Deleted ``vlan_pool`` in favor of ``Interface.tag_ranges``
+
 [2023.1.0] - 2023-06-05
 ***********************
 

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -145,7 +145,6 @@ class KytosConfig():
                     'enable_entities_by_default': False,
                     'napps_pre_installed': [],
                     'authenticate_urls': [],
-                    'vlan_pool': {},
                     'token_expiration_minutes': 180,
                     'thread_pool_max_workers': {},
                     'database': '',
@@ -206,7 +205,6 @@ class KytosConfig():
 
         options.logger_decorators = _parse_json(options.logger_decorators)
         options.napps_pre_installed = _parse_json(options.napps_pre_installed)
-        options.vlan_pool = _parse_json(options.vlan_pool)
         options.authenticate_urls = _parse_json(options.authenticate_urls)
         thread_pool_max_workers = options.thread_pool_max_workers
         options.thread_pool_max_workers = _parse_json(thread_pool_max_workers)

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -42,7 +42,6 @@ from kytos.core.dead_letter import DeadLetter
 from kytos.core.events import KytosEvent
 from kytos.core.exceptions import KytosAPMInitException, KytosDBInitException
 from kytos.core.helpers import executors, now
-from kytos.core.interface import Interface
 from kytos.core.logs import LogManager
 from kytos.core.napps.base import NApp
 from kytos.core.napps.manager import NAppsManager
@@ -678,8 +677,6 @@ class Controller:
                 event_name += 'new'
             else:
                 event_name += 'reconnected'
-
-            self.set_switch_options(dpid=dpid)
             event = KytosEvent(name=event_name, content={'switch': switch})
 
             if connection:
@@ -692,37 +689,6 @@ class Controller:
             self.buffers.app.put(event)
 
             return switch
-
-    def set_switch_options(self, dpid):
-        """Update the switch settings based on kytos.conf options.
-
-        Args:
-            dpid (str): dpid used to identify a switch.
-
-        """
-        switch = self.switches.get(dpid)
-        if not switch:
-            return
-
-        vlan_pool = {}
-        vlan_pool = self.options.vlan_pool
-        if not vlan_pool:
-            return
-
-        if vlan_pool.get(dpid):
-            self.log.info("Loading vlan_pool configuration for dpid %s", dpid)
-            for intf_num, port_list in vlan_pool[dpid].items():
-                if not switch.interfaces.get((intf_num)):
-                    vlan_ids = set()
-                    for vlan_range in port_list:
-                        (vlan_begin, vlan_end) = (vlan_range[0:2])
-                        for vlan_id in range(vlan_begin, vlan_end):
-                            vlan_ids.add(vlan_id)
-                    intf_num = int(intf_num)
-                    intf = Interface(name=intf_num, port_number=intf_num,
-                                     switch=switch)
-                    intf.set_available_tags(vlan_ids)
-                    switch.update_interface(intf)
 
     def create_or_update_connection(self, connection):
         """Update a connection.

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -77,6 +77,10 @@ class KytosNoTagAvailableError(Exception):
         return msg
 
 
+class KytosResizingAvailableTagError(Exception):
+    """Exception raised when available_tag cannot be resized"""
+
+
 class KytosLinkCreationError(Exception):
     """Exception thrown when the link has an empty endpoint."""
 

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -77,12 +77,16 @@ class KytosNoTagAvailableError(Exception):
         return msg
 
 
-class KytosResizingAvailableTagError(Exception):
+class KytosSetTagRangeError(Exception):
     """Exception raised when available_tag cannot be resized"""
 
 
 class KytosLinkCreationError(Exception):
     """Exception thrown when the link has an empty endpoint."""
+
+
+class KytosTagtypeNotSupported(Exception):
+    """Exception thronw when a not supported tag type is not supported"""
 
 
 # Exceptions related  to NApps

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from enum import Enum
 from functools import reduce
 from threading import Lock
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Union
 
 from pyof.v0x01.common.phy_port import Port as PortNo01
 from pyof.v0x01.common.phy_port import PortFeatures as PortFeatures01
@@ -357,7 +357,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
     def use_tags(
         self,
         controller,
-        tags: list[int],
+        tags: Union[int, list[int]],
         tag_type: str = 'vlan',
         use_lock: bool = True,
     ) -> bool:
@@ -370,6 +370,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             tag_type: TAG type value
             use_lock: Boolean to whether use a lock or not
         """
+        if isinstance(tags, int):
+            tags = [tags] * 2
         if use_lock:
             with self._tag_lock:
                 result = self.remove_tags(tags, tag_type)
@@ -449,7 +451,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
     def make_tags_available(
         self,
         controller,
-        tags: list[int],
+        tags: Union[int, list[int]],
         tag_type: str = 'vlan',
         use_lock: bool = True,
     ) -> bool:
@@ -461,6 +463,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             tag_type: TAG type value
             use_lock: Boolean to whether use a lock or not
         """
+        if isinstance(tags, int):
+            tags = [tags] * 2
         if use_lock:
             with self._tag_lock:
                 result = self.add_tags(tags, tag_type)

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -185,6 +185,34 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
     def range_intersection(
         ranges_a: list[list[int]],
         ranges_b: list[list[int]]
+    ) -> list[list[int]]:
+        """Returns the intersection between two list
+        of ranges"""
+        result = []
+        a_i, b_i = 0, 0
+        while a_i < len(ranges_a) and b_i < len(ranges_b):
+            fst_a, snd_a = ranges_a[a_i]
+            fst_b, snd_b = ranges_b[b_i]
+            # Moving forward with non-intersection
+            if snd_a < fst_b:
+                a_i += 1
+            elif snd_b < fst_a:
+                b_i += 1
+            else:
+                # Intersection
+                intersection_start = max(fst_a, fst_b)
+                intersection_end = min(snd_a, snd_b)
+                result.append([intersection_start, intersection_end])
+                if snd_a < snd_b:
+                    a_i += 1
+                else:
+                    b_i += 1
+        return result
+
+    @staticmethod
+    def range_intersection_first_tag(
+        ranges_a: list[list[int]],
+        ranges_b: list[list[int]]
     ) -> Optional[int]:
         """Returns an intersection tag between two list
         of ranges"""

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -64,17 +64,6 @@ napps_repositories = [
 # Use double quotes in each NApp in the list, e.g., ["username/napp"].
 napps_pre_installed = []
 
-# VLAN pool settings
-#
-# The VLAN pool settings is a dictionary of datapath id, which contains
-# a dictionary of of_port numbers with the respective vlan pool range
-# for each port number. See the example below, which sets the vlan range
-# [1, 5, 6, 7, 8, 9] on port 1 and vlan range [3] on port 4 of a switch
-# that has a dpid '00:00:00:00:00:00:00:01'
-
-vlan_pool = {}
-# vlan_pool = {"00:00:00:00:00:00:00:01": {"1": [[1, 2], [5, 10]], "4": [[3, 4]]}}
-
 # The jwt_secret parameter is responsible for signing JSON Web Tokens.
 jwt_secret = {{ jwt_secret }}
 

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -1,66 +1,69 @@
 """Interface tests."""
+# pylint: disable=attribute-defined-outside-init
 import logging
 import pickle
-import unittest
 from unittest.mock import MagicMock, Mock
 
+import pytest
 from pyof.v0x04.common.port import PortFeatures
 
 from kytos.core.common import EntityStatus
-from kytos.core.interface import TAG, UNI, Interface, TAGType
+from kytos.core.exceptions import (KytosSetTagRangeError,
+                                   KytosTagtypeNotSupported)
+from kytos.core.interface import TAG, UNI, Interface
 from kytos.core.switch import Switch
 
 logging.basicConfig(level=logging.CRITICAL)
 
 
-class TestTAG(unittest.TestCase):
+class TestTAG():
     """TAG tests."""
 
-    def setUp(self):
+    def setup_method(self):
         """Create TAG object."""
-        self.tag = TAG(1, 123)
+        self.tag = TAG('vlan', 123)
 
-    def test_from_dict(self):
+    async def test_from_dict(self):
         """Test from_dict method."""
-        tag_dict = {'tag_type': 2, 'value': 456}
+        tag_dict = {'tag_type': 'vlan_qinq', 'value': 456}
         tag = self.tag.from_dict(tag_dict)
 
-        self.assertEqual(tag.tag_type, 2)
-        self.assertEqual(tag.value, 456)
+        assert tag.tag_type == 'vlan_qinq'
+        assert tag.value == 456
 
-    def test_as_dict(self):
+    async def test_as_dict(self):
         """Test as_dict method."""
-        self.assertEqual(self.tag.as_dict(), {'tag_type': 1, 'value': 123})
+        assert self.tag.as_dict() == {'tag_type': 'vlan', 'value': 123}
 
-    def test_from_json(self):
+    async def test_from_json(self):
         """Test from_json method."""
-        tag_json = '{"tag_type": 2, "value": 456}'
+        tag_json = '{"tag_type": "vlan_qinq", "value": 456}'
         tag = self.tag.from_json(tag_json)
 
-        self.assertEqual(tag.tag_type, 2)
-        self.assertEqual(tag.value, 456)
+        assert tag.tag_type == "vlan_qinq"
+        assert tag.value == 456
 
-    def test_as_json(self):
+    async def test_as_json(self):
         """Test as_json method."""
-        self.assertEqual(self.tag.as_json(), '{"tag_type": 1, "value": 123}')
+        assert self.tag.as_json() == '{"tag_type": "vlan", "value": 123}'
 
-    def test__repr__(self):
+    async def test__repr__(self):
         """Test __repr__ method."""
-        self.assertEqual(repr(self.tag), 'TAG(<TAGType.VLAN: 1>, 123)')
+        assert repr(self.tag) == "TAG('vlan', 123)"
 
 
 # pylint: disable=protected-access, too-many-public-methods
-class TestInterface(unittest.TestCase):
+class TestInterface():
     """Test Interfaces."""
 
-    def setUp(self):
+    def setup_method(self):
         """Create interface object."""
         self.iface = self._get_v0x04_iface()
 
-    def test_repr(self):
+    async def test_repr(self):
         """Test repr() output."""
         expected = "Interface('name', 42, Switch('dpid'))"
-        self.assertEqual(repr(self.iface), expected)
+        assert repr(self.iface) == expected
 
     @staticmethod
     def _get_v0x04_iface(*args, **kwargs):
@@ -71,186 +74,178 @@ class TestInterface(unittest.TestCase):
         switch.update_lastseen()
         return Interface('name', 42, switch, *args, **kwargs)
 
-    def test_speed_feature_none(self):
+    async def test_speed_feature_none(self):
         """When port's current features is None."""
         self.iface.features = None
-        self.assertIsNone(self.iface.speed)
-        self.assertEqual('', self.iface.get_hr_speed())
+        assert self.iface.speed is None
+        assert '' == self.iface.get_hr_speed()
 
-    def test_speed_feature_zero(self):
+    async def test_speed_feature_zero(self):
         """When port's current features is 0. E.g. port 65534."""
         self.iface.features = 0
-        self.assertIsNone(self.iface.speed)
-        self.assertEqual('', self.iface.get_hr_speed())
+        assert self.iface.speed is None
+        assert '' == self.iface.get_hr_speed()
 
-    def test_1_tera_speed(self):
+    async def test_1_tera_speed(self):
         """1Tb link."""
         self.iface.features = PortFeatures.OFPPF_1TB_FD
-        self.assertEqual(10**12 / 8, self.iface.speed)
-        self.assertEqual('1 Tbps', self.iface.get_hr_speed())
+        assert 10**12 / 8 == self.iface.speed
+        assert '1 Tbps' == self.iface.get_hr_speed()
 
-    def test_100_giga_speed(self):
+    async def test_100_giga_speed(self):
         """100Gb link."""
         self.iface.features = PortFeatures.OFPPF_100GB_FD
-        self.assertEqual(100 * 10**9 / 8, self.iface.speed)
-        self.assertEqual('100 Gbps', self.iface.get_hr_speed())
+        assert 100 * 10**9 / 8 == self.iface.speed
+        assert '100 Gbps' == self.iface.get_hr_speed()
 
-    def test_40_giga_speed(self):
+    async def test_40_giga_speed(self):
         """40Gb link."""
         self.iface.features = PortFeatures.OFPPF_40GB_FD
-        self.assertEqual(40 * 10**9 / 8, self.iface.speed)
-        self.assertEqual('40 Gbps', self.iface.get_hr_speed())
+        assert 40 * 10**9 / 8 == self.iface.speed
+        assert '40 Gbps' == self.iface.get_hr_speed()
 
-    def test_10_giga_speed(self):
+    async def test_10_giga_speed(self):
         """10Gb link."""
         self.iface.features = PortFeatures.OFPPF_10GB_FD
-        self.assertEqual(10 * 10**9 / 8, self.iface.speed)
-        self.assertEqual('10 Gbps', self.iface.get_hr_speed())
+        assert 10 * 10**9 / 8 == self.iface.speed
+        assert '10 Gbps' == self.iface.get_hr_speed()
 
-    def test_1_giga_speed(self):
+    async def test_1_giga_speed(self):
         """1Gb link."""
         self.iface.features = PortFeatures.OFPPF_1GB_FD
-        self.assertEqual(10**9 / 8, self.iface.speed)
-        self.assertEqual('1 Gbps', self.iface.get_hr_speed())
+        assert 10**9 / 8 == self.iface.speed
+        assert '1 Gbps' == self.iface.get_hr_speed()
 
-    def test_100_mega_speed(self):
+    async def test_100_mega_speed(self):
         """100Mb link."""
         self.iface.features = PortFeatures.OFPPF_100MB_FD
-        self.assertEqual(100 * 10**6 / 8, self.iface.speed)
-        self.assertEqual('100 Mbps', self.iface.get_hr_speed())
+        assert 100 * 10**6 / 8 == self.iface.speed
+        assert '100 Mbps' == self.iface.get_hr_speed()
 
-    def test_10_mega_speed(self):
+    async def test_10_mega_speed(self):
         """10Mb link."""
         self.iface.features = PortFeatures.OFPPF_10MB_FD
-        self.assertEqual(10 * 10**6 / 8, self.iface.speed)
-        self.assertEqual('10 Mbps', self.iface.get_hr_speed())
+        assert 10 * 10**6 / 8 == self.iface.speed
+        assert '10 Mbps' == self.iface.get_hr_speed()
 
-    def test_speed_setter(self):
+    async def test_speed_setter(self):
         """Should return speed that was set and not features'."""
         expected_speed = 12345
         self.iface.set_custom_speed(expected_speed)
         actual_speed = self.iface.speed
-        self.assertEqual(expected_speed, actual_speed)
+        assert expected_speed == actual_speed
 
-    def test_speed_in_constructor(self):
+    async def test_speed_in_constructor(self):
         """Custom speed should override features'."""
         expected_speed = 6789
         iface = self._get_v0x04_iface(speed=expected_speed)
-        self.assertEqual(expected_speed, iface.speed)
+        assert expected_speed == iface.speed
 
-    def test_speed_removing_features(self):
+    async def test_speed_removing_features(self):
         """Should return custom speed again when features becomes None."""
         custom_speed = 101112
         of_speed = 10 * 10**6 / 8
         iface = self._get_v0x04_iface(speed=custom_speed,
                                       features=PortFeatures.OFPPF_10MB_FD)
-        self.assertEqual(of_speed, iface.speed)
+        assert of_speed == iface.speed
         iface.features = None
-        self.assertEqual(custom_speed, iface.speed)
+        assert custom_speed == iface.speed
 
-    def test_interface_available_tags(self):
-        """Test available_tags on Interface class."""
-        default_range = list(range(1, 4096))
-        intf_values = [tag.value for tag in self.iface.available_tags]
-        self.assertListEqual(intf_values, default_range)
+    async def test_interface_available_tags_tag_ranges(self):
+        """Test available_tags and tag_ranges on Interface class."""
+        default_available = {'vlan': [[1, 4095]]}
+        default_tag_ranges = {'vlan': [[1, 4095]]}
+        intf_available = self.iface.available_tags
+        intf_tag_ranges = self.iface.tag_ranges
+        assert intf_available == default_available
+        assert intf_tag_ranges == default_tag_ranges
 
-        custom_range = list(range(100, 199))
-        self.iface.set_available_tags(custom_range)
-        intf_values = [tag.value for tag in self.iface.available_tags]
-        self.assertListEqual(intf_values, custom_range)
+        custom_available = {'vlan': [[10, 200], [210, 4095]]}
+        custom_tag_ranges = {'vlan': [[1, 100], [200, 4095]]}
+        self.iface.set_available_tags_tag_ranges(custom_available,
+                                                 custom_tag_ranges)
+        intf_available = self.iface.available_tags
+        intf_tag_ranges = self.iface.tag_ranges
+        assert intf_available == custom_available
+        assert intf_tag_ranges == custom_tag_ranges
 
-    def test_all_available_tags(self):
-        """Test all available_tags on Interface class."""
-        max_range = 4096
-
-        for i in range(1, max_range):
-            next_tag = self.iface.get_next_available_tag()
-            self.assertIs(type(next_tag), TAG)
-            self.assertEqual(next_tag.value, max_range - i)
-
-        next_tag = self.iface.get_next_available_tag()
-        self.assertEqual(next_tag, False)
-
-    def test_interface_is_tag_available(self):
+    async def test_interface_is_tag_available(self):
         """Test is_tag_available on Interface class."""
         max_range = 4096
-        for i in range(1, max_range):
-            tag = TAG(TAGType.VLAN, i)
-
+        for tag in range(1, max_range):
             next_tag = self.iface.is_tag_available(tag)
-            self.assertTrue(next_tag)
+            assert next_tag
 
         # test lower limit
-        tag = TAG(TAGType.VLAN, 0)
-        self.assertFalse(self.iface.is_tag_available(tag))
+        assert self.iface.is_tag_available(0) is False
         # test upper limit
-        tag = TAG(TAGType.VLAN, max_range)
-        self.assertFalse(self.iface.is_tag_available(tag))
+        assert self.iface.is_tag_available(max_range) is False
 
-    def test_interface_use_tags(self):
-        """Test all use_tag on Interface class."""
+    async def test_interface_use_tags(self):
+        """Test all use_tags on Interface class."""
 
-        tag = TAG(TAGType.VLAN, 100)
+        tags = [100, 200]
         # check use tag for the first time
-        is_success = self.iface.use_tag(tag)
-        self.assertTrue(is_success)
+        is_success = self.iface.use_tags(tags)
+        assert is_success
 
         # check use tag for the second time
-        is_success = self.iface.use_tag(tag)
-        self.assertFalse(is_success)
+        is_success = self.iface.use_tags(tags)
+        assert is_success is False
 
         # check use tag after returning the tag to the pool
-        self.iface.make_tag_available(tag)
-        is_success = self.iface.use_tag(tag)
-        self.assertTrue(is_success)
+        self.iface.make_tags_available(tags)
+        is_success = self.iface.use_tags(tags)
+        assert is_success
 
         # Test sanity safe guard
-        self.assertFalse(self.iface.make_tag_available(None))
-        self.assertTrue(None not in self.iface.available_tags)
+        none = [None, None]
+        assert self.iface.make_tags_available(none) is False
+        assert None not in self.iface.available_tags
 
-    def test_enable(self):
+    async def test_enable(self):
         """Test enable method."""
         self.iface.switch = MagicMock()
 
         self.iface.enable()
 
         self.iface.switch.enable.assert_called()
-        self.assertTrue(self.iface._enabled)
+        assert self.iface._enabled
 
-    def test_get_endpoint(self):
+    async def test_get_endpoint(self):
         """Test get_endpoint method."""
         endpoint = ('endpoint', 'time')
         self.iface.endpoints = [endpoint]
 
         return_endpoint = self.iface.get_endpoint('endpoint')
 
-        self.assertEqual(return_endpoint, endpoint)
+        assert return_endpoint == endpoint
 
-    def test_add_endpoint(self):
+    async def test_add_endpoint(self):
         """Test add_endpoint method."""
         self.iface.add_endpoint('endpoint')
 
-        self.assertEqual(len(self.iface.endpoints), 1)
+        assert len(self.iface.endpoints) == 1
 
-    def test_delete_endpoint(self):
+    async def test_delete_endpoint(self):
         """Test delete_endpoint method."""
         endpoint = ('endpoint', 'time')
         self.iface.endpoints = [endpoint]
 
         self.iface.delete_endpoint('endpoint')
 
-        self.assertEqual(len(self.iface.endpoints), 0)
+        assert len(self.iface.endpoints) == 0
 
-    def test_update_endpoint(self):
+    async def test_update_endpoint(self):
         """Test update_endpoint method."""
         endpoint = ('endpoint', 'time')
         self.iface.endpoints = [endpoint]
 
         self.iface.update_endpoint('endpoint')
 
-        self.assertEqual(len(self.iface.endpoints), 1)
+        assert len(self.iface.endpoints) == 1
 
-    def test_update_link__none(self):
+    async def test_update_link__none(self):
         """Test update_link method when this interface is not in link
            endpoints."""
         link = MagicMock()
@@ -259,9 +254,9 @@ class TestInterface(unittest.TestCase):
 
         result = self.iface.update_link(link)
 
-        self.assertFalse(result)
+        assert result is False
 
-    def test_update_link__endpoint_a(self):
+    async def test_update_link__endpoint_a(self):
         """Test update_link method when this interface is the endpoint a."""
         interface = MagicMock()
         interface.link = None
@@ -271,10 +266,10 @@ class TestInterface(unittest.TestCase):
 
         self.iface.update_link(link)
 
-        self.assertEqual(self.iface.link, link)
-        self.assertEqual(interface.link, link)
+        assert self.iface.link == link
+        assert interface.link == link
 
-    def test_update_link__endpoint_b(self):
+    async def test_update_link__endpoint_b(self):
         """Test update_link method when this interface is the endpoint b."""
         interface = MagicMock()
         interface.link = None
@@ -284,11 +279,11 @@ class TestInterface(unittest.TestCase):
 
         self.iface.update_link(link)
 
-        self.assertEqual(self.iface.link, link)
-        self.assertEqual(interface.link, link)
+        assert self.iface.link == link
+        assert interface.link == link
 
     @staticmethod
-    def test_pickleable_id() -> None:
+    async def test_pickleable_id() -> None:
         """Test to make sure the id is pickleable."""
         switch = Switch("dpid1")
         interface = Interface("s1-eth1", 1, switch)
@@ -296,7 +291,7 @@ class TestInterface(unittest.TestCase):
         intf_dict = pickle.loads(pickled)
         assert intf_dict["id"] == interface.id
 
-    def test_status_funcs(self) -> None:
+    async def test_status_funcs(self) -> None:
         """Test status_funcs."""
         self.iface.enable()
         self.iface.activate()
@@ -322,55 +317,243 @@ class TestInterface(unittest.TestCase):
         assert self.iface.status == EntityStatus.UP
         assert self.iface.status_reason == set()
 
+    async def test_make_tags_available(self) -> None:
+        """Test make_tags_available"""
+        available = {'vlan': [[300, 3000]]}
+        tag_ranges = {'vlan': [[20, 20], [200, 3000]]}
+        self.iface.set_available_tags_tag_ranges(
+            available, tag_ranges
+        )
+        assert self.iface.available_tags == available
+        assert self.iface.tag_ranges == tag_ranges
 
-class TestUNI(unittest.TestCase):
+        assert self.iface.make_tags_available([1, 20]) is False
+        assert self.iface.make_tags_available([250, 280])
+
+    async def range_intersection_first_tag(self) -> None:
+        """Test range_intersection"""
+        tag_ranges_a = [[35, 90]]
+        tag_ranges_b = [[30, 40]]
+        found_tag = self.iface.range_intersection_first_tag(
+            tag_ranges_a, tag_ranges_b
+        )
+        assert found_tag == 35
+
+        tag_ranges_a = [[41, 90]]
+        tag_ranges_b = [[30, 40]]
+        found_tag = self.iface.range_intersection_first_tag(
+            tag_ranges_a, tag_ranges_b
+        )
+        assert found_tag is None
+
+    async def range_intersection(self) -> None:
+        """Test range_intersection_first_tag"""
+        tags_a = [
+            [3, 5], [7, 9], [11, 16], [21, 23], [25, 25], [27, 28], [30, 30]
+        ]
+        tags_b = [
+            [1, 3], [6, 6], [10, 10], [12, 13], [15, 15], [17, 20], [22, 30]
+        ]
+        result = self.iface.range_intersection(tags_a, tags_b)
+        expected = [
+            [3, 3], [12, 13], [15, 15], [22, 23], [25, 25], [27, 28], [30, 30]
+        ]
+        assert result == expected
+
+    async def test_range_difference(self) -> None:
+        """Test range_difference"""
+        ranges_a = [[2, 3], [7, 10], [12, 12], [14, 14], [17, 19], [25, 27]]
+        ranges_b = [[1, 1], [4, 5], [8, 9], [11, 14], [18, 21], [23, 26]]
+        expected = [[2, 3], [7, 7], [10, 10], [17, 17], [27, 27]]
+        actual = self.iface.range_difference(ranges_a, ranges_b)
+        assert expected == actual
+
+    async def test_can_set_tag_ranges(self) -> None:
+        """Test can_set_tag_ranges"""
+        used_tags = [[20, 35], [50, 68], [100, 3000]]
+        tag_ranges = [[20, 40], [45, 68], [100, 3000]]
+        self.iface.can_set_tag_ranges(used_tags, tag_ranges)
+
+        tag_ranges = [[45, 68], [100, 3000]]
+        with pytest.raises(KytosSetTagRangeError):
+            self.iface.can_set_tag_ranges(used_tags, tag_ranges)
+
+        tag_ranges = [[20, 40], [45, 68]]
+        with pytest.raises(KytosSetTagRangeError):
+            self.iface.can_set_tag_ranges(used_tags, tag_ranges)
+
+        tag_ranges = [[20, 40], [60, 68], [100, 3000]]
+        with pytest.raises(KytosSetTagRangeError):
+            self.iface.can_set_tag_ranges(used_tags, tag_ranges)
+
+    async def test_set_tag_ranges(self) -> None:
+        """Test set_tag_ranges"""
+        tag_ranges = [[20, 20], [200, 3000]]
+        with pytest.raises(KytosTagtypeNotSupported):
+            self.iface.set_tag_ranges(tag_ranges, 'vlan_qinq')
+
+        self.iface.set_tag_ranges(tag_ranges, 'vlan')
+        self.iface.use_tags([200, 250])
+        self.iface.set_tag_ranges(tag_ranges, 'vlan')
+        ava_expected = [[20, 20], [251, 3000]]
+        assert self.iface.tag_ranges['vlan'] == tag_ranges
+        assert self.iface.available_tags['vlan'] == ava_expected
+
+        tag_ranges = [[20, 20], [400, 1000]]
+        with pytest.raises(KytosSetTagRangeError):
+            self.iface.set_tag_ranges(tag_ranges, 'vlan')
+
+    async def test_remove_tag_ranges(self) -> None:
+        """Test remove_tag_ranges"""
+        tag_ranges = [[20, 20], [200, 3000]]
+        self.iface.set_tag_ranges(tag_ranges, 'vlan')
+        assert self.iface.tag_ranges['vlan'] == tag_ranges
+
+        with pytest.raises(KytosTagtypeNotSupported):
+            self.iface.remove_tag_ranges('vlan_qinq')
+
+        self.iface.remove_tag_ranges('vlan')
+        default = [[1, 4095]]
+        assert self.iface.tag_ranges['vlan'] == default
+
+    async def test_find_index_remove(self) -> None:
+        """Test find_index_remove"""
+        tag_ranges = [[20, 20], [200, 3000]]
+        self.iface.set_tag_ranges(tag_ranges, 'vlan')
+        assert self.iface.tag_ranges['vlan'] == tag_ranges
+        index = self.iface.find_index_remove(tag_ranges, [20, 20])
+        assert index == 0
+        index = self.iface.find_index_remove(tag_ranges, [10, 15])
+        assert index is None
+        index = self.iface.find_index_remove(tag_ranges, [190, 201])
+        assert index is None
+        index = self.iface.find_index_remove(tag_ranges, [200, 250])
+        assert index == 1
+
+        tag_ranges = [[200, 3000]]
+        self.iface.set_tag_ranges(tag_ranges, 'vlan')
+        assert self.iface.tag_ranges['vlan'] == tag_ranges
+        index = self.iface.find_index_remove(tag_ranges, [200, 250])
+        assert index == 0
+
+    async def test_find_index_add(self) -> None:
+        """Test find_index_add"""
+        tag_ranges = [[20, 20], [200, 3000]]
+        self.iface.set_tag_ranges(tag_ranges, 'vlan')
+        assert self.iface.tag_ranges['vlan'] == tag_ranges
+
+        index = self.iface.find_index_add(tag_ranges, [10, 15])
+        assert index == 0
+        index = self.iface.find_index_add(tag_ranges, [3004, 4000])
+        assert index == 2
+        index = self.iface.find_index_add(tag_ranges, [50, 202])
+        assert index is None
+
+    async def test_remove_tags(self) -> None:
+        """Test remove_tags"""
+        available_tag = [[20, 20], [200, 3000]]
+        tag_ranges = [[1, 4095]]
+        self.iface.set_available_tags_tag_ranges(
+            {'vlan': available_tag}, {'vlan': tag_ranges}
+        )
+        ava_expected = [[20, 20], [241, 3000]]
+        assert self.iface.remove_tags([200, 240])
+        assert self.iface.available_tags['vlan'] == ava_expected
+        ava_expected = [[241, 3000]]
+        assert self.iface.remove_tags([20, 20])
+        assert self.iface.available_tags['vlan'] == ava_expected
+        ava_expected = [[241, 250], [400, 3000]]
+        assert self.iface.remove_tags([251, 399])
+        assert self.iface.available_tags['vlan'] == ava_expected
+        assert self.iface.remove_tags([200, 240]) is False
+
+    async def test_add_tags(self) -> None:
+        """Test add_tags"""
+        available_tag = [[7, 10], [20, 30], [78, 92], [100, 109]]
+        tag_ranges = [[1, 4095]]
+        self.iface.set_available_tags_tag_ranges(
+            {'vlan': available_tag}, {'vlan': tag_ranges}
+        )
+        ava_expected = [[1, 10], [20, 30], [78, 92], [100, 109]]
+        assert self.iface.add_tags([1, 6])
+        assert self.iface.available_tags['vlan'] == ava_expected
+
+        ava_expected = [[1, 30], [78, 92], [100, 109]]
+        assert self.iface.add_tags([11, 19])
+        assert self.iface.available_tags['vlan'] == ava_expected
+
+        ava_expected = [[1, 30], [78, 92], [100, 109], [200, 240]]
+        assert self.iface.add_tags([200, 240])
+        assert self.iface.available_tags['vlan'] == ava_expected
+
+        ava_expected = [[1, 30], [40, 92], [100, 109], [200, 240]]
+        assert self.iface.add_tags([40, 77])
+        assert self.iface.available_tags['vlan'] == ava_expected
+
+        ava_expected = [[1, 30], [40, 98], [100, 109], [200, 240]]
+        assert self.iface.add_tags([93, 98])
+        assert self.iface.available_tags['vlan'] == ava_expected
+
+        assert self.iface.add_tags([35, 98]) is False
+
+    async def test_notify_interface_tags(self, controller) -> None:
+        """Test notify_interface_tags"""
+        name = "kytos/core.interface_tags"
+        content = {"interface": self.iface}
+        self.iface.notify_interface_tags(controller)
+        event = controller.buffers.app.put.call_args[0][0]
+        assert event.name == name
+        assert event.content == content
+
+
+class TestUNI():
     """UNI tests."""
 
-    def setUp(self):
+    def setup_method(self):
         """Create UNI object."""
         switch = MagicMock()
         switch.id = '00:00:00:00:00:00:00:01'
         interface = Interface('name', 1, switch)
-        user_tag = TAG(1, 123)
+        user_tag = TAG('vlan', 123)
         self.uni = UNI(interface, user_tag)
 
-    def test__eq__(self):
+    async def test__eq__(self):
         """Test __eq__ method."""
-        user_tag = TAG(2, 456)
+        user_tag = TAG('vlan', 456)
         interface = Interface('name', 2, MagicMock())
         other = UNI(interface, user_tag)
 
-        self.assertFalse(self.uni == other)
+        assert (self.uni == other) is False
 
-    def test_is_valid(self):
+    async def test_is_valid(self):
         """Test is_valid method for a valid, invalid and none tag."""
-        self.assertTrue(self.uni.is_valid())
+        assert self.uni.is_valid()
 
-        with self.assertRaises(ValueError):
-            TAG(999999, 123)
+        with pytest.raises(ValueError):
+            TAG("some_type", 123)
 
         self.uni.user_tag = None
-        self.assertTrue(self.uni.is_valid())
+        assert self.uni.is_valid()
 
-    def test_is_reserved_valid_tag(self):
+    async def test_is_reserved_valid_tag(self):
         """Test _is_reserved_valid_tag method for string TAG."""
-        self.uni.user_tag = TAG(1, "untagged")
-        self.assertTrue(self.uni.is_valid())
+        self.uni.user_tag = TAG("vlan", "untagged")
+        assert self.uni.is_valid()
 
-        self.uni.user_tag = TAG(1, "any")
-        self.assertTrue(self.uni.is_valid())
+        self.uni.user_tag = TAG("vlan", "any")
+        assert self.uni.is_valid()
 
-        self.uni.user_tag = TAG(1, "2/4094")
-        self.assertFalse(self.uni.is_valid())
+        self.uni.user_tag = TAG("vlan", "2/4094")
+        assert self.uni.is_valid() is False
 
-    def test_as_dict(self):
+    async def test_as_dict(self):
         """Test as_dict method."""
         expected_dict = {'interface_id': '00:00:00:00:00:00:00:01:1',
-                         'tag': {'tag_type': 1, 'value': 123}}
-        self.assertEqual(self.uni.as_dict(), expected_dict)
+                         'tag': {'tag_type': 'vlan', 'value': 123}}
+        assert self.uni.as_dict() == expected_dict
 
-    def test_as_json(self):
+    async def test_as_json(self):
         """Test as_json method."""
         expected_json = '{"interface_id": "00:00:00:00:00:00:00:01:1", ' + \
-                        '"tag": {"tag_type": 1, "value": 123}}'
-        self.assertEqual(self.uni.as_json(), expected_json)
+                        '"tag": {"tag_type": "vlan", "value": 123}}'
+        assert self.uni.as_json() == expected_json

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -330,31 +330,16 @@ class TestInterface():
         assert self.iface.make_tags_available([1, 20]) is False
         assert self.iface.make_tags_available([250, 280])
 
-    async def range_intersection_first_tag(self) -> None:
-        """Test range_intersection"""
-        tag_ranges_a = [[35, 90]]
-        tag_ranges_b = [[30, 40]]
-        found_tag = self.iface.range_intersection_first_tag(
-            tag_ranges_a, tag_ranges_b
-        )
-        assert found_tag == 35
-
-        tag_ranges_a = [[41, 90]]
-        tag_ranges_b = [[30, 40]]
-        found_tag = self.iface.range_intersection_first_tag(
-            tag_ranges_a, tag_ranges_b
-        )
-        assert found_tag is None
-
     async def range_intersection(self) -> None:
-        """Test range_intersection_first_tag"""
+        """Test range_intersection"""
         tags_a = [
             [3, 5], [7, 9], [11, 16], [21, 23], [25, 25], [27, 28], [30, 30]
         ]
         tags_b = [
             [1, 3], [6, 6], [10, 10], [12, 13], [15, 15], [17, 20], [22, 30]
         ]
-        result = self.iface.range_intersection(tags_a, tags_b)
+        iterator_result = self.iface.range_intersection(tags_a, tags_b)
+        result = list(iterator_result)
         expected = [
             [3, 3], [12, 13], [15, 15], [22, 23], [25, 25], [27, 28], [30, 30]
         ]

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -1,12 +1,13 @@
 """Link tests."""
 import logging
 import time
-import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+
+import pytest
 
 from kytos.core.common import EntityStatus
 from kytos.core.exceptions import KytosLinkCreationError
-from kytos.core.interface import TAG, Interface, TAGType
+from kytos.core.interface import Interface, TAGType
 from kytos.core.link import Link
 from kytos.core.switch import Switch
 
@@ -14,10 +15,11 @@ logging.basicConfig(level=logging.CRITICAL)
 
 
 # pylint: disable=protected-access,too-many-public-methods
-class TestLink(unittest.TestCase):
+# pylint: disable=attribute-defined-outside-init
+class TestLink():
     """Test Links."""
 
-    def setUp(self):
+    def setup_method(self):
         """Create interface objects."""
         self.switch1 = self._get_v0x04_switch('dpid1')
         self.iface1 = Interface('interface1', 41, self.switch1)
@@ -42,8 +44,8 @@ class TestLink(unittest.TestCase):
 
         link_3 = Link(iface3, iface4)
 
-        self.assertTrue(link_1 == link_2)
-        self.assertFalse(link_1 == link_3)
+        assert link_1 == link_2
+        assert (link_1 == link_3) is False
 
     def test__repr__(self):
         """Test __repr__ method."""
@@ -51,7 +53,7 @@ class TestLink(unittest.TestCase):
         expected = ("Link(Interface('interface1', 41, Switch('dpid1')), "
                     "Interface('interface2', 42, Switch('dpid2')), "
                     f"{link.id})")
-        self.assertEqual(repr(link), expected)
+        assert repr(link) == expected
 
     def test_id(self):
         """Test id property."""
@@ -67,30 +69,30 @@ class TestLink(unittest.TestCase):
 
             ids.append(link.id)
 
-        self.assertEqual(ids[0], ids[1])
-        self.assertEqual(ids[2], ids[3])
-        self.assertNotEqual(ids[0], ids[2])
+        assert ids[0] == ids[1]
+        assert ids[2] == ids[3]
+        assert ids[0] != ids[2]
 
     def test_init(self):
         """Test normal Link initialization."""
         link = Link(self.iface1, self.iface2)
-        self.assertIsInstance(link, Link)
-        self.assertIs(link.is_active(), True)
-        self.assertIs(link.is_enabled(), False)
+        assert isinstance(link, Link)
+        assert link.is_active()
+        assert link.is_enabled() is False
 
     def test_init_with_null_endpoints(self):
         """Test initialization with None as endpoints."""
-        with self.assertRaises(KytosLinkCreationError):
+        with pytest.raises(KytosLinkCreationError):
             Link(self.iface1, None)
 
-        with self.assertRaises(KytosLinkCreationError):
+        with pytest.raises(KytosLinkCreationError):
             Link(None, self.iface2)
 
     def test_link_id(self):
         """Test equality of links with the same values in different order."""
         link1 = Link(self.iface1, self.iface2)
         link2 = Link(self.iface2, self.iface1)
-        self.assertEqual(link1.id, link2.id)
+        assert link1.id == link2.id
 
     def test_status_funcs(self) -> None:
         """Test status_funcs."""
@@ -197,109 +199,63 @@ class TestLink(unittest.TestCase):
     def test_available_tags(self):
         """Test available_tags property."""
         link = Link(self.iface1, self.iface2)
-        tag_1 = Mock(tag_type=TAGType.VLAN)
-        tag_2 = Mock(tag_type=TAGType.VLAN)
-        tag_3 = Mock(tag_type=TAGType.VLAN_QINQ)
-        tag_4 = Mock(tag_type=TAGType.MPLS)
-        link.endpoint_a.available_tags = [tag_1, tag_2, tag_3, tag_4]
-        link.endpoint_b.available_tags = [tag_2, tag_3, tag_4]
+        link.endpoint_a.available_tags['vlan'] = [[1, 100]]
+        link.endpoint_b.available_tags['vlan'] = [[50, 200]]
 
-        self.assertEqual(link.available_tags, [tag_2, tag_3, tag_4])
+        vlans = link.available_tags()
+        assert vlans == [[50, 100]]
 
-    @patch('kytos.core.interface.Interface.is_tag_available')
-    def test_use_tag__success(self, mock_is_tag_available):
-        """Test use_tag method to success case."""
-        mock_is_tag_available.side_effect = [True, True]
-        link = Link(self.iface1, self.iface2)
-
-        result = link.use_tag(Mock())
-        self.assertTrue(result)
-
-    @patch('kytos.core.interface.Interface.is_tag_available')
-    def test_use_tag__error(self, mock_is_tag_available):
-        """Test use_tag method to error case."""
-        mock_is_tag_available.side_effect = [True, False]
-        link = Link(self.iface1, self.iface2)
-
-        result = link.use_tag(Mock())
-        self.assertFalse(result)
-
-    def test_make_tag_available__success(self):
-        """Test make_tag_available method to success case."""
-        link = Link(self.iface1, self.iface2)
-        self.assertEqual(self.iface1.available_tags[-1],
-                         self.iface2.available_tags[-1])
-        next_value = self.iface1.available_tags[-1].value + 1
-        tag = TAG(TAGType.VLAN, next_value)
-        result = link.make_tag_available(tag)
-        self.assertTrue(result)
-        self.assertTrue(tag in self.iface1.available_tags)
-        self.assertTrue(tag in self.iface2.available_tags)
-
-    def test_make_tag_available__error(self):
-        """Test make_tag_available method to error case."""
-        link = Link(self.iface1, self.iface2)
-        result = link.make_tag_available(self.iface1.available_tags[0])
-        self.assertFalse(result)
-
-    def test_get_next_available_tag(self):
+    def test_get_next_available_tag(self, controller):
         """Test get next available tags returns different tags"""
         link = Link(self.iface1, self.iface2)
-        tag = link.get_next_available_tag()
-        next_tag = link.get_next_available_tag()
+        tag = link.get_next_available_tag(controller)
+        next_tag = link.get_next_available_tag(controller)
 
-        self.assertNotEqual(tag, next_tag)
+        assert tag != next_tag
 
-    def test_get_tag_multiple_calls(self):
+    def test_get_tag_multiple_calls(self, controller):
         """Test get next available tags returns different tags"""
         link = Link(self.iface1, self.iface2)
-        tag = link.get_next_available_tag()
-        next_tag = link.get_next_available_tag()
-        self.assertNotEqual(next_tag.value, tag.value)
+        tag = link.get_next_available_tag(controller)
+        next_tag = link.get_next_available_tag(controller)
+        assert next_tag != tag
 
-    def test_next_tag_with_use_tags(self):
-        """Test get next availabe tags returns different tags"""
-        link = Link(self.iface1, self.iface2)
-        tag = link.get_next_available_tag()
-        is_available = link.is_tag_available(tag)
-        self.assertFalse(is_available)
-        link.use_tag(tag)
-
-    def test_tag_life_cicle(self):
+    def test_tag_life_cicle(self, controller):
         """Test get next available tags returns different tags"""
         link = Link(self.iface1, self.iface2)
-        tag = link.get_next_available_tag()
+        tag = link.get_next_available_tag(controller)
 
         is_available = link.is_tag_available(tag)
-        self.assertFalse(is_available)
+        assert is_available is False
 
-        link.make_tag_available(tag)
+        link.make_tags_available(controller, tag)
         is_available = link.is_tag_available(tag)
-        self.assertTrue(is_available)
+        assert is_available
 
-    def test_concurrent_get_next_tag(self):
+    def test_concurrent_get_next_tag(self, controller):
         """Test get next available tags in concurrent execution"""
         # pylint: disable=import-outside-toplevel
         from tests.helper import test_concurrently
         _link = Link(self.iface1, self.iface2)
 
         _i = []
-        _initial_size = len(_link.endpoint_a.available_tags)
+        available_tags = _link.endpoint_a.available_tags['vlan']
+        _initial_size = 0
+        for i, j in available_tags:
+            _initial_size += j - i + 1
 
         @test_concurrently(20)
-        def test_get_next_available_tag():
+        def test_get_next_available_tag(controller):
             """Assert that get_next_available_tag() returns different tags."""
             _i.append(1)
-            tag = _link.get_next_available_tag()
+            tag = _link.get_next_available_tag(controller)
             time.sleep(0.0001)
-            _link.use_tag(tag)
 
-            next_tag = _link.get_next_available_tag()
-            _link.use_tag(next_tag)
+            next_tag = _link.get_next_available_tag(controller)
 
-            self.assertNotEqual(tag, next_tag)
+            assert tag != next_tag
 
-        test_get_next_available_tag()
+        test_get_next_available_tag(controller)
 
         # sleep not needed because test_concurrently waits for all threads
         # to finish before returning.
@@ -307,29 +263,25 @@ class TestLink(unittest.TestCase):
 
         # Check if after the 20th iteration we have 40 tags
         # It happens because we get 2 tags for every iteration
-        self.assertEqual(_initial_size,
-                         len(_link.endpoint_a.available_tags) + 40)
+        available_tags = _link.endpoint_a.available_tags['vlan']
+        _final_size = 0
+        for i, j in available_tags:
+            _final_size += j - i + 1
+        assert _initial_size == _final_size + 40
 
     def test_available_vlans(self):
         """Test available_vlans method."""
         link = Link(self.iface1, self.iface2)
-        tag_1 = Mock(tag_type=TAGType.VLAN)
-        tag_2 = Mock(tag_type=TAGType.VLAN)
-        tag_3 = Mock(tag_type=TAGType.VLAN_QINQ)
-        tag_4 = Mock(tag_type=TAGType.MPLS)
-        link.endpoint_a.available_tags = [tag_1, tag_2, tag_3, tag_4]
-        link.endpoint_b.available_tags = [tag_2, tag_3, tag_4]
+        link.endpoint_a.available_tags[TAGType.MPLS.value] = [[1, 100]]
+        link.endpoint_b.available_tags[TAGType.MPLS.value] = [[50, 200]]
 
         vlans = link.available_vlans()
-        self.assertEqual(vlans, [tag_2])
+        assert vlans == [TAGType.VLAN.value]
 
     def test_get_available_vlans(self):
         """Test _get_available_vlans method."""
         link = Link(self.iface1, self.iface2)
-        tag_1 = Mock(tag_type=TAGType.VLAN)
-        tag_2 = Mock(tag_type=TAGType.VLAN_QINQ)
-        tag_3 = Mock(tag_type=TAGType.MPLS)
-        link.endpoint_a.available_tags = [tag_1, tag_2, tag_3]
-
+        link.endpoint_a.available_tags[TAGType.VLAN_QINQ.value] = [[1, 1]]
+        link.endpoint_a.available_tags[TAGType.MPLS.value] = [[1, 1]]
         vlans = link._get_available_vlans(link.endpoint_a)
-        self.assertEqual(vlans, [tag_1])
+        assert vlans == [TAGType.VLAN.value]

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -208,27 +208,27 @@ class TestLink():
     def test_get_next_available_tag(self, controller):
         """Test get next available tags returns different tags"""
         link = Link(self.iface1, self.iface2)
-        tag = link.get_next_available_tag(controller)
-        next_tag = link.get_next_available_tag(controller)
+        tag = link.get_next_available_tag(controller, "link_id")
+        next_tag = link.get_next_available_tag(controller, "link_id")
 
         assert tag != next_tag
 
     def test_get_tag_multiple_calls(self, controller):
         """Test get next available tags returns different tags"""
         link = Link(self.iface1, self.iface2)
-        tag = link.get_next_available_tag(controller)
-        next_tag = link.get_next_available_tag(controller)
+        tag = link.get_next_available_tag(controller, "link_id")
+        next_tag = link.get_next_available_tag(controller, "link_id")
         assert next_tag != tag
 
     def test_tag_life_cicle(self, controller):
         """Test get next available tags returns different tags"""
         link = Link(self.iface1, self.iface2)
-        tag = link.get_next_available_tag(controller)
+        tag = link.get_next_available_tag(controller, "link_id")
 
         is_available = link.is_tag_available(tag)
         assert is_available is False
 
-        link.make_tags_available(controller, tag)
+        link.make_tags_available(controller, tag, "link_id")
         is_available = link.is_tag_available(tag)
         assert is_available
 
@@ -248,10 +248,10 @@ class TestLink():
         def test_get_next_available_tag(controller):
             """Assert that get_next_available_tag() returns different tags."""
             _i.append(1)
-            tag = _link.get_next_available_tag(controller)
+            tag = _link.get_next_available_tag(controller, "link_id")
             time.sleep(0.0001)
 
-            next_tag = _link.get_next_available_tag(controller)
+            next_tag = _link.get_next_available_tag(controller, "link_id")
 
             assert tag != next_tag
 

--- a/tests/unit/test_core/test_switch.py
+++ b/tests/unit/test_core/test_switch.py
@@ -61,40 +61,6 @@ class TestSwitch(TestCase):
         self.switch.connection = None
         self.assertIsNone(self.switch.ofp_version)
 
-    def test_switch_vlan_pool_default(self):
-        """Test default vlan_pool value."""
-        self.assertEqual(self.options.vlan_pool, {})
-
-    def test_switch_vlan_pool_options(self):
-        """Test switch with the example from kytos.conf."""
-        dpid = "00:00:00:00:00:00:00:01"
-        vlan_pool = {"00:00:00:00:00:00:00:01":
-                     {"1": [[1, 2], [5, 10]], "4": [[3, 4]]}}
-        self.controller.switches[dpid] = self.switch
-        self.options.vlan_pool = vlan_pool
-        self.controller.get_switch_or_create(dpid, self.switch.connection)
-
-        port_id = 1
-        intf = self.controller.switches[dpid].interfaces[port_id]
-        tag_values = [tag.value for tag in intf.available_tags]
-        self.assertEqual(tag_values, [1, 5, 6, 7, 8, 9])
-
-        port_id = 4
-        intf = self.controller.switches[dpid].interfaces[port_id]
-        tag_values = [tag.value for tag in intf.available_tags]
-        self.assertEqual(tag_values, [3])
-
-        # this port number doesn't exist yet.
-        port_7 = 7
-        intf = Interface("test", port_7, self.switch)
-        # no attr filters, so should associate as it is
-        self.controller.switches[dpid].update_interface(intf)
-        intf_obj = self.controller.switches[dpid].interfaces[port_7]
-        self.assertEqual(intf_obj, intf)
-        # assert default vlan_pool range (1, 4096)
-        tag_values = [tag.value for tag in intf_obj.available_tags]
-        self.assertEqual(tag_values, list(range(1, 4096)))
-
     def test_update_description(self):
         """Test update_description method."""
         desc = MagicMock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,coverage,lint
+envlist = coverage,lint
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint
+envlist = py39,coverage,lint
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,coverage,lint
+envlist = lint
 
 [gh-actions]
 python =


### PR DESCRIPTION
Closes #405 
Closes #408 

### Summary

Deprecated `vlan_pool`
Added `Interface.tag_ranges` replacing `vlan_pool`. It has a format `dict[list[list[int]]]`
Changed `Interface.available_tags` format to `dict[list[list[int]]]`
Moved `kytos/*.link_available_tags` to  kytos/core/interface.py
Changed Link methods related to TAG.
Changed `tag_type` from integer to string. E.g. `"vlan"`


### Local Tests
Actions related to TAGs:
- Created/deleted EVCs.
- Set `tag_ranges` and restart kytos.
- Send `kytos/core.link_available_tags` manually through console

Unit tests added

### End-to-End Tests
E2E tests are passing, [comment](https://github.com/kytos-ng/kytos/pull/409#issuecomment-1714156976). 