### PR TITLE
Added `special_available_tags` to store special vlan from an interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 - Added ``kytos/core.interface_tags`` event publication to notify any modification of ``Interface.tag_ranges`` or ``Interface.available_tags``.
 - Added ``TAGRange`` class which is used when a ``UNI`` has a tag as a list of ranges.
 - Added ``KytosTagError`` exception that cover other exceptions ``KytosTagtypeNotSupported``, ``KytosInvalidTagRanges``, ``KytosSetTagRangeError``, ``KytosTagsNotInTagRanges`` and ``KytosTagsAreNotAvailable`` all of which are related to TAGs.
+- Added ``special_available_tags`` which stores `"untagged"` and `"any"` if they can be used from an Interface.
 
 Changed
 =======

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -114,22 +114,15 @@ class KytosSetTagRangeError(KytosTagError):
 class KytosTagsNotInTagRanges(KytosTagError):
     """Exception thrown when tags are outside of tag ranges"""
     def __init__(self, conflict: list[list[int]], intf_id: str) -> None:
-        msg = f"The tags {conflict} are outside tag_ranges in {intf_id}"
-        super().__init__(f"KytosSetTagRangeError, {msg}")
+        msg = f"The tags {conflict} are outside tag ranges in {intf_id}"
+        super().__init__(f"KytosTagsNotInTagRanges, {msg}")
 
 
 class KytosTagsAreNotAvailable(KytosTagError):
     """Exception thrown when tags are not available."""
     def __init__(self, conflict: list[list[int]], intf_id: str) -> None:
         msg = f"The tags {conflict} are not available in {intf_id}"
-        super().__init__(f"KytosSetTagRangeError, {msg}")
-
-
-class KytosSpecialTagNotAvailable(KytosTagError):
-    """Exception thrown when an special tag is not available."""
-    def __init__(self, conflict: str, intf_id: str) -> None:
-        msg = f"The special tag '{conflict}' is not available in {intf_id}"
-        super().__init__(f"KytosSetTagRangeError, {msg}")
+        super().__init__(f"KytosTagsAreNotAvailable, {msg}")
 
 
 # Exceptions related  to NApps

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -112,16 +112,23 @@ class KytosSetTagRangeError(KytosTagError):
 
 
 class KytosTagsNotInTagRanges(KytosTagError):
-    """Exception thrown when a tag is outside of tag ranges"""
+    """Exception thrown when tags are outside of tag ranges"""
     def __init__(self, conflict: list[list[int]], intf_id: str) -> None:
         msg = f"The tags {conflict} are outside tag_ranges in {intf_id}"
         super().__init__(f"KytosSetTagRangeError, {msg}")
 
 
 class KytosTagsAreNotAvailable(KytosTagError):
-    """Exception thrown when a tag is not available."""
+    """Exception thrown when tags are not available."""
     def __init__(self, conflict: list[list[int]], intf_id: str) -> None:
         msg = f"The tags {conflict} are not available in {intf_id}"
+        super().__init__(f"KytosSetTagRangeError, {msg}")
+
+
+class KytosSpecialTagNotAvailable(KytosTagError):
+    """Exception thrown when an special tag is not available."""
+    def __init__(self, conflict: str, intf_id: str) -> None:
+        msg = f"The special tag '{conflict}' is not available in {intf_id}"
         super().__init__(f"KytosSetTagRangeError, {msg}")
 
 

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -278,7 +278,7 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             )
             self.tag_ranges[tag_type] = self.default_tag_values[tag_type]
 
