### PR TITLE
feature: Added support to `list[list[int]]` input

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,12 +10,15 @@ Added
 =====
 - Added ``Interface.tag_ranges`` as ``dict[str, list[list[int]]]`` as replacement for ``vlan_pool`` settings.
 - Added ``kytos/core.interface_tags`` event publication to notify any modification of ``Interface.tag_ranges`` or ``Interface.available_tags``.
+- Added ``TAGRange`` class which is used when a ``UNI`` has a tag as a list of ranges.
+- Added ``KytosTagError`` exception that cover other exceptions ``KytosTagtypeNotSupported``, ``KytosInvalidTagRanges``, ``KytosSetTagRangeError``, ``KytosTagsNotInTagRanges`` and ``KytosTagsAreNotAvailable`` all of which are related to TAGs.
 
 Changed
 =======
 - Parametrized default ``maxTimeMS`` when creating an index via ``Mongo.boostrap_index`` via environment variable ``MONGO_IDX_TIMEOUTMS=30000``. The retries parameters reuse the same environment variables ``MONGO_AUTO_RETRY_STOP_AFTER_ATTEMPT=3``, ``MONGO_AUTO_RETRY_WAIT_RANDOM_MIN=0.1``, ``MONGO_AUTO_RETRY_WAIT_RANDOM_MAX=1`` that NApps controllers have been using.
 - ``kytosd`` process will exit if a NApp raises an exception during its ``setup()`` execution.
 - Change format for ``Interface.available_tags`` to ``dict[str, list[list[int]]]``. Storing ``tag_types`` as keys and a list of ranges for ``available_tags`` as values.
+- ``Interface.use_tags`` and ``Interface.make_tags_available`` are compatible with list of ranges.
 
 Deprecated
 ==========

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -121,6 +121,19 @@ class KytosTagsAreNotAvailable(Exception):
                f" in {self.intf_id}"
 
 
+class KytosInvalidRanges(Exception):
+    """Exception thrown when a tag is not available."""
+    def __init__(self, message: str) -> None:
+        super().__init__()
+        self.message = message
+
+    def __repr__(self):
+        return f"KytosInvalidRanges {self.message}"
+
+    def __str__(self) -> str:
+        return f"KytosInvalidRanges {self.message}"
+
+
 # Exceptions related  to NApps
 
 

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -86,7 +86,33 @@ class KytosLinkCreationError(Exception):
 
 
 class KytosTagtypeNotSupported(Exception):
-    """Exception thronw when a not supported tag type is not supported"""
+    """Exception thrown when a not supported tag type is not supported"""
+
+
+class KytosTagsNotInTagRanges(Exception):
+    """Exception thrown when a tag is outside of tag ranges"""
+    def __init__(self, conflict: list[list[int]]) -> None:
+        super().__init__()
+        self.conflict = conflict
+
+    def __repr__(self):
+        return f"The tags {self.conflict} are outside tag_ranges"
+
+    def __str__(self) -> str:
+        return f"The tags {self.conflict} are outside tag_ranges"
+
+
+class KytosTagsAreNotAvailable(Exception):
+    """Exception thrown when a tag is not available."""
+    def __init__(self, conflict: list[list[int]]) -> None:
+        super().__init__()
+        self.conflict = conflict
+
+    def __repr__(self):
+        return f"The tags {self.conflict} are not available."
+
+    def __str__(self) -> str:
+        return f"The tags {self.conflict} are not available."
 
 
 # Exceptions related  to NApps

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -91,28 +91,34 @@ class KytosTagtypeNotSupported(Exception):
 
 class KytosTagsNotInTagRanges(Exception):
     """Exception thrown when a tag is outside of tag ranges"""
-    def __init__(self, conflict: list[list[int]]) -> None:
+    def __init__(self, conflict: list[list[int]], intf_id: str) -> None:
         super().__init__()
         self.conflict = conflict
+        self.intf_id = intf_id
 
     def __repr__(self):
-        return f"The tags {self.conflict} are outside tag_ranges"
+        return f"The tags {self.conflict} are outside tag_ranges"\
+               f" in {self.intf_id}"
 
     def __str__(self) -> str:
-        return f"The tags {self.conflict} are outside tag_ranges"
+        return f"The tags {self.conflict} are outside tag_ranges"\
+               f" in {self.intf_id}"
 
 
 class KytosTagsAreNotAvailable(Exception):
     """Exception thrown when a tag is not available."""
-    def __init__(self, conflict: list[list[int]]) -> None:
+    def __init__(self, conflict: list[list[int]], intf_id: str) -> None:
         super().__init__()
         self.conflict = conflict
+        self.intf_id = intf_id
 
     def __repr__(self):
-        return f"The tags {self.conflict} are not available."
+        return f"The tags {self.conflict} are not available."\
+               f" in {self.intf_id}"
 
     def __str__(self) -> str:
-        return f"The tags {self.conflict} are not available."
+        return f"The tags {self.conflict} are not available."\
+               f" in {self.intf_id}"
 
 
 # Exceptions related  to NApps

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -85,8 +85,28 @@ class KytosLinkCreationError(Exception):
     """Exception thrown when the link has an empty endpoint."""
 
 
