### PR TITLE
Add in a config option for api threadpool size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Added
 - Added ``special_available_tags`` which stores `"untagged"` and `"any"` if they can be used from an Interface.
 - Added ``maxsize_multiplier`` on ``event_buffer_conf``, which will multiply the ``maxsize`` value of the queue. By default, all KytosEventBuffer who use a bounded queue will have ``maxsize_multiplier: 2``. This default is reasonable to work out of the box with kytos-ng core NApps. But, if you have other NApps who tend to produce too many events you might want to either increase the size of the queue with and/or increase the number of max workers in the thread pool if the event handler is running on a thread pool. Typically, you'll want to first start adjusting the number of workers in the thread pool.
 - Introduced a new ``meta`` on ``KytosBuffers``, which is meant for general core control events.
+- Added ``api`` threadpool. This is used by the ASGI server to handle requests to non async endpoints.
+- Added in configuration option ``api_concurrency_limit``, specifies the max number of concurrent API requests before rejecting the request.
 
 Changed
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+General Information
+===================
+
+- ``kytos.conf.template`` has changed you might want to regenerate ``kytos.conf`` if you want to set non default values
+
 Added
 =====
 - Added ``Interface.tag_ranges`` as ``dict[str, list[list[int]]]`` as replacement for ``vlan_pool`` settings.

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -60,7 +60,7 @@ class APIServer:
                 Middleware(CORSMiddleware, allow_origins=["*"]),
             ],
         )
-        api_threadpool_size = get_thread_pool_max_workers().get('api', 40)
+        api_threadpool_size = get_thread_pool_max_workers().get('api', 160)
         
         concurrency_limit = KytosConfig().options["daemon"].api_concurrency_limit
         if concurrency_limit == 'threadpool':

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -12,6 +12,8 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlretrieve
 
 import httpx
+from anyio.lowlevel import RunVar
+from anyio import CapacityLimiter
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
@@ -23,6 +25,7 @@ from uvicorn import Server
 
 from kytos.core.auth import authenticated
 from kytos.core.config import KytosConfig
+from kytos.core.helpers import get_thread_pool_max_workers
 from kytos.core.rest_api import JSONResponse, Request
 
 LOG = logging.getLogger(__name__)
@@ -57,11 +60,24 @@ class APIServer:
                 Middleware(CORSMiddleware, allow_origins=["*"]),
             ],
         )
+        api_threadpool_size = get_thread_pool_max_workers().get('api', 40)
+        
+        concurrency_limit = KytosConfig().options["daemon"].api_concurrency_limit
+        if concurrency_limit == 'threadpool':
+            concurrency_limit = api_threadpool_size
+
+        @self.app.on_event("startup")
+        def _app_startup_func():
+            RunVar("_default_thread_limiter").set(
+                CapacityLimiter(api_threadpool_size)
+            )
+
         self.server = Server(
             UvicornConfig(
                 self.app,
                 host=self.listen,
                 port=self.port,
+                limit_concurrency=concurrency_limit
             )
         )
 

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -12,8 +12,8 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlretrieve
 
 import httpx
-from anyio.lowlevel import RunVar
 from anyio import CapacityLimiter
+from anyio.lowlevel import RunVar
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
@@ -60,9 +60,11 @@ class APIServer:
                 Middleware(CORSMiddleware, allow_origins=["*"]),
             ],
         )
+        kytos_conf = KytosConfig().options["daemon"]
+
         api_threadpool_size = get_thread_pool_max_workers().get('api', 160)
-        
-        concurrency_limit = KytosConfig().options["daemon"].api_concurrency_limit
+
+        concurrency_limit = kytos_conf.api_concurrency_limit
         if concurrency_limit == 'threadpool':
             concurrency_limit = api_threadpool_size
 

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -158,6 +158,7 @@ class KytosConfig():
             'listen': '0.0.0.0',
             'port': 6653,
             'api_traceback_on_500': True,
+            'api_concurrency_limit': 'threadpool',
             'foreground': False,
             'protocol_name': '',
             'enable_entities_by_default': False,
@@ -261,6 +262,7 @@ class KytosConfig():
         options.event_buffer_conf = _parse_json(
             options.event_buffer_conf
         )
+        options.api_concurrency_limit = _parse_json(options.api_concurrency_limit)
 
         return options
 

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -262,7 +262,9 @@ class KytosConfig():
         options.event_buffer_conf = _parse_json(
             options.event_buffer_conf
         )
-        options.api_concurrency_limit = _parse_json(options.api_concurrency_limit)
+        options.api_concurrency_limit = _parse_json(
+            options.api_concurrency_limit
+        )
 
         return options
 

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -72,7 +72,8 @@ jwt_secret = {{ jwt_secret }}
 # - sb: it's used automatically by kytos/of_core.* events, it's meant for southbound related messages
 # - app: it's meant for general NApps event, it's default pool if no other one has been specified
 # - db: it can be used by for higher priority db related tasks (need to be parametrized on decorator)
-thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512}
+# - api: Not used by events, but instead API requests.
+thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512, "api": 80}
 
 # Configuration for KytosEventBuffers
 # Valid event buffers are "msg_in", "msg_out", "app", "conn", and "raw".
@@ -127,3 +128,7 @@ apm =
 # is in the list, then every URL containing "kytos/mef_eline" will match
 # it and, therefore, require authentication.
 # authenticate_urls = ["kytos/mef_eline", "kytos/pathfinder"]
+
+# Define the max number of connections to accept before additional
+# connections are automatically rejected.
+api_concurrency_limit = "threadpool"

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -73,7 +73,7 @@ jwt_secret = {{ jwt_secret }}
 # - app: it's meant for general NApps event, it's default pool if no other one has been specified
 # - db: it can be used by for higher priority db related tasks (need to be parametrized on decorator)
 # - api: Not used by events, but instead API requests.
-thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512, "api": 80}
+thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512, "api": 160}
 
 # Configuration for KytosEventBuffers
 # Valid event buffers are "msg_in", "msg_out", "app", "conn", and "raw".

--- a/tests/unit/test_core/test_helpers.py
+++ b/tests/unit/test_core/test_helpers.py
@@ -52,7 +52,7 @@ class TestHelpers(TestCase):
     @staticmethod
     def test_default_executors():
         """Test default expected executors."""
-        pools = ["app", "db", "sb"]
+        pools = ["api", "app", "db", "sb"]
         assert sorted(pools) == sorted(executors.keys())
         assert not ds_executors
 


### PR DESCRIPTION
Closes kytos-ng/mef_eline#406

### Summary

Adds in a new threadpool called `api`. This is used to specify the number of threads used to handle API requests concurrently by the ASGI server. Also added in the configuration option `api_concurrency_limit` which specifies the maximum amount of concurrent requests to accept before requests are outright rejected.

### Local Tests

Raising the `api` threadpool size allows for handling more API requests which depend on other api requests without locking up. Locking up still a possibility, but now possible to mitigate with a larger pool size here.