-    def set_special_tagss(
+    def set_special_tags(
         self,
         tag_type: str,
         special_tags: list[str],

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -7,6 +7,24 @@ from typing import Iterator, Optional, Union
 from kytos.core.exceptions import KytosInvalidTagRanges
 
 
+def get_special_tag_range(tag_range: list[str], default) -> list[str]:
+    """Get special_tag_range and check values"""
+    # Find duplicated
+    if len(tag_range) != len(set(tag_range)):
+        msg = "There are duplicated values in the range."
+        raise KytosInvalidTagRanges(msg)
+
+    # Find invalid tag
+    default_set = set(default)
+    for tag in tag_range:
+        try:
+            default_set.remove(tag)
+        except KeyError:
+            msg = f"The tag {tag} is not supported"
+            raise KytosInvalidTagRanges(msg)
+    return tag_range
+
+
 def map_singular_values(tag_range: Union[int, list[int]]):
     """Change integer or singular interger list to
     list[int, int] when necessary"""

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -7,8 +7,8 @@ from typing import Iterator, Optional, Union
 from kytos.core.exceptions import KytosInvalidTagRanges
 
 
-def get_special_tag_range(tag_range: list[str], default) -> list[str]:
-    """Get special_tag_range and check values"""
+def get_special_tags(tag_range: list[str], default) -> list[str]:
+    """Get special_tags and check values"""
     # Find duplicated
     if len(tag_range) != len(set(tag_range)):
         msg = "There are duplicated values in the range."

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -158,24 +158,24 @@ class TestInterface():
         default_available = {'vlan': [[1, 4095]]}
         default_tag_ranges = {'vlan': [[1, 4095]]}
         default_special_vlans = {'vlan': ["untagged", "any"]}
-        default_special_tag_range = {'vlan': ["untagged", "any"]}
+        default_special_tags = {'vlan': ["untagged", "any"]}
         assert self.iface.available_tags == default_available
         assert self.iface.tag_ranges == default_tag_ranges
         assert self.iface.special_available_tags == default_special_vlans
-        assert self.iface.special_tag_range == default_special_tag_range
+        assert self.iface.special_tags == default_special_tags
 
         custom_available = {'vlan': [[10, 200], [210, 4095]]}
         custom_tag_ranges = {'vlan': [[1, 100], [200, 4095]]}
         custom_special_vlans = {'vlan': ["any"]}
-        custom_special_tag_range = {'vlan': ["any"]}
+        custom_special_tags = {'vlan': ["any"]}
         self.iface.set_available_tags_tag_ranges(
             custom_available, custom_tag_ranges,
-            custom_special_vlans, custom_special_tag_range
+            custom_special_vlans, custom_special_tags
         )
         assert self.iface.available_tags == custom_available
         assert self.iface.tag_ranges == custom_tag_ranges
         assert self.iface.special_available_tags == custom_special_vlans
-        assert self.iface.special_tag_range == custom_special_tag_range
+        assert self.iface.special_tags == custom_special_tags
 
     async def test_interface_is_tag_available(self):
         """Test is_tag_available on Interface class."""
@@ -346,11 +346,11 @@ class TestInterface():
         available = {'vlan': [[300, 3000]]}
         tag_ranges = {'vlan': [[20, 20], [200, 3000]]}
         special_available_tags = {'vlan': []}
-        special_tag_range = {'vlan': ["any"]}
+        special_tags = {'vlan': ["any"]}
         self.iface._notify_interface_tags = MagicMock()
         self.iface.set_available_tags_tag_ranges(
             available, tag_ranges,
-            special_available_tags, special_tag_range
+            special_available_tags, special_tags
         )
         assert self.iface.available_tags == available
         assert self.iface.tag_ranges == tag_ranges
@@ -439,7 +439,7 @@ class TestInterface():
             "available_tag": {'vlan': available_tag},
             "tag_ranges": {'vlan': tag_ranges},
             "special_available_tags": {'vlan': ["untagged", "any"]},
-            "special_tag_range": {'vlan': ["untagged", "any"]}
+            "special_tags": {'vlan': ["untagged", "any"]}
         }
         self.iface.set_available_tags_tag_ranges(**parameters)
         assert self.iface._remove_tags([4, 6]) is False
@@ -453,7 +453,7 @@ class TestInterface():
             "available_tag": {'vlan': available_tag},
             "tag_ranges": {'vlan': tag_ranges},
             "special_available_tags": {'vlan': ["untagged", "any"]},
-            "special_tag_range": {'vlan': ["untagged", "any"]}
+            "special_tags": {'vlan': ["untagged", "any"]}
         }
         self.iface.set_available_tags_tag_ranges(**parameters)
         ava_expected = [[4, 10], [20, 30]]
@@ -498,7 +498,7 @@ class TestInterface():
             "available_tag": {'vlan': available_tag},
             "tag_ranges": {'vlan': tag_ranges},
             "special_available_tags": {'vlan': ["untagged", "any"]},
