### PR TITLE
chore: reuse `sys.exit` call when catching exceptions

### DIFF
--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -164,55 +164,55 @@ class TestController(TestCase):
         self.assertRaises(ValueError,
                           self.controller.toggle_debug, name="foobar")
 
-    @patch('kytos.core.controller.Controller.init_apm_or_core_shutdown')
-    @patch('kytos.core.controller.Controller.db_conn_or_core_shutdown')
+    @patch('kytos.core.controller.init_apm')
+    @patch('kytos.core.controller.db_conn_wait')
     @patch('kytos.core.controller.Controller.start_controller')
     @patch('kytos.core.controller.Controller.create_pidfile')
     @patch('kytos.core.controller.Controller.enable_logs')
     def test_start(self, *args):
         """Test start method."""
         (mock_enable_logs, mock_create_pidfile,
-         mock_start_controller, mock_db_conn_or_shutdown,
-         mock_init_apm_or_shutdown) = args
+         mock_start_controller, mock_db_conn_wait,
+         mock_init_apm) = args
         self.controller.start()
 
         mock_enable_logs.assert_called()
         mock_create_pidfile.assert_called()
         mock_start_controller.assert_called()
-        mock_db_conn_or_shutdown.assert_not_called()
-        mock_init_apm_or_shutdown.assert_not_called()
+        mock_db_conn_wait.assert_not_called()
+        mock_init_apm.assert_not_called()
 
     @patch('kytos.core.controller.sys')
-    @patch('kytos.core.controller.Controller.init_apm_or_core_shutdown')
-    @patch('kytos.core.controller.Controller.db_conn_or_core_shutdown')
+    @patch('kytos.core.controller.init_apm')
+    @patch('kytos.core.controller.db_conn_wait')
     @patch('kytos.core.controller.Controller.start_controller')
     @patch('kytos.core.controller.Controller.create_pidfile')
     @patch('kytos.core.controller.Controller.enable_logs')
     def test_start_error_broad_exception(self, *args):
         """Test start error handling broad exception."""
         (mock_enable_logs, mock_create_pidfile,
-         mock_start_controller, mock_db_conn_or_shutdown,
-         mock_init_apm_or_shutdown, mock_sys) = args
+         mock_start_controller, mock_db_conn_wait,
+         mock_init_apm, mock_sys) = args
         mock_start_controller.side_effect = Exception
         self.controller.start()
 
         mock_enable_logs.assert_called()
         mock_create_pidfile.assert_called()
         mock_start_controller.assert_called()
-        mock_db_conn_or_shutdown.assert_not_called()
-        mock_init_apm_or_shutdown.assert_not_called()
+        mock_db_conn_wait.assert_not_called()
+        mock_init_apm.assert_not_called()
         mock_sys.exit.assert_called()
 
-    @patch('kytos.core.controller.Controller.init_apm_or_core_shutdown')
-    @patch('kytos.core.controller.Controller.db_conn_or_core_shutdown')
+    @patch('kytos.core.controller.init_apm')
+    @patch('kytos.core.controller.db_conn_wait')
     @patch('kytos.core.controller.Controller.start_controller')
     @patch('kytos.core.controller.Controller.create_pidfile')
     @patch('kytos.core.controller.Controller.enable_logs')
     def test_start_with_mongodb_and_apm(self, *args):
         """Test start method with database and APM options set."""
         (mock_enable_logs, mock_create_pidfile,
-         mock_start_controller, mock_db_conn_or_shutdown,
-         mock_init_apm_or_shutdown) = args
+         mock_start_controller, mock_db_conn_wait,
+         mock_init_apm) = args
         self.controller.options.database = "mongodb"
         self.controller.options.apm = "es"
         self.controller.start()
@@ -220,21 +220,18 @@ class TestController(TestCase):
         mock_enable_logs.assert_called()
         mock_create_pidfile.assert_called()
         mock_start_controller.assert_called()
-        mock_db_conn_or_shutdown.assert_called()
-        mock_init_apm_or_shutdown.assert_called()
+        mock_db_conn_wait.assert_called()
+        mock_init_apm.assert_called()
 
     @patch('kytos.core.controller.sys.exit')
-    @patch('kytos.core.controller.Controller.start_controller')
     @patch('kytos.core.controller.Controller.create_pidfile')
     @patch('kytos.core.controller.Controller.enable_logs')
     def test_start_with_invalid_database_backend(self, *args):
         """Test start method with unsupported database backend."""
-        (mock_enable_logs, _,
-         mock_start_controller, mock_sys_exit) = args
+        (mock_enable_logs, _, mock_sys_exit) = args
         self.controller.options.database = "invalid"
         self.controller.start()
         mock_enable_logs.assert_called()
-        mock_start_controller.assert_called()
         mock_sys_exit.assert_called()
 
     @patch('os.getpid')


### PR DESCRIPTION
Closes #415 

### Summary

- Reuse `sys.exit` call when catching `(KytosDBInitException, KytosAPMInitException)` and remove their individual `sys.exit` calls. 
- I didn't update the changelog since this is just an equivalent internal refactoring 

### Local Tests

- Invalid ``--database`` value:

```
❯ kytosd -f --database mongodbx -E
Web update - Web UI was not updated
Kytos couldn't start because of KytosDBInitException: DB backend 'mongodbx' isn't supported. Current supported databases: mongodb
2023-09-29 10:14:46,594 - INFO [kytos.core.db] [db.py:152:db_conn_wait] (MainThread) Starting DB connection
Task was destroyed but it is pending!
task: <Task pending name='Task-1' coro=<start_shell_async() running at /home/viniarck/repos/kytos/kytos/core/kytosd.py:121>>
2023-09-29 10:14:46,594 - ERROR [kytos.core.controller] [kytosd.py:157:async_main] (MainThread) Kytos couldn't start because of KytosDBInitException: DB backend 'mongodbx' isn't support
ed. Current supported databases: mongodb
2023-09-29 10:14:46,594 - INFO [kytos.core.controller] [kytosd.py:158:async_main] (MainThread) Shutting down Kytos...
/home/viniarck/repos/kytos/kytos/core/kytosd.py:99: RuntimeWarning: coroutine 'start_shell_async' was never awaited
  async_main(config)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

- Invalid ``--apm`` value:

```
❯ kytosd -f --database mongodb --apm esx -E
Web update - Web UI was not updated
2023-09-29 10:14:59,770 - INFO [kytos.core.db] [db.py:152:db_conn_wait] (MainThread) Starting DB connection
2023-09-29 10:14:59,771 - INFO [kytos.core.db] [db.py:137:_mongo_conn_wait] (MainThread) Trying to run 'hello' command on MongoDB...
2023-09-29 10:14:59,781 - INFO [kytos.core.db] [db.py:139:_mongo_conn_wait] (MainThread) Ran 'hello' command on MongoDB successfully. It's ready!
2023-09-29 10:14:59,823 - INFO [kytos.core.auth] [auth.py:97:bootstrap_indexes] (MainThread) Created DB index [('username', 1)], collection: users
Kytos couldn't start because of KytosAPMInitException: APM backend 'esx' isn't supported. Current supported APMs: es
2023-09-29 10:14:59,826 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/login/ - GET
Task was destroyed but it is pending!
task: <Task pending name='Task-1' coro=<start_shell_async() running at /home/viniarck/repos/kytos/kytos/core/kytosd.py:121>>
2023-09-29 10:14:59,826 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/ - GET
2023-09-29 10:14:59,826 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/{username} - GET
/home/viniarck/repos/kytos/kytos/core/kytosd.py:99: RuntimeWarning: coroutine 'start_shell_async' was never awaited
  async_main(config)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
2023-09-29 10:14:59,826 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/ - POST
2023-09-29 10:14:59,826 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/{username} - DELETE
2023-09-29 10:14:59,826 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/{username} - PATCH
2023-09-29 10:14:59,826 - ERROR [kytos.core.controller] [kytosd.py:157:async_main] (MainThread) Kytos couldn't start because of KytosAPMInitException: APM backend 'esx' isn't supported.
 Current supported APMs: es
2023-09-29 10:14:59,826 - INFO [kytos.core.controller] [kytosd.py:158:async_main] (MainThread) Shutting down Kytos...
```

- Simulating an unhandled exception on `flow_manager` during `setup()`:

Notice below that we might end up with redundant/duplicated information in the console, since [ultimately](https://github.com/kytos-ng/kytos/blob/master/kytos/core/kytosd.py#L156-L157), when handling a `SystemExit`, controller.log will log it as an error. However, in some cases it might not do it properly see issue #418 for more information, so we'll need to keep the `print` and have this redudant information here to avoid losing context in the meantime. 

> ERROR [kytos.core.controller] [kytosd.py:157:async_main] (MainThread) Kytos couldn't start because of KytosNAppSetupException: NApp kytos/flow_manager exception

```
❯ kytosd -f --database mongodb -E
Web update - Web UI was not updated
2023-09-29 10:15:24,314 - INFO [kytos.core.db] [db.py:152:db_conn_wait] (MainThread) Starting DB connection
2023-09-29 10:15:24,316 - INFO [kytos.core.db] [db.py:137:_mongo_conn_wait] (MainThread) Trying to run 'hello' command on MongoDB...
2023-09-29 10:15:24,325 - INFO [kytos.core.db] [db.py:139:_mongo_conn_wait] (MainThread) Ran 'hello' command on MongoDB successfully. It's ready!
2023-09-29 10:15:24,339 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/login/ - GET
2023-09-29 10:15:24,339 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/ - GET
2023-09-29 10:15:24,339 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/{username} - GET
2023-09-29 10:15:24,340 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/ - POST
2023-09-29 10:15:24,340 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/{username} - DELETE
2023-09-29 10:15:24,340 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/kytos/core/auth/users/{username} - PATCH
2023-09-29 10:15:24,340 - INFO [kytos.core.controller] [controller.py:283:create_pidfile] (MainThread) /home/viniarck/repos/kytos/.direnv/python-3.9/var/run/kytos
2023-09-29 10:15:24,340 - INFO [kytos.core.controller] [controller.py:341:start_controller] (MainThread) Starting Kytos - Kytos Controller
2023-09-29 10:15:24,342 - INFO [kytos.core.controller] [controller.py:350:start_controller] (MainThread) Starting TCP server: <kytos.core.atcp_server.KytosServer object at 0x7f6bb07d5370
>
2023-09-29 10:15:24,343 - INFO [kytos.core.atcp_server] [atcp_server.py:75:serve_forever] (MainThread) Kytos listening at 0.0.0.0:6653
2023-09-29 10:15:24,343 - INFO [kytos.core.controller] [controller.py:360:start_controller] (MainThread) Loading Kytos NApps...
2023-09-29 10:15:24,345 - INFO [kytos.core.napps.napp_dir_listener] [napp_dir_listener.py:40:start] (MainThread) NAppDirListener Started...
2023-09-29 10:15:24,349 - INFO [kytos.core.controller] [controller.py:885:load_napps] (MainThread) Loading NApp kytos/flow_manager
Kytos couldn't start because of KytosNAppSetupException: NApp kytos/flow_manager exception unexpected  Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 851, in load_napp
    napp = napp_module.Main(controller=self)
  File "/home/viniarck/repos/kytos/kytos/core/napps/base.py", line 194, in __init__
    self.setup()
  File "/home/viniarck/repos/napps/napps/kytos/flow_manager/main.py", line 86, in setup
    raise ValueError("unexpected")
