### PR TITLE
feat: set default ``maxTimeMS`` when creating an index; unhandled exc on `setup()` will exit `kytosd`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ UNRELEASED - Under development
 Changed
 =======
 - Parametrized default ``maxTimeMS`` when creating an index via ``Mongo.boostrap_index`` via environment variable ``MONGO_IDX_TIMEOUTMS=30000``. The retries parameters reuse the same environment variables ``MONGO_AUTO_RETRY_STOP_AFTER_ATTEMPT=3``, ``MONGO_AUTO_RETRY_WAIT_RANDOM_MIN=0.1``, ``MONGO_AUTO_RETRY_WAIT_RANDOM_MAX=1`` that NApps controllers have been using.
-- ``kytosd`` process will exit if a NApp raises an exeption during its ``setup()`` execution.
+- ``kytosd`` process will exit if a NApp raises an exception during its ``setup()`` execution.
 
 
 [2023.1.0] - 2023-06-05

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Changed
+=======
+- Parametrized default ``maxTimeMS`` when creating an index via ``Mongo.boostrap_index`` via environment variable ``MONGO_IDX_TIMEOUTMS=30000``. The retries parameters reuse the same environment variables ``MONGO_AUTO_RETRY_STOP_AFTER_ATTEMPT=3``, ``MONGO_AUTO_RETRY_WAIT_RANDOM_MIN=0.1``, ``MONGO_AUTO_RETRY_WAIT_RANDOM_MAX=1`` that NApps controllers have been using.
+- ``kytosd`` process will exit if a NApp raises an exeption during its ``setup()`` execution.
+
+
 [2023.1.0] - 2023-06-05
 ***********************
 

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -21,6 +21,7 @@ import os
 import re
 import sys
 import threading
+import traceback
 from asyncio import AbstractEventLoop
 from importlib import import_module
 from importlib import reload as reload_module
@@ -263,9 +264,10 @@ class Controller:
                 self.create_pidfile()
             self.start_controller()
         except Exception as exc:
-            message = f"Kytos couldn't start because of {str(exc)}"
-            self.log.exception(message, exc_info=True)
-            sys.exit(message)
+            exc_fmt = traceback.format_exc(chain=True)
+            message = f"Kytos couldn't start because of {str(exc)} {exc_fmt}"
+            print(message)
+            sys.exit(1)
 
     def create_pidfile(self):
         """Create a pidfile."""
@@ -860,10 +862,8 @@ class Controller:
         try:
             napp = napp_module.Main(controller=self)
         except Exception as exc:  # noqa pylint: disable=bare-except
-            self.log.critical("NApp initialization failed: %s/%s",
-                              username, napp_name, exc_info=True)
             msg = f"NApp {username}/{napp_name} exception {str(exc)} "
-            raise KytosNAppSetupException(msg)
+            raise KytosNAppSetupException(msg) from exc
 
         self.napps[(username, napp_name)] = napp
 

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -101,6 +101,17 @@ class KytosNAppException(Exception):
         return self.message
 
 
+class KytosNAppSetupException(KytosNAppException):
+    """KytosNAppSetupException. """
+
+    def __init__(self, message="KytosNAppSetupException") -> None:
+        """KytosNAppSetupException."""
+        super().__init__(message=message)
+
+    def __str__(self):
+        return f"KytosNAppSetupException: {self.message}"
+
+
 class KytosNAppMissingInitArgument(KytosNAppException):
     """Exception thrown when NApp have a missing init argument."""
 

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -194,7 +194,6 @@ class TestController(TestCase):
          mock_start_controller, mock_db_conn_or_shutdown,
          mock_init_apm_or_shutdown, mock_sys) = args
         mock_start_controller.side_effect = Exception
-        self.controller.log = MagicMock()
         self.controller.start()
 
         mock_enable_logs.assert_called()
@@ -202,7 +201,6 @@ class TestController(TestCase):
         mock_start_controller.assert_called()
         mock_db_conn_or_shutdown.assert_not_called()
         mock_init_apm_or_shutdown.assert_not_called()