-            "special_tag_range": {'vlan': ["untagged", "any"]}
+            "special_tags": {'vlan': ["untagged", "any"]}
         }
         self.iface.set_available_tags_tag_ranges(**parameters)
         assert self.iface._add_tags([4, 6])

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -158,25 +158,24 @@ class TestInterface():
         default_available = {'vlan': [[1, 4095]]}
         default_tag_ranges = {'vlan': [[1, 4095]]}
         default_special_vlans = {'vlan': ["untagged", "any"]}
-        intf_available = self.iface.available_tags
-        intf_tag_ranges = self.iface.tag_ranges
-        intf_special_vlans = self.iface.special_available_tags
-        assert intf_available == default_available
-        assert intf_tag_ranges == default_tag_ranges
-        assert intf_special_vlans == default_special_vlans
+        default_special_tag_range = {'vlan': ["untagged", "any"]}
+        assert self.iface.available_tags == default_available
+        assert self.iface.tag_ranges == default_tag_ranges
+        assert self.iface.special_available_tags == default_special_vlans
+        assert self.iface.special_tag_range == default_special_tag_range
 
         custom_available = {'vlan': [[10, 200], [210, 4095]]}
         custom_tag_ranges = {'vlan': [[1, 100], [200, 4095]]}
         custom_special_vlans = {'vlan': ["any"]}
+        custom_special_tag_range = {'vlan': ["any"]}
         self.iface.set_available_tags_tag_ranges(
-            custom_available, custom_tag_ranges, custom_special_vlans
+            custom_available, custom_tag_ranges,
+            custom_special_vlans, custom_special_tag_range
         )
-        intf_available = self.iface.available_tags
-        intf_tag_ranges = self.iface.tag_ranges
-        intf_special_vlans = self.iface.special_available_tags
-        assert intf_available == custom_available
-        assert intf_tag_ranges == custom_tag_ranges
-        assert intf_special_vlans == custom_special_vlans
+        assert self.iface.available_tags == custom_available
+        assert self.iface.tag_ranges == custom_tag_ranges
+        assert self.iface.special_available_tags == custom_special_vlans
+        assert self.iface.special_tag_range == custom_special_tag_range
 
     async def test_interface_is_tag_available(self):
         """Test is_tag_available on Interface class."""
@@ -346,10 +345,12 @@ class TestInterface():
         """Test make_tags_available"""
         available = {'vlan': [[300, 3000]]}
         tag_ranges = {'vlan': [[20, 20], [200, 3000]]}
-        special_available_tags = {'vlan': ["untagged"]}
+        special_available_tags = {'vlan': []}
+        special_tag_range = {'vlan': ["any"]}
         self.iface._notify_interface_tags = MagicMock()
         self.iface.set_available_tags_tag_ranges(
-            available, tag_ranges, special_available_tags
+            available, tag_ranges,
+            special_available_tags, special_tag_range
         )
         assert self.iface.available_tags == available
         assert self.iface.tag_ranges == tag_ranges
@@ -369,6 +370,9 @@ class TestInterface():
             self.iface.make_tags_available(controller, [1, 1], use_lock=False)
 
         assert self.iface.make_tags_available(controller, 300) == [[300, 300]]
+
+        with pytest.raises(KytosTagsNotInTagRanges):
+            self.iface.make_tags_available(controller, "untagged")
 
         assert self.iface.make_tags_available(controller, "any") is None
         assert "any" in self.iface.special_available_tags["vlan"]
@@ -410,6 +414,7 @@ class TestInterface():
         self.iface.set_available_tags_tag_ranges(
             {'vlan': available_tag},
             {'vlan': tag_ranges},
+            {'vlan': ["untagged", "any"]},
             {'vlan': ["untagged", "any"]}
         )
         ava_expected = [[20, 20], [241, 3000]]
@@ -433,7 +438,8 @@ class TestInterface():
         parameters = {
             "available_tag": {'vlan': available_tag},
             "tag_ranges": {'vlan': tag_ranges},
-            "special_available_tags": {'vlan': ["untagged", "any"]}
+            "special_available_tags": {'vlan': ["untagged", "any"]},
+            "special_tag_range": {'vlan': ["untagged", "any"]}
         }
         self.iface.set_available_tags_tag_ranges(**parameters)
         assert self.iface._remove_tags([4, 6]) is False