-class KytosTagtypeNotSupported(Exception):
+class KytosTagError(Exception):
+    """Exception to catch an error when setting tag type or value."""
+    def __init__(self, msg: str) -> None:
+        self.msg = msg
+
+    def __str__(self) -> str:
+        return f"{self.msg}"
+
+    def __repr__(self) -> str:
+        return f"{self.msg}"
+
+
+class KytosTagtypeNotSupported(KytosTagError):
     """Exception thrown when a not supported tag type is not supported"""
+    def __init__(self, msg: str) -> None:
+        super().__init__(f"KytosTagtypeNotSupported, {msg}")
+
+
+class KytosInvalidTagRanges(KytosTagError):
+    """Exception thrown when a list of ranges is invalid."""
+    def __init__(self, msg: str) -> None:
+        super().__init__(f"KytosInvalidTagRanges, {msg}")
 
 
 class KytosTagsNotInTagRanges(Exception):
@@ -119,19 +139,6 @@ class KytosTagsAreNotAvailable(Exception):
     def __str__(self) -> str:
         return f"The tags {self.conflict} are not available."\
                f" in {self.intf_id}"
-
-
-class KytosInvalidRanges(Exception):
-    """Exception thrown when a tag is not available."""
-    def __init__(self, message: str) -> None:
-        super().__init__()
-        self.message = message
-
-    def __repr__(self):
-        return f"KytosInvalidRanges {self.message}"
-
-    def __str__(self) -> str:
-        return f"KytosInvalidRanges {self.message}"
 
 
 # Exceptions related  to NApps

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -77,10 +77,6 @@ class KytosNoTagAvailableError(Exception):
         return msg
 
 
-class KytosSetTagRangeError(Exception):
-    """Exception raised when available_tag cannot be resized"""
-
-
 class KytosLinkCreationError(Exception):
     """Exception thrown when the link has an empty endpoint."""
 
@@ -107,6 +103,12 @@ class KytosInvalidTagRanges(KytosTagError):
     """Exception thrown when a list of ranges is invalid."""
     def __init__(self, msg: str) -> None:
         super().__init__(f"KytosInvalidTagRanges, {msg}")
+
+
+class KytosSetTagRangeError(KytosTagError):
+    """Exception raised when available_tag cannot be resized"""
+    def __init__(self, msg: str) -> None:
+        super().__init__(f"KytosSetTagRangeError, {msg}")
 
 
 class KytosTagsNotInTagRanges(Exception):

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -111,36 +111,18 @@ class KytosSetTagRangeError(KytosTagError):
         super().__init__(f"KytosSetTagRangeError, {msg}")
 
 
-class KytosTagsNotInTagRanges(Exception):
+class KytosTagsNotInTagRanges(KytosTagError):
     """Exception thrown when a tag is outside of tag ranges"""
     def __init__(self, conflict: list[list[int]], intf_id: str) -> None:
-        super().__init__()
-        self.conflict = conflict
-        self.intf_id = intf_id
-
-    def __repr__(self):
-        return f"The tags {self.conflict} are outside tag_ranges"\
-               f" in {self.intf_id}"
-
-    def __str__(self) -> str:
-        return f"The tags {self.conflict} are outside tag_ranges"\
-               f" in {self.intf_id}"
+        msg = f"The tags {conflict} are outside tag_ranges in {intf_id}"
+        super().__init__(f"KytosSetTagRangeError, {msg}")
 
 
-class KytosTagsAreNotAvailable(Exception):
+class KytosTagsAreNotAvailable(KytosTagError):
     """Exception thrown when a tag is not available."""
     def __init__(self, conflict: list[list[int]], intf_id: str) -> None:
-        super().__init__()
-        self.conflict = conflict
-        self.intf_id = intf_id
-
-    def __repr__(self):
-        return f"The tags {self.conflict} are not available."\
-               f" in {self.intf_id}"
-
-    def __str__(self) -> str:
-        return f"The tags {self.conflict} are not available."\
-               f" in {self.intf_id}"
+        msg = f"The tags {conflict} are not available in {intf_id}"
+        super().__init__(f"KytosSetTagRangeError, {msg}")
 
 
 # Exceptions related  to NApps

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -310,11 +310,11 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
                 if result is False:
                     self.available_tags[tag_type] = available_copy
                     conflict = range_difference(tags, available_copy)
-                    raise KytosTagsAreNotAvailable(conflict)
+                    raise KytosTagsAreNotAvailable(conflict, self._id)
         else:
             result = self.remove_tags(tags, tag_type)
             if result is False:
-                raise KytosTagsAreNotAvailable([tags])
+                raise KytosTagsAreNotAvailable([tags], self._id)
 
     # pylint: disable=too-many-branches
     def add_tags(self, tags: list[int], tag_type: str = 'vlan') -> bool:
@@ -330,7 +330,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         # Check if tags is within self.tag_ranges
         tag_ranges = self.tag_ranges[tag_type]
         if find_index_remove(tag_ranges, tags) is None:
-            raise KytosTagsNotInTagRanges([tags])
+            raise KytosTagsNotInTagRanges([tags], self._id)
 
         available = self.available_tags[tag_type]
         index = find_index_add(available, tags)
@@ -413,7 +413,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         if isinstance(tags[0], list):
             diff = range_difference(tags, self.tag_ranges[tag_type])
             if diff:
