### PR TITLE
fix: avoid `kytosd` hanging its termination when handling `SystemExit` with SIGTERM

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Changed
 - ``kytosd`` process will exit if a NApp raises an exception during its ``setup()`` execution.
 - Change format for ``Interface.available_tags`` to ``dict[str, list[list[int]]]``. Storing ``tag_types`` as keys and a list of ranges for ``available_tags`` as values.
 
+Fixed
+=====
+- Avoid ``kytosd`` hanging its termination when handling ``SystemExit`` with SIGTERM
+
 Deprecated
 ==========
 - Deleted ``vlan_pool`` from ``kytos.conf`` in favor of ``Interface.tag_ranges`` which updates from ``kytos/topology`` API endpoint, ``v3/interfaces/{intf_id}/tag_ranges``.

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -170,11 +170,9 @@ class Controller:
         try:
             decorators = [self._resolve(deco) for deco in decorators]
         except ModuleNotFoundError as err:
-            print(f'Failed to resolve decorator module: {err.name}')
-            sys.exit(1)
+            sys.exit(f'Failed to resolve decorator module: {err.name}')
         except AttributeError:
-            print(f'Failed to resolve decorator name: {decorators}')
-            sys.exit(1)
+            sys.exit(f'Failed to resolve decorator name: {decorators}')
         LogManager.decorate_logger_class(*decorators)
         LogManager.load_config_file(self.options.logging, self.options.debug)
         # pylint: disable=fixme
@@ -264,12 +262,10 @@ class Controller:
             self.start_controller()
         except (KytosDBInitException, KytosAPMInitException) as exc:
             message = f"Kytos couldn't start because of {str(exc)}"
-            print(message)
             sys.exit(message)
         except Exception as exc:
             exc_fmt = traceback.format_exc(chain=True)
             message = f"Kytos couldn't start because of {str(exc)} {exc_fmt}"
-            print(message)
             sys.exit(message)
 
     def create_pidfile(self):

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -127,9 +127,9 @@ def stop_controller_sys_exit(controller, config, shell_task=None):
             pass
 
     try:
-        with open(config.pidfile, "r") as f:
-            pid = int(f.read().strip())
-            os.kill(pid, signal.SIGTERM.value)
+        with open(config.pidfile, "r", encoding="utf8") as file:
+            pid = int(file.read().strip())
+            os.kill(pid, signal.SIGTERM)
     except (FileNotFoundError, OSError):
         pass
 

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -117,6 +117,23 @@ def stop_controller(controller, shell_task=None):
         shell_task.cancel()
 
 
+def stop_controller_sys_exit(controller, config, shell_task=None):
+    """Stop the controller while handling sys exit."""
+    controller.stop()
+    if shell_task:
+        try:
+            shell_task.cancel()
+        except asyncio.CancelledError:
+            pass
+
+    try:
+        with open(config.pidfile, "r") as f:
+            pid = int(f.read().strip())
+            os.kill(pid, signal.SIGTERM.value)
+    except (FileNotFoundError, OSError):
+        pass
+
+
 async def start_shell_async(controller, executor):
     """Run the shell inside a thread and stop controller when done."""
     _start_shell = functools.partial(start_shell, controller)
@@ -153,7 +170,10 @@ def async_main(config):
     try:
         loop.run_forever()
     except SystemExit as exc:
-        controller.log.error(exc)
-        controller.log.info("Shutting down Kytos...")
+        print(exc)
+        print("Shutting down Kytos...")
+        loop.remove_signal_handler(signal.SIGINT)
+        loop.remove_signal_handler(signal.SIGTERM)
+        stop_controller_sys_exit(controller, config, shell_task)
     finally:
         loop.close()

--- a/tests/unit/test_core/test_kytosd.py
+++ b/tests/unit/test_core/test_kytosd.py
@@ -94,10 +94,10 @@ class TestKytosd(TestCase):
 
     @patch("builtins.open", create=True)
     @patch('kytos.core.kytosd.os')