-        self.controller.log.exception.assert_called()
         mock_sys.exit.assert_called()
 
     @patch('kytos.core.controller.Controller.init_apm_or_core_shutdown')

--- a/tests/unit/test_core/test_db.py
+++ b/tests/unit/test_core/test_db.py
@@ -92,13 +92,16 @@ class TestDb(TestCase):
         keys = [("interfaces.id", 1)]
         Mongo().bootstrap_index(coll, keys)
         assert db[coll].create_index.call_count == 1
-        db[coll].create_index.assert_called_with(keys, background=True)
+        db[coll].create_index.assert_called_with(keys,
+                                                 background=True,
+                                                 maxTimeMS=30000)
 
         keys = [("interfaces.id", 1), ("interfaces.name", 1)]
         Mongo().bootstrap_index(coll, keys)
         assert db[coll].create_index.call_count == 2
         db[coll].create_index.assert_called_with(keys,
-                                                 background=True)
+                                                 background=True,
+                                                 maxTimeMS=30000)
 
     @staticmethod
     @patch("kytos.core.db.LOG")


### PR DESCRIPTION
Closes #413 (check out the last comments there for more information)
Partly addresses https://github.com/kytos-ng/kytos/issues/314 

### Summary

See updated changelog file

### Local Tests

- Simulated a Mongo `OperationFailure` (equivalent to index creation op error), confirmed the retries also worked as expected, and confirmed the traceback was included (this will generate some extra information, but when this happens, sometimes it can be an actual bug, so the traceback will be needed for reporting a bug):