-                raise KytosTagsNotInTagRanges(diff)
+                raise KytosTagsNotInTagRanges(diff, self._id)
             available_tags = self.available_tags[tag_type]
             new_tags, conflict = range_addition(tags, available_tags)
             self.available_tags[tag_type] = new_tags

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -41,7 +41,7 @@ class TAGType(Enum):
 class TAG:
     """Class that represents a TAG."""
 
-    def __init__(self, tag_type, value):
+    def __init__(self, tag_type: str, value: int):
         self.tag_type = TAGType(tag_type).value
         self.value = value
 
@@ -70,6 +70,22 @@ class TAG:
 
     def __repr__(self):
         return f"TAG({self.tag_type!r}, {self.value!r})"
+
+
+# pylint: disable=super-init-not-called
+class TAGRange(TAG):
+    """Class that represents an User-to-Network Interface with
+     a tag value as a list."""
+
+    def __init__(
+        self,
+        tag_type: str,
+        value: list[list[int]],
+        mask_list: list[str, int]
+    ):
+        self.tag_type = TAGType(tag_type).value
+        self.value = value
+        self.mask_list = mask_list
 
 
 class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
@@ -740,7 +756,11 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
 class UNI:
     """Class that represents an User-to-Network Interface."""
 
-    def __init__(self, interface, user_tag=None):
+    def __init__(
+        self,
+        interface: Interface,
+        user_tag: Union[None, TAG, TAGRange]
+    ):
         self.user_tag = user_tag
         self.interface = interface
 

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -83,11 +83,11 @@ class TAGRange(TAG):
         self,
         tag_type: str,
         value: list[list[int]],
-        mask_list: list[Union[str, int]] = []
+        mask_list: list[Union[str, int]] = None
     ):
         self.tag_type = TAGType(tag_type).value
         self.value = value
-        self.mask_list = mask_list
+        self.mask_list = mask_list or []
 
     def as_dict(self):
         """Return a dictionary representating a tag range object."""

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -87,6 +87,14 @@ class TAGRange(TAG):
         self.value = value
         self.mask_list = mask_list
 
+    def as_dict(self):
+        """Return a dictionary representating a tag range object."""
+        return {
+            'tag_type': self.tag_type,
+            'value': self.value,
+            'mask_list': self.mask_list
+        }
+
 
 class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
     """Interface Class used to abstract the network interfaces."""

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -297,6 +297,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             tag_type: TAG type value
             use_lock: Boolean to whether use a lock or not
         """
+        if not tags:
+            return
         if isinstance(tags, int):
             tags = [tags] * 2
         if use_lock:
@@ -402,6 +404,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         Return:
             conflict: Return any values that were not added.
         """
+        if not tags:
+            return
         if isinstance(tags, int):
             tags = [tags] * 2
         if isinstance(tags[0], int) and tags[0] != tags[1]:

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -78,7 +78,6 @@ class TAGRange(TAG):
     """Class that represents an User-to-Network Interface with
      a tag value as a list."""
 
-    # pylint: disable=dangerous-default-value
     def __init__(
         self,
         tag_type: str,

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -157,10 +157,10 @@ class Link(GenericEntity):
                     try:
                         tag, _ = next(tags)
                         self.endpoint_a.use_tags(
-                            controller, tag, use_lock=False
+                            controller, tag, use_lock=False, check_order=False
                         )
                         self.endpoint_b.use_tags(
-                            controller, tag, use_lock=False
+                            controller, tag, use_lock=False, check_order=False
                         )
                         return tag
                     except StopIteration:
@@ -179,10 +179,12 @@ class Link(GenericEntity):
             with self.endpoint_a._tag_lock:
                 with self.endpoint_b._tag_lock:
                     conflict_a = self.endpoint_a.make_tags_available(
-                        controller, tags, tag_type, False, check_order
+                        controller, tags, tag_type, use_lock=False,
+                        check_order=check_order
                     )
                     conflict_b = self.endpoint_b.make_tags_available(
-                        controller, tags, tag_type, False, check_order
+                        controller, tags, tag_type, use_lock=False,
+                        check_order=check_order
                     )
         return conflict_a, conflict_b
 

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -12,8 +12,7 @@ from typing import Union
 
 from kytos.core.common import EntityStatus, GenericEntity
 from kytos.core.exceptions import (KytosLinkCreationError,
-                                   KytosNoTagAvailableError,
-                                   KytosTagsNotInTagRanges)
+                                   KytosNoTagAvailableError)
 from kytos.core.id import LinkID
 from kytos.core.interface import Interface, TAGType
 from kytos.core.tag_ranges import range_intersection
@@ -170,7 +169,7 @@ class Link(GenericEntity):
     def make_tags_available(
         self,
         controller,
-        tags: Union[int, list[int]],
+        tags: Union[int, list[int], list[list[int]]],
         link_id,
         tag_type: str = 'vlan'
     ) -> tuple[list[list[int]], list[list[int]]]:
@@ -178,15 +177,12 @@ class Link(GenericEntity):
         with self._get_available_vlans_lock[link_id]:
             with self.endpoint_a._tag_lock:
                 with self.endpoint_b._tag_lock:
-                    try:
-                        conflict_a = self.endpoint_a.make_tags_available(
-                            controller, tags, tag_type, False
-                        )
-                        conflict_b = self.endpoint_b.make_tags_available(
-                            controller, tags, tag_type, False
-                        )
-                    except KytosTagsNotInTagRanges as err:
-                        raise err
+                    conflict_a = self.endpoint_a.make_tags_available(
+                        controller, tags, tag_type, False
+                    )
+                    conflict_b = self.endpoint_b.make_tags_available(
+                        controller, tags, tag_type, False
+                    )
         return conflict_a, conflict_b
 
     def available_vlans(self):

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -171,17 +171,18 @@ class Link(GenericEntity):
         controller,
         tags: Union[int, list[int], list[list[int]]],
         link_id,
-        tag_type: str = 'vlan'
+        tag_type: str = 'vlan',
+        check_order: bool = True,
     ) -> tuple[list[list[int]], list[list[int]]]:
         """Add a specific tag in available_tags."""
         with self._get_available_vlans_lock[link_id]:
             with self.endpoint_a._tag_lock:
                 with self.endpoint_b._tag_lock:
                     conflict_a = self.endpoint_a.make_tags_available(
-                        controller, tags, tag_type, False
+                        controller, tags, tag_type, False, check_order
                     )
                     conflict_b = self.endpoint_b.make_tags_available(
-                        controller, tags, tag_type, False
+                        controller, tags, tag_type, False, check_order
                     )
         return conflict_a, conflict_b
 

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -61,7 +61,7 @@ def range_intersection(
     ranges_b: list[list[int]]
 ) -> Iterator[list[int]]:
     """Returns an iterator of an intersection between
-    two list of ranges"""
+    two validated list of ranges"""
     a_i, b_i = 0, 0
     while a_i < len(ranges_a) and b_i < len(ranges_b):
         fst_a, snd_a = ranges_a[a_i]
@@ -83,10 +83,11 @@ def range_intersection(
 
 
 def range_difference(
-    ranges_a: list[list[int]],
-    ranges_b: list[list[int]]
+    ranges_a: list[Optional[list[int]]],
+    ranges_b: list[Optional[list[int]]]
 ) -> list[list[int]]:
-    """The operation is (ranges_a - ranges_b).
+    """The operation is two validated list of ranges
+     (ranges_a - ranges_b).
     This method simulates difference of sets. E.g.:
     [[10, 15]] - [[4, 11], [14, 45]] = [[12, 13]]
     """