-    def test_stop_controller_sys_exit(self, mock_os, mock_open) -> None:
+    def test_stop_controller_sys_exit(self, mock_os, _mock_open) -> None:
         """Test stop the controller sys exit."""
         controller, config = MagicMock(), MagicMock()
         stop_controller_sys_exit(controller, config)
         controller.stop.assert_called()
         mock_os.kill.assert_called()
-        assert mock_os.kill.call_args[0][1] == signal.SIGTERM.value
+        assert mock_os.kill.call_args[0][1] == signal.SIGTERM

--- a/tests/unit/test_core/test_kytosd.py
+++ b/tests/unit/test_core/test_kytosd.py
@@ -1,8 +1,10 @@
 """Test kytos.core.kytosd module."""
+import signal
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from kytos.core.kytosd import _create_pid_dir, async_main, main, start_shell
+from kytos.core.kytosd import (_create_pid_dir, async_main, main, start_shell,
+                               stop_controller_sys_exit)
 
 
 class TestKytosd(TestCase):
@@ -89,3 +91,13 @@ class TestKytosd(TestCase):
         async_main(MagicMock())
 
         event_loop.call_soon.assert_called_with(controller.start)
+
+    @patch("builtins.open", create=True)
+    @patch('kytos.core.kytosd.os')
+    def test_stop_controller_sys_exit(self, mock_os, mock_open) -> None:
+        """Test stop the controller sys exit."""
+        controller, config = MagicMock(), MagicMock()
+        stop_controller_sys_exit(controller, config)
+        controller.stop.assert_called()
+        mock_os.kill.assert_called()
+        assert mock_os.kill.call_args[0][1] == signal.SIGTERM.value


### PR DESCRIPTION
Closes #424 

### Summary

See updated changelog

### Local Tests

- Confirmed `kytosd` got terminated as expected with the existing sys.exit cases. 
- Confirmed no side effects when stopping `kytosd` in foreground normally with CTRL-D
- Confirmed that the moved `print(exc)` printed out `SystemExit` content. 

Here's the same exec with the reported issue:

```
2023-10-25 09:52:17,053 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/amlight/sdntrace_cp/v1/trace - PUT
2023-10-25 09:52:17,053 - INFO [kytos.core.api_server] [api_server.py:429:_start_endpoint] (MainThread) Started /api/amlight/sdntrace_cp/v1/traces - PUT
2023-10-25 09:52:17,053 - INFO [kytos.core.controller] [controller.py:847:load_napps] (MainThread) Loading NApp amlight/noviflow
2023-10-25 09:52:17,056 - INFO [kytos.core.napps.base] [base.py:248:run] (noviflow) Running NApp: <Main(noviflow, started 140440724563648)>
2023-10-25 09:52:17,056 - INFO [kytos.core.controller] [controller.py:847:load_napps] (MainThread) Loading NApp kytos/mef_eline
2023-10-25 09:52:17,270 - INFO [apscheduler.scheduler] [base.py:171:start] (MainThread) Scheduler started
Kytos couldn't start because of KytosNAppSetupException: NApp kytos/mef_eline exception some err  Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 813, in load_napp
    napp = napp_module.Main(controller=self)
  File "/home/viniarck/repos/kytos/kytos/core/napps/base.py", line 194, in __init__
    self.setup()
  File "/home/viniarck/repos/napps/napps/kytos/mef_eline/main.py", line 66, in setup
    raise ValueError("some err")
ValueError: some err

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 262, in start
    self.start_controller()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 358, in start_controller
    self.load_napps()
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 848, in load_napps
    self.load_napp(napp.username, napp.name)
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 816, in load_napp
    raise KytosNAppSetupException(msg) from exc
kytos.core.exceptions.KytosNAppSetupException: KytosNAppSetupException: NApp kytos/mef_eline exception some err 

Shutting down Kytos...
[1]    28495 terminated  kytosd -f --database mongodb -E
```

### End-to-End Tests

```
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 242 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 47%]
.                                                                        [ 47%]
tests/test_e2e_14_mef_eline.py x                                         [ 48%]
tests/test_e2e_15_mef_eline.py ....                                      [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py .............                              [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 220 passed, 6 skipped, 9 xfailed, 7 xpassed, 867 warnings in 11640.76s (3:14:00) =
```