@@ -446,7 +452,8 @@ class TestInterface():
         parameters = {
             "available_tag": {'vlan': available_tag},
             "tag_ranges": {'vlan': tag_ranges},
-            "special_available_tags": {'vlan': ["untagged", "any"]}
+            "special_available_tags": {'vlan': ["untagged", "any"]},
+            "special_tag_range": {'vlan': ["untagged", "any"]}
         }
         self.iface.set_available_tags_tag_ranges(**parameters)
         ava_expected = [[4, 10], [20, 30]]
@@ -490,7 +497,8 @@ class TestInterface():
         parameters = {
             "available_tag": {'vlan': available_tag},
             "tag_ranges": {'vlan': tag_ranges},
-            "special_available_tags": {'vlan': ["untagged", "any"]}
+            "special_available_tags": {'vlan': ["untagged", "any"]},
+            "special_tag_range": {'vlan': ["untagged", "any"]}
         }
         self.iface.set_available_tags_tag_ranges(**parameters)
         assert self.iface._add_tags([4, 6])

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -407,6 +407,24 @@ class TestInterface():
         default = [[1, 4095]]
         assert self.iface.tag_ranges['vlan'] == default
 
+    def test_set_special_tags(self) -> None:
+        """Test set_special_tags"""
+        self.iface.special_available_tags["vlan"] = ["untagged"]
+        tag_type = "error"
+        special_tags = ["untagged", "any"]
+        with pytest.raises(KytosTagtypeNotSupported):
+            self.iface.set_special_tags(tag_type, special_tags)
+
+        tag_type = "vlan"
+        special_tags = ["untagged"]
+        with pytest.raises(KytosSetTagRangeError):
+            self.iface.set_special_tags(tag_type, special_tags)
+
+        special_tags = ["any"]
+        self.iface.set_special_tags(tag_type, special_tags)
+        assert self.iface.special_available_tags["vlan"] == []
+        assert self.iface.special_tags["vlan"] == ["any"]
+
     async def test_remove_tags(self) -> None:
         """Test _remove_tags"""
         available_tag = [[20, 20], [200, 3000]]

--- a/tests/unit/test_core/test_tag_ranges.py
+++ b/tests/unit/test_core/test_tag_ranges.py
@@ -3,9 +3,28 @@ import pytest
 
 from kytos.core.exceptions import KytosInvalidTagRanges
 from kytos.core.tag_ranges import (find_index_add, find_index_remove,
-                                   get_tag_ranges, get_validated_tags,
-                                   map_singular_values, range_addition,
-                                   range_difference, range_intersection)
+                                   get_special_tags, get_tag_ranges,
+                                   get_validated_tags, map_singular_values,
+                                   range_addition, range_difference,
+                                   range_intersection)
+
+
+def test_get_special_tags():
+    """Test get_special_tags"""
+
+    # "even_tags" is an hypotetical future special vlan
+    default = ["untagged", "any", "even_tags"]
+
+    tag_range = ["any", "any"]
+    with pytest.raises(KytosInvalidTagRanges):
+        get_special_tags(tag_range, default)
+
+    tag_range = ["untagged", "any"]
+    assert get_special_tags(tag_range, default) == tag_range
+
+    tag_range = ["untagged", "error"]
+    with pytest.raises(KytosInvalidTagRanges):
+        get_special_tags(tag_range, default)
 
 
 def test_map_singular_values():
@@ -147,6 +166,11 @@ def test_range_addition():
     result = range_addition(ranges_a, ranges_b)
     assert expected_add == result[0]
     assert expected_intersection == result[1]
+
+    empty_range = []
+    other_range = [[1, 100], [200, 400]]
+    assert range_addition(empty_range, other_range) == (other_range, [])
+    assert range_addition(other_range, empty_range) == (other_range, [])
 
 
 async def test_get_validated_tags() -> None:


### PR DESCRIPTION
Closes #430 

### Summary
Added `special_available_tags` to Interface
Adapted `use_tags()` and `make_tags_available()` to accept strings.

### Local Tests
Created EVCs with `"untagged"` and `"any"` as vlans

### End-To-End Tests
TBA