```
Web update - Web UI was not updated
2023-09-26 14:28:47,620 - INFO [kytos.core.db] (MainThread) Starting DB connection
2023-09-26 14:28:47,621 - INFO [kytos.core.db] (MainThread) Trying to run 'hello' command on MongoDB...
2023-09-26 14:28:47,631 - INFO [kytos.core.db] (MainThread) Ran 'hello' command on MongoDB successfully. It's ready!
2023-09-26 14:28:47,631 - WARNING [kytos.core.retry] (MainThread) Retry #1 for bootstrap_index, args: (<class 'kytos.core.db.Mongo'>, 'users', [('username', 1)]), kwargs: {'unique': Tru
e}, seconds since start: 0.00
2023-09-26 14:28:48,192 - WARNING [kytos.core.retry] (MainThread) Retry #2 for bootstrap_index, args: (<class 'kytos.core.db.Mongo'>, 'users', [('username', 1)]), kwargs: {'unique': Tru
e}, seconds since start: 0.56
Kytos couldn't start because of some forced OperationFailure Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 260, in start
    self.start_auth()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 165, in start_auth
    self.auth = Auth(self)
  File "/home/viniarck/repos/kytos/kytos/core/auth.py", line 202, in __init__
    self.user_controller.bootstrap_indexes()
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 324, in wrapped_f
    return self(f, *args, **kw)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 404, in __call__
    do = self.iter(retry_state=retry_state)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 349, in iter
    return fut.result()
  File "/usr/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 407, in __call__
    result = fn(*args, **kwargs)
  File "/home/viniarck/repos/kytos/kytos/core/retry.py", line 25, in decorated
    return func(*args, **kwargs)
  File "/home/viniarck/repos/kytos/kytos/core/auth.py", line 96, in bootstrap_indexes
    if self.mongo.bootstrap_index(collection, keys, **kwargs):
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 324, in wrapped_f
    return self(f, *args, **kw)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 404, in __call__
    do = self.iter(retry_state=retry_state)
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 360, in iter
    raise retry_exc.reraise()
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 193, in reraise
    raise self.last_attempt.result()
  File "/usr/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/home/viniarck/repos/kytos/.direnv/python-3.9/lib/python3.9/site-packages/tenacity/__init__.py", line 407, in __call__
    result = fn(*args, **kwargs)
  File "/home/viniarck/repos/kytos/kytos/core/db.py", line 121, in bootstrap_index
    raise OperationFailure("some forced OperationFailure")
pymongo.errors.OperationFailure: some forced OperationFailure

Task was destroyed but it is pending!
task: <Task pending name='Task-1' coro=<start_shell_async() running at /home/viniarck/repos/kytos/kytos/core/kytosd.py:120>>
sys:1: RuntimeWarning: coroutine 'start_shell_async' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

- Simulated a generic error, undefined variable on `flow_manager`, noticed that the traeback was chained correctly just so you can trace it completely:

```
Web update - Web UI was not updated
2023-09-26 14:35:31,877 - INFO [kytos.core.db] (MainThread) Starting DB connection
2023-09-26 14:35:31,878 - INFO [kytos.core.db] (MainThread) Trying to run 'hello' command on MongoDB...
2023-09-26 14:35:31,889 - INFO [kytos.core.db] (MainThread) Ran 'hello' command on MongoDB successfully. It's ready!
2023-09-26 14:35:31,901 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/core/auth/login/ - GET
2023-09-26 14:35:31,901 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/core/auth/users/ - GET
2023-09-26 14:35:31,901 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/core/auth/users/{username} - GET
2023-09-26 14:35:31,901 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/core/auth/users/ - POST
2023-09-26 14:35:31,901 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/core/auth/users/{username} - DELETE
2023-09-26 14:35:31,901 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/core/auth/users/{username} - PATCH
2023-09-26 14:35:31,901 - INFO [kytos.core.controller] (MainThread) /home/viniarck/repos/kytos/.direnv/python-3.9/var/run/kytos
2023-09-26 14:35:31,901 - INFO [kytos.core.controller] (MainThread) Starting Kytos - Kytos Controller
2023-09-26 14:35:31,903 - INFO [kytos.core.controller] (MainThread) Starting TCP server: <kytos.core.atcp_server.KytosServer object at 0x7f540d51d490>
2023-09-26 14:35:31,903 - INFO [kytos.core.atcp_server] (MainThread) Kytos listening at 0.0.0.0:6653
2023-09-26 14:35:31,903 - INFO [kytos.core.controller] (MainThread) Loading Kytos NApps...
2023-09-26 14:35:31,905 - INFO [kytos.core.napps.napp_dir_listener] (MainThread) NAppDirListener Started...
2023-09-26 14:35:31,907 - INFO [kytos.core.controller] (MainThread) Loading NApp kytos/flow_manager
Kytos couldn't start because of KytosNAppSetupException: NApp kytos/flow_manager exception name 'undef_var' is not defined  Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 863, in load_napp
    napp = napp_module.Main(controller=self)
  File "/home/viniarck/repos/kytos/kytos/core/napps/base.py", line 194, in __init__
    self.setup()
  File "/home/viniarck/repos/napps/napps/kytos/flow_manager/main.py", line 90, in setup
    undef_var
NameError: name 'undef_var' is not defined

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 265, in start
    self.start_controller()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 359, in start_controller
    self.load_napps()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 898, in load_napps
    self.load_napp(napp.username, napp.name)
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 866, in load_napp
    raise KytosNAppSetupException(msg) from exc
kytos.core.exceptions.KytosNAppSetupException: KytosNAppSetupException: NApp kytos/flow_manager exception name 'undef_var' is not defined 

Task was destroyed but it is pending!
task: <Task pending name='Task-1' coro=<start_shell_async() running at /home/viniarck/repos/kytos/kytos/core/kytosd.py:120>>
2023-09-26 14:35:32,041 - ERROR [kytos.core.controller] (MainThread) 1
2023-09-26 14:35:32,041 - INFO [kytos.core.controller] (MainThread) Shutting down Kytos...
/home/viniarck/repos/kytos/kytos/core/kytosd.py:98: RuntimeWarning: coroutine 'start_shell_async' was never awaited
  async_main(config)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```


### End-to-End Tests

I'll dispatch an exec on GitLab, I'll post the results here later:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 242 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 47%]
...                                                                      [ 48%]
tests/test_e2e_14_mef_eline.py x                                         [ 49%]
tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py .............                              [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
=============================== warnings summary ===============================
= 220 passed, 6 skipped, 11 xfailed, 5 xpassed, 867 warnings in 11472.15s (3:11:12) =
```