### PR TITLE
Added all_tags_available()

### DIFF
--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -242,6 +242,12 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
          special_available_tags and special_tags."""
         return ["untagged", "any"]
 
+    def all_tags_available(self) -> bool:
+        """Return True if all tags are avaiable (no tags used),
+         False otherwise"""
+        with self._tag_lock:
+            return self.available_tags == self.tag_ranges
+
     def set_tag_ranges(self, tag_ranges: list[list[int]], tag_type: str):
         """Set new restriction, tag_ranges."""
         if tag_type != TAGType.VLAN.value:

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -246,7 +246,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         """Return True if all tags are avaiable (no tags used),
          False otherwise"""
         with self._tag_lock:
-            return self.available_tags == self.tag_ranges
+            return (self.available_tags == self.tag_ranges and
+                    self.special_available_tags == self.special_tags)
 
     def set_tag_ranges(self, tag_ranges: list[list[int]], tag_type: str):
         """Set new restriction, tag_ranges."""

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -535,9 +535,12 @@ class TestInterface():
         """Test all_tags_available"""
         self.iface.available_tags = {"vlan": [[1, 1000]]}
         self.iface.tag_ranges = {"vlan": [[1, 20], [22, 1000]]}
+        self.iface.special_available_tags = {"vlan": []}
+        self.iface.special_tags = {"vlan": ["any"]}
         assert self.iface.all_tags_available() is False
 
         self.iface.tag_ranges = {"vlan": [[1, 1000]]}
+        self.iface.special_available_tags = {"vlan": ["any"]}
         assert self.iface.all_tags_available()
 
 

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -531,6 +531,15 @@ class TestInterface():
         assert event.name == name
         assert event.content == content
 
+    def test_all_tags_available(self) -> None:
+        """Test all_tags_available"""
+        self.iface.available_tags = {"vlan": [[1, 1000]]}
+        self.iface.tag_ranges = {"vlan": [[1, 20], [22, 1000]]}
+        assert self.iface.all_tags_available() is False
+
+        self.iface.tag_ranges = {"vlan": [[1, 1000]]}
+        assert self.iface.all_tags_available()
+
 
 class TestUNI():
     """UNI tests."""


### PR DESCRIPTION
Closes #435 

### Summary

Added a thread safe method to check if no tags are being used

### Local Test
Used in `topology` [PR](https://github.com/kytos-ng/topology/pull/181) where switch interfaces should not have any tags being used
Unit test added