### PR TITLE
docs: updating AUTHORS_NG.rst file for `2023.2` release

### DIFF
--- a/AUTHORS_NG.rst
+++ b/AUTHORS_NG.rst
@@ -7,12 +7,12 @@ Core Team
 - Vinicius Arcanjo <vindasil AT fiu DOT edu>
 - Rogerio Motitsuki <rogerio.motitsuki AT gmail DOT com>
 - David Ramirez <davramir AT fiu DOT edu>
-- Gretel De la Peña <gdelapea AT fiu DOT edu>
 
 Core Team Alumni
 ================
 
 - Antonio Francisco <ajoaoff AT gmail.com>
+- Gretel De la Peña <gdelapea AT fiu DOT edu>
 
 Team Leader
 ***********
@@ -34,3 +34,4 @@ Contributors
 - Krishna Reddy Enugala <kenugala AT fiu DOT edu>
 - Gretel De la Peña <gdelapea AT fiu DOT edu>
 - Noel Ngu <corevaluenoel AT gmail DOT com>
+- Heriberto Luna < hluna006 AT fiu DOT edu >


### PR DESCRIPTION

### Summary

- Including @HeriLFIU as contributor
- Moving @gretelliz as core team alumni since she will still contribute but primarily focus on SDX from now on

Noel is also a `2023.2` contributor but he had already been included. 

Thanks, folks. 