ValueError: unexpected

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 265, in start
    self.start_controller()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 363, in start_controller
    self.load_napps()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 886, in load_napps
    self.load_napp(napp.username, napp.name)
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 854, in load_napp
    raise KytosNAppSetupException(msg) from exc
kytos.core.exceptions.KytosNAppSetupException: KytosNAppSetupException: NApp kytos/flow_manager exception unexpected 

Task was destroyed but it is pending!
task: <Task pending name='Task-1' coro=<start_shell_async() running at /home/viniarck/repos/kytos/kytos/core/kytosd.py:121>>
2023-09-29 10:15:24,463 - ERROR [kytos.core.controller] [kytosd.py:157:async_main] (MainThread) Kytos couldn't start because of KytosNAppSetupException: NApp kytos/flow_manager exception
 unexpected  Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 851, in load_napp
    napp = napp_module.Main(controller=self)
  File "/home/viniarck/repos/kytos/kytos/core/napps/base.py", line 194, in __init__
    self.setup()
  File "/home/viniarck/repos/napps/napps/kytos/flow_manager/main.py", line 86, in setup
    raise ValueError("unexpected")
ValueError: unexpected

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 265, in start
    self.start_controller()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 363, in start_controller
    self.load_napps()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 886, in load_napps
    self.load_napp(napp.username, napp.name)
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 854, in load_napp
    raise KytosNAppSetupException(msg) from exc
kytos.core.exceptions.KytosNAppSetupException: KytosNAppSetupException: NApp kytos/flow_manager exception unexpected 

2023-09-29 10:15:24,463 - INFO [kytos.core.controller] [kytosd.py:158:async_main] (MainThread) Shutting down Kytos...
/home/viniarck/repos/kytos/kytos/core/kytosd.py:99: RuntimeWarning: coroutine 'start_shell_async' was never awaited
  async_main(config)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

- Start `kytosd` correctly:

```
2023-09-29 10:15:43,776 - INFO [kytos.core.controller] [controller.py:885:load_napps] (MainThread) Loading NApp kytos/of_core
2023-09-29 10:15:43,819 - INFO [kytos.core.napps.base] [base.py:248:run] (of_core) Running NApp: <Main(of_core, started 140644601292480)>
2023-09-29 10:15:43,820 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /ui/{username}/{napp_name}/{filename:path} - GET
2023-09-29 10:15:43,820 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /ui/{section_name}/ - GET
2023-09-29 10:15:43,820 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started / - GET
2023-09-29 10:15:43,820 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /index.html - GET

     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2023.1.0

kytos $> INFO:     Started server process [34553]                                                                                                                                         
2023-09-29 10:15:43,926 - INFO [uvicorn.error] [on.py:48:startup] (MainThread) Waiting for application startup.
2023-09-29 10:15:43,926 - INFO [kytos.core.controller] [controller.py:558:event_handler] (MainThread) Event handler conn started
2023-09-29 10:15:43,926 - INFO [kytos.core.controller] [controller.py:558:event_handler] (MainThread) Event handler raw started
2023-09-29 10:15:43,926 - INFO [kytos.core.controller] [controller.py:558:event_handler] (MainThread) Event handler msg_in started
2023-09-29 10:15:43,926 - INFO [kytos.core.controller] [controller.py:585:msg_out_event_handler] (MainThread) Event handler msg_out started
2023-09-29 10:15:43,926 - INFO [kytos.core.controller] [controller.py:558:event_handler] (MainThread) Event handler app started
2023-09-29 10:15:44,000 - INFO [uvicorn.error] [on.py:62:startup] (MainThread) Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8181 (Press CTRL+C to quit)
kytos $>                                                                                                                                                                                                                                                                                                                                                                  
```

### End-to-End Tests

I'll dispatch an exec shortly on GitLab. 
