### PR TITLE
Enabling an interface does not enable its switch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed
 Fixed
 =====
 - Avoid ``kytosd`` hanging its termination when handling ``SystemExit`` with SIGTERM
+- Enabling an interface does not longer enables its switch
 
 Deprecated
 ==========

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -569,14 +569,6 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
             self.special_available_tags = special_available_tags
             self.special_tags = special_tags
 
-    def enable(self):
-        """Enable this interface instance.
-
-        Also enable the switch instance this interface is attached to.
-        """
-        self.switch.enable()
-        self._enabled = True
-
     def is_tag_available(self, tag: int, tag_type: str = 'vlan'):
         """Check if a tag is available."""
         with self._tag_lock:

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -218,15 +218,6 @@ class TestInterface():
         self.iface.use_tags(controller, "untagged")
         assert "untagged" not in self.iface.special_available_tags["vlan"]
 
-    async def test_enable(self):
-        """Test enable method."""
-        self.iface.switch = MagicMock()
-
-        self.iface.enable()
-
-        self.iface.switch.enable.assert_called()
-        assert self.iface._enabled
-
     async def test_get_endpoint(self):
         """Test get_endpoint method."""
         endpoint = ('endpoint', 'time')


### PR DESCRIPTION
Closes #441 


### Summary
Enable fields are being updated in the topology [PR #181](https://github.com/kytos-ng/topology/pull/181).
Enabling an interface while its switch is disabled is no longer allowed so `self.switch.enable()` is unnecessary.

### Local tests
Updated unit test by deleting the test.
Tests in topology PR development