@@ -131,10 +132,10 @@ def range_difference(
 
 
 def range_addition(
-    ranges_a: list[list[int]],
-    ranges_b: list[list[int]]
+    ranges_a: list[Optional[list[int]]],
+    ranges_b: list[Optional[list[int]]]
 ) -> tuple[list[list[int]], list[list[int]]]:
-    """Addition between two ranges.
+    """Addition between two validated list of ranges.
      Simulates the addition between two sets.
      Return[adittion product, intersection]"""
     if not ranges_b:

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -56,12 +56,36 @@ def get_tag_ranges(ranges: list[list[int]]):
     return ranges
 
 
+def get_validated_tags(
+    tags: Union[list[int], list[list[int]]]
+) -> Union[list[int], list[list[int]]]:
+    """Return tags which values are validated to be correct."""
+    if isinstance(tags, list) and isinstance(tags[0], int):
+        if len(tags) == 1:
+            return [tags[0], tags[0]]
+        if len(tags) == 2 and tags[0] > tags[1]:
+            raise KytosInvalidTagRanges(f"Range out of order {tags}")
+        if len(tags) > 2:
+            raise KytosInvalidTagRanges(f"Range must have 2 values {tags}")
+        return tags
+    if isinstance(tags, list) and isinstance(tags[0], list):
+        return get_tag_ranges(tags)
+    raise KytosInvalidTagRanges(f"Value type not recognized {tags}")
+
+
 def range_intersection(
     ranges_a: list[list[int]],
     ranges_b: list[list[int]]
 ) -> Iterator[list[int]]:
     """Returns an iterator of an intersection between
-    two validated list of ranges"""
+    two validated list of ranges.
+    
+    Necessities:
+        The lists from argument need to be ordered and validated.
+        E.g. [[1, 2], [4, 60]]
+        Use get_tag_ranges() for list[list[int]] or
+            get_validated_tags() for also list[int]
+    """
     a_i, b_i = 0, 0
     while a_i < len(ranges_a) and b_i < len(ranges_b):
         fst_a, snd_a = ranges_a[a_i]
@@ -88,8 +112,13 @@ def range_difference(
 ) -> list[list[int]]:
     """The operation is two validated list of ranges
      (ranges_a - ranges_b).
-    This method simulates difference of sets. E.g.:
-    [[10, 15]] - [[4, 11], [14, 45]] = [[12, 13]]
+    This method simulates difference of sets.
+
+    Necessities:
+        The lists from argument need to be ordered and validated.
+        E.g. [[1, 2], [4, 60]]
+        Use get_tag_ranges() for list[list[int]] or
+            get_validated_tags() for also list[int]
     """
     if not ranges_a:
         return []
@@ -137,7 +166,14 @@ def range_addition(
 ) -> tuple[list[list[int]], list[list[int]]]:
     """Addition between two validated list of ranges.
      Simulates the addition between two sets.
-     Return[adittion product, intersection]"""
+     Return[adittion product, intersection]
+
+     Necessities:
+        The lists from argument need to be ordered and validated.
+        E.g. [[1, 2], [4, 60]]
+        Use get_tag_ranges() for list[list[int]] or
+            get_validated_tags() for also list[int]
+     """
     if not ranges_b:
         return deepcopy(ranges_a), []
     if not ranges_a:

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -87,6 +87,11 @@ def range_difference(
     This method simulates difference of sets. E.g.:
     [[10, 15]] - [[4, 11], [14, 45]] = [[12, 13]]
     """
+    #print(f"RANGES -> {ranges_a} - {ranges_b}")
+    if not ranges_a:
+        return []
+    if not ranges_b:
+        return ranges_a
     result = []
     a_i, b_i = 0, 0
     update = True
@@ -130,6 +135,10 @@ def range_addition(
     """Addition between two ranges.
      Simulates the addition between two sets.
      Return[adittion product, intersection]"""
+    if not ranges_b:
+        return ranges_a
+    if not ranges_a:
+        return ranges_b
     result = []
     conflict = []
     a_i = b_i = 0

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -22,9 +22,10 @@ def get_tag_ranges(ranges: list[list[int]]):
     - It should be ordered
     - Not unnecessary partition (eg. [[10,20],[20,30]])
     - Singular intergers are changed to ranges (eg. [10] to [[10, 10]])
+
     The ranges are understood as [inclusive, inclusive]"""
     if len(ranges) < 1:
-        msg = "tag_ranges is empty"
+        msg = "Tag range is empty"
         raise KytosInvalidTagRanges(msg)
     last_tag = 0
     ranges_n = len(ranges)
@@ -34,23 +35,23 @@ def get_tag_ranges(ranges: list[list[int]]):
             msg = f"The range {ranges[i]} is not ordered"
             raise KytosInvalidTagRanges(msg)
         if last_tag and last_tag > ranges[i][0]:
-            msg = f"tag_ranges is not ordered. {last_tag}"\
+            msg = f"Tag ranges are not ordered. {last_tag}"\
                      f" is higher than {ranges[i][0]}"
             raise KytosInvalidTagRanges(msg)
         if last_tag and last_tag == ranges[i][0] - 1:
-            msg = f"tag_ranges has an unnecessary partition. "\
+            msg = f"Tag ranges have an unnecessary partition. "\
                      f"{last_tag} is before to {ranges[i][0]}"
             raise KytosInvalidTagRanges(msg)
         if last_tag and last_tag == ranges[i][0]:
-            msg = f"tag_ranges has repetition. {ranges[i-1]}"\
+            msg = f"Tag ranges have repetition. {ranges[i-1]}"\
                      f" have same values as {ranges[i]}"
             raise KytosInvalidTagRanges(msg)
         last_tag = ranges[i][1]
     if ranges[-1][1] > 4095:
-        msg = "Maximum value for tag_ranges is 4095"
+        msg = "Maximum value for a tag is 4095"
         raise KytosInvalidTagRanges(msg)
     if ranges[0][0] < 1:
-        msg = "Minimum value for tag_ranges is 1"
+        msg = "Minimum value for a tag is 1"
         raise KytosInvalidTagRanges(msg)
     return ranges
 
@@ -137,9 +138,9 @@ def range_addition(
      Simulates the addition between two sets.
      Return[adittion product, intersection]"""
     if not ranges_b:
-        return deepcopy(ranges_a)
+        return deepcopy(ranges_a), []
     if not ranges_a:
-        return deepcopy(ranges_b)
+        return deepcopy(ranges_b), []
     result = []
     conflict = []
     a_i = b_i = 0

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -1,0 +1,160 @@
+"""Methods for list of ranges [inclusive, inclusive]"""
+import bisect
+from typing import Iterator, Optional
+
+
+def range_intersection(
+    ranges_a: list[list[int]],
+    ranges_b: list[list[int]]
+) -> Iterator[list[int]]:
+    """Returns an iterator of an intersection between
+    two list of ranges"""
+    a_i, b_i = 0, 0
+    while a_i < len(ranges_a) and b_i < len(ranges_b):
+        fst_a, snd_a = ranges_a[a_i]
+        fst_b, snd_b = ranges_b[b_i]
+        # Moving forward with non-intersection
+        if snd_a < fst_b:
+            a_i += 1
+        elif snd_b < fst_a:
+            b_i += 1
+        else:
+            # Intersection
+            intersection_start = max(fst_a, fst_b)
+            intersection_end = min(snd_a, snd_b)
+            yield [intersection_start, intersection_end]
+            if snd_a < snd_b:
+                a_i += 1
+            else:
+                b_i += 1
+
+
+def range_difference(
+    ranges_a: list[list[int]],
+    ranges_b: list[list[int]]
+) -> list[list[int]]:
+    """The operation is (ranges_a - ranges_b).
+    This method simulates difference of sets. E.g.:
+    [[10, 15]] - [[4, 11], [14, 45]] = [[12, 13]]
+    """
+    result = []
+    a_i, b_i = 0, 0
+    update = True
+    while a_i < len(ranges_a) and b_i < len(ranges_b):
+        if update:
+            start_a, end_a = ranges_a[a_i]
+        else:
+            update = True
+        start_b, end_b = ranges_b[b_i]
+        # Moving forward with non-intersection
+        if end_a < start_b:
+            result.append([start_a, end_a])
+            a_i += 1
+        elif end_b < start_a:
+            b_i += 1
+        else:
+            # Intersection
+            if start_a < start_b:
+                result.append([start_a, start_b - 1])
+            if end_a > end_b:
+                start_a = end_b + 1
+                update = False
+                b_i += 1
+            else:
+                a_i += 1
+    # Append last intersection and the rest of ranges_a
+    while a_i < len(ranges_a):
+        if update:
+            start_a, end_a = ranges_a[a_i]
+        else:
+            update = True
+        result.append([start_a, end_a])
+        a_i += 1
+    return result
+
+
+def range_addition(
+    ranges_a: list[list[int]],
+    ranges_b: list[list[int]]
+) -> tuple[list[list[int]], list[list[int]]]:
+    """Addition between two ranges.
+     Simulates the addition between two sets.
+     Return[adittion product, intersection]"""
+    result = []
+    conflict = []
+    a_i = b_i = 0
+    len_a = len(ranges_a)
+    len_b = len(ranges_b)
+    while a_i < len_a or b_i < len_b:
+        if (a_i < len_a and
+                (b_i >= len_b or ranges_a[a_i][1] < ranges_b[b_i][0] - 1)):
+            result.append(ranges_a[a_i])
+            a_i += 1
+        elif (b_i < len_b and
+                (a_i >= len_a or ranges_b[b_i][1] < ranges_a[a_i][0] - 1)):
+            result.append(ranges_b[b_i])
+            b_i += 1
+        # Intersection and continuos ranges
+        else:
+            fst = max(ranges_a[a_i][0], ranges_b[b_i][0])
+            snd = min(ranges_a[a_i][1], ranges_b[b_i][1])
+            if fst <= snd:
+                conflict.append([fst, snd])
+            new_range = [
+                min(ranges_a[a_i][0], ranges_b[b_i][0]),
+                max(ranges_a[a_i][1], ranges_b[b_i][1])
+            ]
+            a_i += 1
+            b_i += 1
+            while a_i < len_a or b_i < len_b:
+                if a_i < len_a and (ranges_a[a_i][0] <= new_range[1] + 1):
+                    if ranges_a[a_i][0] <= new_range[1]:
+                        conflict.append([
+                            max(ranges_a[a_i][0], new_range[0]),
+                            min(ranges_a[a_i][1], new_range[1])
+                        ])
+                    new_range[1] = max(ranges_a[a_i][1], new_range[1])
+                    a_i += 1
+                elif b_i < len_b and (ranges_b[b_i][0] <= new_range[1] + 1):
+                    if ranges_b[b_i][0] <= new_range[1]:
+                        conflict.append([
+                            max(ranges_b[b_i][0], new_range[0]),
+                            min(ranges_b[b_i][1], new_range[1])
+                        ])
+                    new_range[1] = max(ranges_b[b_i][1], new_range[1])
+                    b_i += 1
+                else:
+                    break
+            result.append(new_range)
+    return result, conflict
+
+
+def find_index_remove(
+    available_tags: list[list[int]],
+    tag_range: list[int]
+) -> Optional[int]:
+    """Find the index of tags in available_tags to be removed"""
+    index = bisect.bisect_left(available_tags, tag_range)
+    if (index < len(available_tags) and
+            tag_range[0] >= available_tags[index][0] and
+            tag_range[1] <= available_tags[index][1]):
+        return index
+    if (index - 1 > -1 and
+            tag_range[0] >= available_tags[index-1][0] and
+            tag_range[1] <= available_tags[index-1][1]):
+        return index - 1
+    return None
+
+
+def find_index_add(
+    available_tags: list[list[int]],
+    tags: list[int]
+) -> Optional[int]:
+    """Find the index of tags in available_tags to be added.
+    This method assumes that tags is within self.tag_ranges"""
+    index = bisect.bisect_left(available_tags, tags)
+    if (index == 0 or tags[0] > available_tags[index-1][1]) and \
+       (index == len(available_tags) or
+            tags[1] < available_tags[index][0]):
+        return index
+    return None

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -79,7 +79,7 @@ def range_intersection(
 ) -> Iterator[list[int]]:
     """Returns an iterator of an intersection between
     two validated list of ranges.
-    
+
     Necessities:
         The lists from argument need to be ordered and validated.
         E.g. [[1, 2], [4, 60]]

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -370,7 +370,6 @@ class TestInterface():
 
         self.iface.set_tag_ranges(tag_ranges, 'vlan')
         self.iface.use_tags(controller, [200, 250])
-        self.iface.set_tag_ranges(tag_ranges, 'vlan')
         ava_expected = [[20, 20], [251, 3000]]
         assert self.iface.tag_ranges['vlan'] == tag_ranges
         assert self.iface.available_tags['vlan'] == ava_expected

--- a/tests/unit/test_core/test_tag_ranges.py
+++ b/tests/unit/test_core/test_tag_ranges.py
@@ -3,9 +3,9 @@ import pytest
 
 from kytos.core.exceptions import KytosInvalidTagRanges
 from kytos.core.tag_ranges import (find_index_add, find_index_remove,
-                                   get_tag_ranges, map_singular_values,
-                                   range_addition, range_difference,
-                                   range_intersection)
+                                   get_tag_ranges, get_validated_tags,
+                                   map_singular_values, range_addition,
+                                   range_difference, range_intersection)
 
 
 def test_map_singular_values():
@@ -147,3 +147,22 @@ def test_range_addition():
     result = range_addition(ranges_a, ranges_b)
     assert expected_add == result[0]
     assert expected_intersection == result[1]
+
+
+async def test_get_validated_tags() -> None:
+    """Test get_validated_tags"""
+    result = get_validated_tags([1, 2])
+    assert result == [1, 2]
+
+    result = get_validated_tags([4])
+    assert result == [4, 4]
+
+    result = get_validated_tags([[1, 2], [4, 5]])
+    assert result == [[1, 2], [4, 5]]
+
+    with pytest.raises(KytosInvalidTagRanges):
+        get_validated_tags("a")
+    with pytest.raises(KytosInvalidTagRanges):
+        get_validated_tags([1, 2, 3])
+    with pytest.raises(KytosInvalidTagRanges):
+        get_validated_tags([5, 2])

--- a/tests/unit/test_core/test_tag_ranges.py
+++ b/tests/unit/test_core/test_tag_ranges.py
@@ -1,7 +1,7 @@
 """Test kytos.core.tag_ranges"""
 import pytest
 
-from kytos.core.exceptions import KytosInvalidRanges
+from kytos.core.exceptions import KytosInvalidTagRanges
 from kytos.core.tag_ranges import (find_index_add, find_index_remove,
                                    get_tag_ranges, map_singular_values,
                                    range_addition, range_difference,
@@ -26,37 +26,37 @@ def test_get_tag_ranges():
 
     # Empty
     mock_ranges = []
-    with pytest.raises(KytosInvalidRanges):
+    with pytest.raises(KytosInvalidTagRanges):
         get_tag_ranges(mock_ranges)
 
     # Range not ordered
     mock_ranges = [[20, 19]]
-    with pytest.raises(KytosInvalidRanges):
+    with pytest.raises(KytosInvalidTagRanges):
         get_tag_ranges(mock_ranges)
 
     # Ranges not ordered
     mock_ranges = [[20, 50], [30, 3000]]
-    with pytest.raises(KytosInvalidRanges):
+    with pytest.raises(KytosInvalidTagRanges):
         get_tag_ranges(mock_ranges)
 
     # Unnecessary partition
     mock_ranges = [[20, 50], [51, 3000]]
-    with pytest.raises(KytosInvalidRanges):
+    with pytest.raises(KytosInvalidTagRanges):
         get_tag_ranges(mock_ranges)
 
     # Repeated tag
     mock_ranges = [[20, 50], [50, 3000]]
-    with pytest.raises(KytosInvalidRanges):
+    with pytest.raises(KytosInvalidTagRanges):
         get_tag_ranges(mock_ranges)
 
     # Over 4095
     mock_ranges = [[20, 50], [52, 4096]]
-    with pytest.raises(KytosInvalidRanges):
+    with pytest.raises(KytosInvalidTagRanges):
         get_tag_ranges(mock_ranges)
 
     # Under 1
     mock_ranges = [[0, 50], [52, 3000]]
-    with pytest.raises(KytosInvalidRanges):
+    with pytest.raises(KytosInvalidTagRanges):
         get_tag_ranges(mock_ranges)
 
 

--- a/tests/unit/test_core/test_tag_ranges.py
+++ b/tests/unit/test_core/test_tag_ranges.py
@@ -1,7 +1,63 @@
 """Test kytos.core.tag_ranges"""
+import pytest
+
+from kytos.core.exceptions import KytosInvalidRanges
 from kytos.core.tag_ranges import (find_index_add, find_index_remove,
+                                   get_tag_ranges, map_singular_values,
                                    range_addition, range_difference,
                                    range_intersection)
+
+
+def test_map_singular_values():
+    """Test map_singular_values"""
+    mock_tag = 201
+    result = map_singular_values(mock_tag)
+    assert result == [201, 201]
+    mock_tag = [201]
+    result = map_singular_values(mock_tag)
+    assert result == [201, 201]
+
+
+def test_get_tag_ranges():
+    """Test _get_tag_ranges"""
+    mock_ranges = [100, [150], [200, 3000]]
+    result = get_tag_ranges(mock_ranges)
+    assert result == [[100, 100], [150, 150], [200, 3000]]
+
+    # Empty
+    mock_ranges = []
+    with pytest.raises(KytosInvalidRanges):
+        get_tag_ranges(mock_ranges)
+
+    # Range not ordered
+    mock_ranges = [[20, 19]]
+    with pytest.raises(KytosInvalidRanges):
+        get_tag_ranges(mock_ranges)
+
+    # Ranges not ordered
+    mock_ranges = [[20, 50], [30, 3000]]
+    with pytest.raises(KytosInvalidRanges):
+        get_tag_ranges(mock_ranges)
+
+    # Unnecessary partition
+    mock_ranges = [[20, 50], [51, 3000]]
+    with pytest.raises(KytosInvalidRanges):
+        get_tag_ranges(mock_ranges)
+
+    # Repeated tag
+    mock_ranges = [[20, 50], [50, 3000]]
+    with pytest.raises(KytosInvalidRanges):
+        get_tag_ranges(mock_ranges)
+
+    # Over 4095
+    mock_ranges = [[20, 50], [52, 4096]]
+    with pytest.raises(KytosInvalidRanges):
+        get_tag_ranges(mock_ranges)
+
+    # Under 1
+    mock_ranges = [[0, 50], [52, 3000]]
+    with pytest.raises(KytosInvalidRanges):
+        get_tag_ranges(mock_ranges)
 
 
 def test_range_intersection():

--- a/tests/unit/test_core/test_tag_ranges.py
+++ b/tests/unit/test_core/test_tag_ranges.py
@@ -1,0 +1,93 @@
+"""Test kytos.core.tag_ranges"""
+from kytos.core.tag_ranges import (find_index_add, find_index_remove,
+                                   range_addition, range_difference,
+                                   range_intersection)
+
+
+def test_range_intersection():
+    """Test range_intersection"""
+    tags_a = [
+        [3, 5], [7, 9], [11, 16], [21, 23], [25, 25], [27, 28], [30, 30]
+    ]
+    tags_b = [
+        [1, 3], [6, 6], [10, 10], [12, 13], [15, 15], [17, 20], [22, 30]
+    ]
+    result = []
+    iterator_result = range_intersection(tags_a, tags_b)
+    for tag_range in iterator_result:
+        result.append(tag_range)
+    expected = [
+        [3, 3], [12, 13], [15, 15], [22, 23], [25, 25], [27, 28], [30, 30]
+    ]
+    assert result == expected
+
+
+def test_range_difference():
+    """Test range_difference"""
+    ranges_a = [[7, 10], [12, 12], [14, 14], [17, 19], [25, 27], [30, 30]]
+    ranges_b = [[1, 1], [4, 5], [8, 9], [11, 14], [18, 26]]
+    expected = [[7, 7], [10, 10], [17, 17], [27, 27], [30, 30]]
+    actual = range_difference(ranges_a, ranges_b)
+    assert expected == actual
+
+
+def test_find_index_remove():
+    """Test find_index_remove"""
+    tag_ranges = [[20, 50], [200, 3000]]
+    index = find_index_remove(tag_ranges, [20, 20])
+    assert index == 0
+    index = find_index_remove(tag_ranges, [10, 15])
+    assert index is None
+    index = find_index_remove(tag_ranges, [25, 30])
+    assert index == 0
+
+
+def test_find_index_add():
+    """Test find_index_add"""
+    tag_ranges = [[20, 20], [200, 3000]]
+    index = find_index_add(tag_ranges, [10, 15])
+    assert index == 0
+    index = find_index_add(tag_ranges, [3004, 4000])
+    assert index == 2
+    index = find_index_add(tag_ranges, [50, 202])
+    assert index is None
+
+
+def test_range_addition():
+    """Test range_addition"""
+    ranges_a = [
+        [3, 10], [20, 50], [60, 70], [80, 90], [100, 110],
+        [112, 120], [130, 140], [150, 160]
+    ]
+    ranges_b = [
+        [1, 1], [3, 3], [9, 22], [24, 55], [57, 62],
+        [81, 101], [123, 128]
+    ]
+    expected_add = [
+        [1, 1], [3, 55], [57, 70], [80, 110], [112, 120],
+        [123, 128], [130, 140], [150, 160]
+    ]
+    expected_intersection = [
+        [3, 3], [9, 10], [20, 22], [24, 50], [60, 62],
+        [81, 90], [100, 101]
+    ]
+    result = range_addition(ranges_a, ranges_b)
+    assert expected_add == result[0]
+    assert expected_intersection == result[1]
+
+    ranges_a = [[1, 4], [9, 15]]
+    ranges_b = [[6, 7]]
+    expected_add = [[1, 4], [6, 7], [9, 15]]
+    expected_intersection = []
+    result = range_addition(ranges_a, ranges_b)
+    assert expected_add == result[0]
+    assert expected_intersection == result[1]
+
+    # Corner case, assuring not unnecessary divisions
+    ranges_a = [[1, 2], [6, 7]]
+    ranges_b = [[3, 4], [9, 10]]
+    expected_add = [[1, 4], [6, 7], [9, 10]]
+    expected_intersection = []
+    result = range_addition(ranges_a, ranges_b)
+    assert expected_add == result[0]
+    assert expected_intersection == result[1]


### PR DESCRIPTION
Closes #427 

### Summary

- Added `range_addition()`. Its presence is not final but is used in the meantime.

- Added exceptions `KytosInvalidRanges`, `KytosTagsAreNotAvailable` and `KytosTagsNotInTagRanges`
- Added support for input `list[list[int]]` to `use_tags()` and `make_tags_available()`
- These methods also have changed their return. For `use_tags()` there is no longer a return value, instead, it raises `KytosTagsAreNotAvailable` for any errors. `make_tags_available()` returns any conflicting values, this does not stop the addition process. It can also raise `KytosTagsNotInTagRanges`.
- Created the file `tag_ranges.py` that contains every Interface range-related method that was static.
- Created `TAGRange` class for tags that have a list of ranges of tags.
- Moved `get_tag_ranges()` and `map_singular_values()` to `tag_ranges.py` so it can be used for other, currently `mef_eline` and `topology` are planned to use it.

### Local Tests
- Need to modify some unit tests.
- Using these changes in `vlan_range` development

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 244 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 47%]
.                                                                        [ 47%]
tests/test_e2e_14_mef_eline.py x                                         [ 47%]
tests/test_e2e_15_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 72%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 75%]
tests/test_e2e_40_sdntrace.py .............                              [ 80%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_42_sdntrace.py ..                                         [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
```
