### PR TITLE
feat: configurable queue monitors for event buffers and thread pools

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 - Added ``special_available_tags`` which stores `"untagged"` and `"any"` if they can be used from an Interface.
 - Added ``maxsize_multiplier`` on ``event_buffer_conf``, which will multiply the ``maxsize`` value of the queue. By default, all KytosEventBuffer who use a bounded queue will have ``maxsize_multiplier: 2``. This default is reasonable to work out of the box with kytos-ng core NApps. But, if you have other NApps who tend to produce too many events you might want to either increase the size of the queue with and/or increase the number of max workers in the thread pool if the event handler is running on a thread pool. Typically, you'll want to first start adjusting the number of workers in the thread pool.
 - Introduced a new ``meta`` on ``KytosBuffers``, which is meant for general core control events.
+- Added ``thread_pool_queue_monitors`` and ``event_buffer_monitors`` on kytos.conf. By default, it'll detect and log full queue usage over 5 secs on event thread pools and on kytos event buffers. These alerts are for providing basic visibility per second about queues usage, which these alerts you can try to understand if indeed you have way too many events or if you need to increase the number of thread pool workers depending on the scalability and workload you have.
 
 Changed
 =======

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -199,6 +199,24 @@ class KytosConfig():
                     }
                 },
             },
+            "thread_pool_queue_monitors": [
+              {
+                "min_hits": 5,
+                "delta_secs": 5,
+                "min_queue_full_percent": 150,
+                "log_at_most_n": 0,
+                "queues": ["sb", "app", "db"]
+              }
+            ],
+            "event_buffer_monitors": [
+              {
+                "min_hits": 5,
+                "delta_secs": 5,
+                "min_queue_full_percent": 100,
+                "log_at_most_n": 0,
+                "buffers": ["msg_in", "msg_out", "raw", "app"]
+              }
+            ]
         }
 
         options, argv = self.conf_parser.parse_known_args()
@@ -260,6 +278,12 @@ class KytosConfig():
         )
         options.event_buffer_conf = _parse_json(
             options.event_buffer_conf
+        )
+        options.event_buffer_monitors = _parse_json(
+            options.event_buffer_monitors
+        )
+        options.thread_pool_queue_monitors = _parse_json(
+            options.thread_pool_queue_monitors
         )
 
         return options

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -32,7 +32,6 @@ from socket import error as SocketError
 
 from pyof.foundation.exceptions import PackException
 
-from kytos.core.queue_monitor import QueueMonitorWindow
 from kytos.core.api_server import APIServer, JSONResponse, Request
 from kytos.core.apm import init_apm
 from kytos.core.atcp_server import KytosServer, KytosServerProtocol
@@ -50,6 +49,7 @@ from kytos.core.logs import LogManager
 from kytos.core.napps.base import NApp
 from kytos.core.napps.manager import NAppsManager
 from kytos.core.napps.napp_dir_listener import NAppDirListener
+from kytos.core.queue_monitor import QueueMonitorWindow
 from kytos.core.switch import Switch
 
 __all__ = ('Controller',)

--- a/kytos/core/queue_monitor.py
+++ b/kytos/core/queue_monitor.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import asyncio
+import logging
+from typing import Callable, Optional
+from collections import deque
+from uuid import uuid4
+from pydantic.dataclasses import dataclass
+from pydantic import Field
+from datetime import datetime, timedelta, timezone
+from kytos.core.helpers import now
+
+LOG = logging.getLogger(__name__)
+
+
+@dataclass
+class QueueData:
+    """QueueData Record."""
+
+    size: int
+    id: str = Field(default_factory=lambda: uuid4())
+    created_at: datetime = Field(default_factory=lambda: now())
+
+
+class QueueMonitorWindow:
+
+    """QueueMonitorWindow."""
+
+    def __init__(
+        self,
+        name: str,
+        delta_secs: int,
+        min_size_threshold: int,
+        min_hits: int,
+        qsize_func: Callable[[], int],
+    ) -> None:
+        """QueueMonitorWindow."""
+        self.name = name
+        self.deque: deque[QueueData] = deque()
+        self.delta_secs = delta_secs
+        self.min_size_threshold = min_size_threshold
+        self.min_hits = min_hits
+        self._default_last_logged = datetime(
+            year=1970, month=1, day=1, tzinfo=timezone.utc
+        )
+        self._last_logged: datetime = self._default_last_logged
+        self._tasks: set[asyncio.Task] = set()
+        self.qsize_func = qsize_func
+        self._sampling_freq_secs = 1
+
+    def __repr__(self) -> str:
+        """Repr."""
+        last_logged = (
+            self._last_logged
+            if self._last_logged != self._default_last_logged
+            else None
+        )
+        return (
+            f"QueueMonitorWindow(name={self.name}, len={len(self.deque)}, "
+            f"last_logged={last_logged}, "
+            f"min_hits={self.min_hits}, "
+            f"min_size_threshold={self.min_size_threshold}, "
+            f"delta_secs={self.delta_secs})"
+        )
+
+    def start(self) -> None:
+        """Start sampling."""
+        LOG.info(f"Starting {self}")
+        task = asyncio.create_task(self._keep_sampling())
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    def stop(self):
+        """Stop."""
+        for task in self._tasks:
+            task.cancel()
+
+    async def _keep_sampling(self) -> None:
+        """Keep sampling."""
+        try:
+            while True:
+                self._try_to_append(QueueData(size=self.qsize_func()))
+                self._try_to_log_stats()
+                await asyncio.sleep(self._sampling_freq_secs)
+        except asyncio.CancelledError:
+            pass
+
+    def _try_to_append(self, queue_data: QueueData) -> Optional[QueueData]:
+        """Try to append."""
+        if queue_data.size < self.min_size_threshold:
+            return None
+
+        self.deque.append(queue_data)
+        return queue_data
+
+    def _try_to_log_stats(self) -> None:
+        """Try to log stats."""
+        self._popleft_passed_records()
+        if (
+            self.deque
+            and len(self.deque) >= self.min_hits
+            and self._last_logged + timedelta(seconds=self.delta_secs) <= now()
+        ):
+            first = self.deque.popleft()
+            cur = first
+            minv, maxv, size_acc, count = first.size, first.size, first.size, 1
+            while (
+                self.deque
+                and (self.deque[0].created_at - first.created_at).seconds
+                <= self.delta_secs
+            ):
+                cur = self.deque.popleft()
+                minv = min(minv, cur.size)
+                maxv = max(maxv, cur.size)
+                count += 1
+            avg = size_acc / count
+            self._last_logged = cur.created_at
+            msg = (
+                f"QueueMonitorWindow alert: {self.name}, counted: {count}, "
+                f"min size: {minv}, max size: {maxv}, avg: {avg}, "
+                f"first at: {first.created_at}, last at: {cur.created_at},"
+                f" delta seconds: {self.delta_secs}, min_hits: {self.min_hits}"
+            )
+            LOG.warning(msg)
+
+    def _popleft_passed_records(self) -> None:
+        """Pop left passed records."""
+        delta = self.delta_secs
+        while (
+            self.deque and (now() - self.deque[0].created_at).seconds > delta
+        ):
+            self.deque.popleft()

--- a/kytos/core/queue_monitor.py
+++ b/kytos/core/queue_monitor.py
@@ -2,12 +2,14 @@
 # -*- coding: utf-8 -*-
 import asyncio
 import logging
+import math
 from typing import Callable, Optional
 from collections import deque
 from uuid import uuid4
 from pydantic.dataclasses import dataclass
 from pydantic import Field
 from datetime import datetime, timedelta, timezone
+from kytos.core.exceptions import KytosCoreException
 from kytos.core.helpers import now
 
 LOG = logging.getLogger(__name__)
@@ -23,30 +25,52 @@ class QueueData:
 
 
 class QueueMonitorWindow:
-
     """QueueMonitorWindow."""
 
     def __init__(
         self,
         name: str,
+        min_hits: int,
         delta_secs: int,
         min_size_threshold: int,
-        min_hits: int,
         qsize_func: Callable[[], int],
+        log_at_most_n=0,
     ) -> None:
         """QueueMonitorWindow."""
         self.name = name
-        self.deque: deque[QueueData] = deque()
+        self.min_hits = min_hits
         self.delta_secs = delta_secs
         self.min_size_threshold = min_size_threshold
-        self.min_hits = min_hits
+        self.qsize_func = qsize_func
+        self.log_at_most_n = log_at_most_n
+
+        self.deque: deque[QueueData] = deque()
         self._default_last_logged = datetime(
             year=1970, month=1, day=1, tzinfo=timezone.utc
         )
         self._last_logged: datetime = self._default_last_logged
         self._tasks: set[asyncio.Task] = set()
-        self.qsize_func = qsize_func
         self._sampling_freq_secs = 1
+        self._validate()
+
+    def _validate(self) -> None:
+        """Validate QueueMonitorWindow."""
+        positive_attrs = (
+            "min_hits",
+            "delta_secs",
+            "min_size_threshold",
+        )
+        for attr in positive_attrs:
+            val = getattr(self, attr)
+            if val < 0:
+                raise KytosCoreException(
+                    f"{attr}: {val} must be positive"
+                )
+        ratio = self.min_hits / self.delta_secs
+        if ratio > 1:
+            raise KytosCoreException(
+                f"min_hits/delta_secs: {ratio} must be <= 1 "
+            )
 
     def __repr__(self) -> str:
         """Repr."""
@@ -56,7 +80,7 @@ class QueueMonitorWindow:
             else None
         )
         return (
-            f"QueueMonitorWindow(name={self.name}, len={len(self.deque)}, "
+            f"QueueMonitor(name={self.name}, len={len(self.deque)}, "
             f"last_logged={last_logged}, "
             f"min_hits={self.min_hits}, "
             f"min_size_threshold={self.min_size_threshold}, "
@@ -80,7 +104,8 @@ class QueueMonitorWindow:
         try:
             while True:
                 self._try_to_append(QueueData(size=self.qsize_func()))
-                self._try_to_log_stats()
+                records = self._try_to_log_stats()
+                self._try_to_log_at_most_n_records(records)
                 await asyncio.sleep(self._sampling_freq_secs)
         except asyncio.CancelledError:
             pass
@@ -93,15 +118,36 @@ class QueueMonitorWindow:
         self.deque.append(queue_data)
         return queue_data
 
-    def _try_to_log_stats(self) -> None:
+    def _try_to_log_at_most_n_records(self, records: list[QueueData]) -> None:
+        """Try to log at most n records."""
+        if self.log_at_most_n <= 0 or not records:
+            return
+
+        for i in range(
+            0,
+            len(records),
+            math.ceil(len(records) / self.log_at_most_n),
+        ):
+            record = records[i]
+            msg = (
+                f"{self.name}, "
+                f"record[{i}]/[{len(records)}]: size: {record.size}, "
+                f"at: {record.created_at}"
+            )
+            LOG.warning(msg)
+
+    def _try_to_log_stats(self) -> list[QueueData]:
         """Try to log stats."""
         self._popleft_passed_records()
+        records = []
         if (
             self.deque
             and len(self.deque) >= self.min_hits
             and self._last_logged + timedelta(seconds=self.delta_secs) <= now()
         ):
             first = self.deque.popleft()
+            if self.log_at_most_n > 0:
+                records.append(first)
             cur = first
             minv, maxv, size_acc, count = first.size, first.size, first.size, 1
             while (
@@ -113,20 +159,21 @@ class QueueMonitorWindow:
                 minv = min(minv, cur.size)
                 maxv = max(maxv, cur.size)
                 count += 1
+                if self.log_at_most_n > 0:
+                    records.append(first)
             avg = size_acc / count
             self._last_logged = cur.created_at
             msg = (
-                f"QueueMonitorWindow alert: {self.name}, counted: {count}, "
+                f"{self.name}, counted: {count}, "
                 f"min size: {minv}, max size: {maxv}, avg: {avg}, "
                 f"first at: {first.created_at}, last at: {cur.created_at},"
                 f" delta seconds: {self.delta_secs}, min_hits: {self.min_hits}"
             )
             LOG.warning(msg)
+        return records
 
     def _popleft_passed_records(self) -> None:
         """Pop left passed records."""
         delta = self.delta_secs
-        while (
-            self.deque and (now() - self.deque[0].created_at).seconds > delta
-        ):
+        while self.deque and (now() - self.deque[0].created_at).seconds > delta:
             self.deque.popleft()

--- a/kytos/core/queue_monitor.py
+++ b/kytos/core/queue_monitor.py
@@ -1,4 +1,5 @@
 """queue monitor."""
+# pylint: disable=invalid-name, unnecessary-lambda
 
 from __future__ import annotations
 
@@ -6,7 +7,7 @@ import asyncio
 import logging
 import math
 from collections import deque
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Optional
 from uuid import uuid4
 
@@ -15,7 +16,6 @@ from pydantic.dataclasses import dataclass
 
 from kytos.core.exceptions import KytosCoreException
 from kytos.core.helpers import executors, now
-from datetime import timezone
 
 LOG = logging.getLogger(__name__)
 

--- a/kytos/core/queue_monitor.py
+++ b/kytos/core/queue_monitor.py
@@ -1,19 +1,20 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""queue monitor."""
+
 from __future__ import annotations
 
 import asyncio
 import logging
 import math
-from typing import Callable, Optional
 from collections import deque
-from uuid import uuid4
-from pydantic.dataclasses import dataclass
-from pydantic import Field
 from datetime import datetime
+from typing import Callable, Optional
+from uuid import uuid4
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
 from kytos.core.exceptions import KytosCoreException
-from kytos.core.helpers import now
-from kytos.core.helpers import executors
+from kytos.core.helpers import executors, now
 
 LOG = logging.getLogger(__name__)
 

--- a/kytos/core/queue_monitor.py
+++ b/kytos/core/queue_monitor.py
@@ -123,9 +123,10 @@ class QueueMonitorWindow:
         first_at, last_at = records[0].created_at, records[-1].created_at
         msg = (
             f"{self.name}, counted: {len(records)}, "
-            f"min_size: {min_size}, max_size: {max_size}, avg: {avg}, "
+            f"min/avg/max size: {min_size}/{avg}/{max_size}, "
             f"first at: {first_at}, last at: {last_at}, "
-            f"delta seconds: {self.delta_secs}, min_hits: {self.min_hits}"
+            f"delta secs: {self.delta_secs}, min_hits: {self.min_hits}, "
+            f"min_size_threshold: {self.min_size_threshold}"
         )
         LOG.warning(msg)
 

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -74,6 +74,34 @@ jwt_secret = {{ jwt_secret }}
 # - db: it can be used by for higher priority db related tasks (need to be parametrized on decorator)
 thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512}
 
+# Queue monitors are for detecting and alerting certain queueing thresholds over a delta time.
+# Each queue size will be sampled every second. min_hits / delta_secs needs to be <= 1
+# hits/seconds is measured as a fixed window if the sampled rate is over min_hits/second, it'll log the records at the end of each window
+
+# The queue size is the internal of the thread pool, it's unbounded, if it's queueing too much you might try to want to increase the number of thread pools workers
+thread_pool_queue_monitors =
+  [
+    {
+      "min_hits": 5,
+      "delta_secs": 5,
+      "min_queue_full_percent": 100,
+      "log_at_most_n": 0,
+      "queues": ["sb", "app", "db"]
+    }
+  ]
+
+# The queue size is derived frome each buffer queue
+event_buffer_monitors =
+  [
+    {
+      "min_hits": 5,
+      "delta_secs": 5,
+      "min_queue_full_percent": 100,
+      "log_at_most_n": 0,
+      "buffers": ["msg_in", "msg_out", "raw", "app"]
+    }
+  ]
+
 # Configuration for KytosEventBuffers
 # Valid event buffers are "msg_in", "msg_out", "app", "conn", and "raw".
 # Valid queue types are:

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -77,6 +77,7 @@ thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512}
 # Queue monitors are for detecting and alerting certain queuing thresholds over a delta time.
 # Each queue size will be sampled every second. min_hits / delta_secs needs to be <= 1
 # hits/seconds is measured as a fixed window if the sampled rate is over min_hits/second, it'll log the records at the end of each window
+# You can also set log_at_most_n > 0 if you'd like to have extra information about the sampled "n" hits
 
 # The queue size is the internal of the thread pool, it's unbounded, if it's queuing too much you might try to want to increase the number of thread pools workers
 thread_pool_queue_monitors =

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -74,11 +74,11 @@ jwt_secret = {{ jwt_secret }}
 # - db: it can be used by for higher priority db related tasks (need to be parametrized on decorator)
 thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512}
 
-# Queue monitors are for detecting and alerting certain queueing thresholds over a delta time.
+# Queue monitors are for detecting and alerting certain queuing thresholds over a delta time.
 # Each queue size will be sampled every second. min_hits / delta_secs needs to be <= 1
 # hits/seconds is measured as a fixed window if the sampled rate is over min_hits/second, it'll log the records at the end of each window
 
-# The queue size is the internal of the thread pool, it's unbounded, if it's queueing too much you might try to want to increase the number of thread pools workers
+# The queue size is the internal of the thread pool, it's unbounded, if it's queuing too much you might try to want to increase the number of thread pools workers
 thread_pool_queue_monitors =
   [
     {

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -733,6 +733,12 @@ class TestControllerAsync:
         controller.load_napps.assert_called()
         controller.api_server.start_web_ui.assert_called()
 
+        # These monitors are expected by default
+        expected_buffer_qmons = ["msg_in", "msg_out", "raw", "app"]
+        expected_tp_qmons = ["sb", "app", "db"]
+        expected_len = len(expected_tp_qmons) + len(expected_buffer_qmons)
+        assert len(controller.qmonitors) == expected_len
+
     async def test_stop_controller(self, controller):
         """Test stop_controller method."""
         controller.loop = MagicMock()
@@ -743,6 +749,7 @@ class TestControllerAsync:
         controller._buffers = MagicMock()
         controller.api_server = api_server
         controller.napp_dir_listener = napp_dir_listener
+        controller.stop_queue_monitors = MagicMock()
 
         controller.stop_controller()
 
@@ -752,6 +759,7 @@ class TestControllerAsync:
         controller.unload_napps.assert_called()
         controller.server.shutdown.assert_called()
         controller.loop.stop.assert_called()
+        controller.stop_queue_monitors.assert_called()
 
     async def test_raw_event_handler(self, controller):
         """Test raw_event_handler async method by handling a shutdown event."""

--- a/tests/unit/test_core/test_queue_monitor.py
+++ b/tests/unit/test_core/test_queue_monitor.py
@@ -1,0 +1,31 @@
+from kytos.core.queue_monitor import QueueMonitorWindow
+from kytos.core.exceptions import KytosCoreException
+
+import pytest
+
+
+class TestQueueMonitor:
+    """TestQueueMonitor."""
+
+    @pytest.mark.parametrize(
+        "min_hits,delta_secs,min_size_threshold,exc_str",
+        [
+            (5, 1, 10, "min_hits/delta_secs: 5.0 must be <= 1"),
+            (-1, 10, 10, "min_hits: -1 must be positive"),
+            (2, -1, 10, "delta_secs: -1 must be positive"),
+            (2, 10, -1, "min_size_threshold: -1 must be positive"),
+        ],
+    )
+    def test_validate_constructor(
+        self, min_hits, delta_secs, min_size_threshold, exc_str
+    ) -> None:
+        """Test validate."""
+        with pytest.raises(KytosCoreException) as exc:
+            QueueMonitorWindow(
+                "app",
+                min_hits,
+                delta_secs,
+                min_size_threshold,
+                qsize_func=lambda: 1,
+            )
+        assert exc_str in str(exc)

--- a/tests/unit/test_core/test_queue_monitor.py
+++ b/tests/unit/test_core/test_queue_monitor.py
@@ -1,3 +1,5 @@
+"""test queue_monitor."""
+
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -62,7 +64,8 @@ class TestQueueMonitor:
         n_records = 5
         for _ in range(n_records):
             created_at = now() - timedelta(seconds=delta_secs + 1)
-            assert qmon._try_to_append(QueueRecord(size=256, created_at=created_at))
+            assert qmon._try_to_append(QueueRecord(size=256,
+                                                   created_at=created_at))
         assert len(qmon.deque) == n_records
         qmon._popleft_passed_records()
         assert not qmon.deque
@@ -168,10 +171,11 @@ class TestQueueMonitor:
         # old elements are expected to be discarded, resulting in no records
         for _ in range(n_records):
             created_at = now() - timedelta(seconds=delta_secs + 1)
-            assert qmon._try_to_append(QueueRecord(size=256, created_at=created_at))
+            assert qmon._try_to_append(QueueRecord(size=256,
+                                                   created_at=created_at))
         assert len(qmon.deque) == n_records
         records = qmon._get_records()
-        assert not len(records)
+        assert not records
         assert not qmon.deque
 
     def test_get_records_partial(self) -> None:
@@ -195,7 +199,7 @@ class TestQueueMonitor:
         # only 5 out of these 10 records are expected, given delta_secs = 5
         records = qmon._get_records()
         assert len(records) == 5
-        assert not len(qmon.deque)
+        assert not qmon.deque
 
         n_records = 2
         for i in range(n_records, 0, -1):
@@ -206,7 +210,7 @@ class TestQueueMonitor:
 
         # no records are expected now since n_records 2 < min_hits 3
         records = qmon._get_records()
-        assert not len(records)
+        assert not records
 
     def test_create_from_buffer_config(self) -> None:
         """Test create from buffer config."""

--- a/tests/unit/test_core/test_queue_monitor.py
+++ b/tests/unit/test_core/test_queue_monitor.py
@@ -1,10 +1,11 @@
-from kytos.core.queue_monitor import QueueMonitorWindow, QueueRecord
-from kytos.core.exceptions import KytosCoreException
-from kytos.core.helpers import now
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+from kytos.core.exceptions import KytosCoreException
+from kytos.core.helpers import now
+from kytos.core.queue_monitor import QueueMonitorWindow, QueueRecord
 
 
 class TestQueueMonitor:

--- a/tests/unit/test_core/test_queue_monitor.py
+++ b/tests/unit/test_core/test_queue_monitor.py
@@ -1,5 +1,7 @@
-from kytos.core.queue_monitor import QueueMonitorWindow
+from kytos.core.queue_monitor import QueueMonitorWindow, QueueData
 from kytos.core.exceptions import KytosCoreException
+from kytos.core.helpers import now
+from datetime import timedelta
 
 import pytest
 
@@ -29,3 +31,43 @@ class TestQueueMonitor:
                 qsize_func=lambda: 1,
             )
         assert exc_str in str(exc)
+
+    def test_try_to_append(self) -> None:
+        """Test try to append."""
+        qmon = QueueMonitorWindow(
+            "app",
+            min_hits=2,
+            delta_secs=10,
+            min_size_threshold=128,
+            qsize_func=lambda: 1,
+        )
+        assert not qmon.deque
+        assert not qmon._try_to_append(QueueData(size=64))
+        assert not qmon.deque
+        assert qmon._try_to_append(QueueData(size=256))
+        assert len(qmon.deque) == 1
+
+    def test_popleft_passed_records(self) -> None:
+        """Test popleft passed records."""
+        delta_secs = 10
+        qmon = QueueMonitorWindow(
+            "app",
+            min_hits=2,
+            delta_secs=delta_secs,
+            min_size_threshold=128,
+            qsize_func=lambda: 1,
+        )
+        n_records = 5
+        for _ in range(n_records):
+            dt = (now() - timedelta(seconds=delta_secs + 1))
+            assert qmon._try_to_append(QueueData(size=256, created_at=dt))
+        assert len(qmon.deque) == n_records
+        qmon._popleft_passed_records()
+        assert not qmon.deque
+
+        # it shouldn't popleft now if delta_secs haven't passed
+        for _ in range(n_records):
+            assert qmon._try_to_append(QueueData(size=256, created_at=now()))
+        assert len(qmon.deque) == n_records
+        qmon._popleft_passed_records()
+        assert len(qmon.deque) == n_records

--- a/tests/unit/test_core/test_queue_monitor.py
+++ b/tests/unit/test_core/test_queue_monitor.py
@@ -1,8 +1,8 @@
-from kytos.core.queue_monitor import QueueMonitorWindow, QueueData
+from kytos.core.queue_monitor import QueueMonitorWindow, QueueRecord
 from kytos.core.exceptions import KytosCoreException
 from kytos.core.helpers import now
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -43,9 +43,9 @@ class TestQueueMonitor:
             qsize_func=lambda: 1,
         )
         assert not qmon.deque
-        assert not qmon._try_to_append(QueueData(size=64))
+        assert not qmon._try_to_append(QueueRecord(size=64))
         assert not qmon.deque
-        assert qmon._try_to_append(QueueData(size=256))
+        assert qmon._try_to_append(QueueRecord(size=256))
         assert len(qmon.deque) == 1
 
     def test_popleft_passed_records(self) -> None:
@@ -60,15 +60,15 @@ class TestQueueMonitor:
         )
         n_records = 5
         for _ in range(n_records):
-            dt = now() - timedelta(seconds=delta_secs + 1)
-            assert qmon._try_to_append(QueueData(size=256, created_at=dt))
+            created_at = now() - timedelta(seconds=delta_secs + 1)
+            assert qmon._try_to_append(QueueRecord(size=256, created_at=created_at))
         assert len(qmon.deque) == n_records
         qmon._popleft_passed_records()
         assert not qmon.deque
 
         # it shouldn't popleft now if delta_secs haven't passed
         for _ in range(n_records):
-            assert qmon._try_to_append(QueueData(size=256, created_at=now()))
+            assert qmon._try_to_append(QueueRecord(size=256, created_at=now()))
         assert len(qmon.deque) == n_records
         qmon._popleft_passed_records()
         assert len(qmon.deque) == n_records
@@ -77,10 +77,10 @@ class TestQueueMonitor:
         "log_at_most_n, gen_n_records, expected_log_count",
         [(5, 5, 5), (5, 10, 5), (5, 3, 3), (0, 10, 0)],
     )
-    def test_try_to_log_at_most_n_records(
+    def test_log_at_most_n_records(
         self, monkeypatch, log_at_most_n, gen_n_records, expected_log_count
     ) -> None:
-        """Test try_to_log_at_most_n_records."""
+        """Test log_at_most_n_records."""
         log_mock = MagicMock()
         monkeypatch.setattr("kytos.core.queue_monitor.LOG", log_mock)
         qmon = QueueMonitorWindow(
@@ -91,9 +91,118 @@ class TestQueueMonitor:
             qsize_func=lambda: 1,
             log_at_most_n=log_at_most_n,
         )
-        qmon._try_to_log_at_most_n_records([])
+        qmon._log_at_most_n_records([])
         assert not log_mock.call_count
 
-        records = [QueueData(size=129) for _ in range(gen_n_records)]
-        qmon._try_to_log_at_most_n_records(records)
+        records = [QueueRecord(size=129) for _ in range(gen_n_records)]
+        qmon._log_at_most_n_records(records)
         assert log_mock.warning.call_count == expected_log_count
+
+    def test_log_queue_stats(self, monkeypatch) -> None:
+        """Test log queue stats."""
+        log_mock = MagicMock()
+        monkeypatch.setattr("kytos.core.queue_monitor.LOG", log_mock)
+        qmon = QueueMonitorWindow(
+            "app",
+            min_hits=2,
+            delta_secs=10,
+            min_size_threshold=128,
+            qsize_func=lambda: 1,
+        )
+        qmon._log_queue_stats([])
+        assert not log_mock.warning.call_count
+        n_records = 5
+        records = [QueueRecord(size=128 + i) for i in range(n_records)]
+        qmon._log_queue_stats(records)
+        assert log_mock.warning.call_count == 1
+        rec_sizes = [rec.size for rec in records]
+        min_size, max_size = min(rec_sizes), max(rec_sizes)
+        avg = sum(rec_sizes) / len(rec_sizes)
+        expected = (
+            f"{qmon.name}, counted: {len(records)}, "
+            f"min_size: {min_size}, "
+            f"max_size: {max_size}, "
+            f"avg: {avg}, first at: {str(records[0].created_at)}, "
+            f"last at: {str(records[-1].created_at)}, "
+            f"delta seconds: {qmon.delta_secs}, min_hits: {qmon.min_hits}"
+        )
+        log_mock.warning.assert_called_with(expected)
+
+    async def test_start_stop(self, monkeypatch) -> None:
+        """Test start stop."""
+        sleep_mock = AsyncMock
+        monkeypatch.setattr("asyncio.sleep", sleep_mock)
+        qmon = QueueMonitorWindow(
+            "app",
+            min_hits=2,
+            delta_secs=10,
+            min_size_threshold=128,
+            qsize_func=lambda: 1,
+        )
+        qmon.start()
+        assert qmon._tasks
+        qmon.stop()
+
+    def test_get_records(self) -> None:
+        """Test get_records."""
+        delta_secs = 10
+        qmon = QueueMonitorWindow(
+            "app",
+            min_hits=2,
+            delta_secs=delta_secs,
+            min_size_threshold=128,
+            qsize_func=lambda: 1,
+        )
+
+        assert not qmon._get_records()
+        n_records = 5
+        for _ in range(n_records):
+            assert qmon._try_to_append(QueueRecord(size=256, created_at=now()))
+        # all elements are expected to be returned
+        assert len(qmon.deque) == n_records
+        records = qmon._get_records()
+        assert len(records) == n_records
+        assert not qmon.deque
+
+        # old elements are expected to be discarded, resulting in no records
+        for _ in range(n_records):
+            created_at = now() + timedelta(seconds=delta_secs + 1)
+            assert qmon._try_to_append(QueueRecord(size=256, created_at=created_at))
+        assert len(qmon.deque) == n_records
+        records = qmon._get_records()
+        assert not len(records)
+        assert not qmon.deque
+
+    def test_get_records_partial(self) -> None:
+        """Test get_records partial."""
+        delta_secs = 5
+        qmon = QueueMonitorWindow(
+            "app",
+            min_hits=3,
+            delta_secs=delta_secs,
+            min_size_threshold=128,
+            qsize_func=lambda: 1,
+        )
+
+        n_records = 10
+        for i in range(n_records, 0, -1):
+            assert qmon._try_to_append(
+                QueueRecord(size=256, created_at=now() - timedelta(seconds=i))
+            )
+        assert len(qmon.deque) == n_records
+
+        # only 5 out of these 10 records are expected, given delta_secs = 5
+        records = qmon._get_records()
+        assert len(records) == 5
+        assert not len(qmon.deque)
+
+        n_records = 2
+        for i in range(n_records, 0, -1):
+            assert qmon._try_to_append(
+                QueueRecord(size=256, created_at=now() - timedelta(seconds=i))
+            )
+        assert len(qmon.deque) == n_records
+
+        # no records are expected now since n_records 2 < min_hits 3
+        records = qmon._get_records()
+        assert not len(records)

--- a/tests/unit/test_core/test_queue_monitor.py
+++ b/tests/unit/test_core/test_queue_monitor.py
@@ -120,11 +120,11 @@ class TestQueueMonitor:
         avg = sum(rec_sizes) / len(rec_sizes)
         expected = (
             f"{qmon.name}, counted: {len(records)}, "
-            f"min_size: {min_size}, "
-            f"max_size: {max_size}, "
-            f"avg: {avg}, first at: {str(records[0].created_at)}, "
+            f"min/avg/max size: {min_size}/{avg}/{max_size}, "
+            f"first at: {str(records[0].created_at)}, "
             f"last at: {str(records[-1].created_at)}, "
-            f"delta seconds: {qmon.delta_secs}, min_hits: {qmon.min_hits}"
+            f"delta secs: {qmon.delta_secs}, min_hits: {qmon.min_hits}, "
+            f"min_size_threshold: {qmon.min_size_threshold}"
         )
         log_mock.warning.assert_called_with(expected)
 


### PR DESCRIPTION
Closes #439 

### Summary

- See updated changelog file and `kytos.conf.template` for more specific information
- The default config should works well out of the gate for our current `kytos-ng` NApps and AmLight's scalability network like (I simulated with 300 EVCs + a few link flaps)
- Notice that with queue monitors the major goal is to detect high queuing usage over a delta t in seconds sampled each second, so we're not trying to have extremely granular visibility (telemetry like), but just to start detecting when on a per second scale if any queues of event buffers or the max workers of thread pools need to either be increased or if a NApp might be misbehaving and sending way too many events.

### Local Tests

- I tested the default config with 300 EVCs with some link flap and no warnings showed up as expected
- I also explored three configs that will be described below, while also injecting a hundreds of concurrent events targeting a slow-ish handler to simulate a case where the queue of a thread pool would keep increasing significantly

#### Config a (default)

```
2024-02-08 10:27:48,058 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(msg_in, min_hits=5, min_size=512, delta_secs=5)...
2024-02-08 10:27:48,058 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(msg_out, min_hits=5, min_size=512, delta_secs=5)...
2024-02-08 10:27:48,058 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(raw, min_hits=5, min_size=512, delta_secs=5)...
2024-02-08 10:27:48,058 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(app, min_hits=5, min_size=1024, delta_secs=5)...
2024-02-08 10:27:48,058 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(threadpool_sb, min_hits=5, min_size=256, delta_secs=5)...
2024-02-08 10:27:48,058 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(threadpool_app, min_hits=5, min_size=512, delta_secs=5)...
2024-02-08 10:27:48,058 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(threadpool_db, min_hits=5, min_size=256, delta_secs=5)...



... after injecting too many events ... 


2024-02-08 10:29:34,182 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 5, min/avg/max size: 4608/10336.6/12958, first at: 2024-02-08 13:29:29.802628+00:00, last at: 2024-02-08 13:29:34.182469+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 512
2024-02-08 10:29:39,188 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 5, min/avg/max size: 9392/10410.0/11428, first at: 2024-02-08 13:29:35.184075+00:00, last at: 2024-02-08 13:29:39.188669+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 512
2024-02-08 10:29:44,195 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 5, min/avg/max size: 6838/7859.6/8880, first at: 2024-02-08 13:29:40.189934+00:00, last at: 2024-02-08 13:29:44.195025+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 512

```

#### Config b

```
thread_pool_queue_monitors =
  [
    {
      "min_hits": 5,
      "delta_secs": 10,
      "min_queue_full_percent": 100,
      "log_at_most_n": 3,
      "queues": ["sb", "app", "db"]
    }
  ]


2024-02-08 10:26:03,160 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(msg_in, min_hits=5, min_size=512, delta_secs=5)...
2024-02-08 10:26:03,160 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(msg_out, min_hits=5, min_size=512, delta_secs=5)...
2024-02-08 10:26:03,160 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(raw, min_hits=5, min_size=512, delta_secs=5)...
2024-02-08 10:26:03,160 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(app, min_hits=5, min_size=1024, delta_secs=5)...
2024-02-08 10:26:03,160 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(threadpool_sb, min_hits=5, min_size=256, delta_secs=10)...
2024-02-08 10:26:03,160 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(threadpool_app, min_hits=5, min_size=512, delta_secs=10)...
2024-02-08 10:26:03,160 - INFO [kytos.core.controller] (MainThread) Starting QueueMonitor(threadpool_db, min_hits=5, min_size=256, delta_secs=10)...


... after injecting too many events ... 

2024-02-08 10:26:40,911 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 5, min/avg/max size: 2560/10130.0/13470, first at: 2024-02-08 13:26:36.561493+00:00, last at: 2024-02-08 13:26:40.911422+00:00, delta secs: 10, min_hits: 5, min_size_threshold: 512
2024-02-08 10:26:40,911 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, record[0]/[5]: size: 2560, at: 2024-02-08 13:26:36.561493+00:00
2024-02-08 10:26:40,911 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, record[2]/[5]: size: 13470, at: 2024-02-08 13:26:38.909429+00:00
2024-02-08 10:26:40,911 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, record[4]/[5]: size: 12446, at: 2024-02-08 13:26:40.911422+00:00

2024-02-08 10:26:50,927 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 10, min/avg/max size: 7350/9643.2/11940, first at: 2024-02-08 13:26:41.912263+00:00, last at: 2024-02-08 13:26:50.926982+00:00, delta secs: 10, min_hits: 5, min_size_threshold: 512
2024-02-08 10:26:50,927 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, record[0]/[10]: size: 11940, at: 2024-02-08 13:26:41.912263+00:00
2024-02-08 10:26:50,927 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, record[4]/[10]: size: 9898, at: 2024-02-08 13:26:45.919824+00:00
2024-02-08 10:26:50,927 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, record[8]/[10]: size: 7856, at: 2024-02-08 13:26:49.925610+00:00

```

#### Config c

This (temporary) config can be useful when you just want to see if every second if there's at least 1 event being queued, this can be useful to give you an idea of how busy the queues are in a local stress test scenario for instance, which can help you to identify certain base line usage and/or spiky queue usage loads in a particular case:

```
thread_pool_queue_monitors =
  [
    {
      "min_hits": 1,
      "delta_secs": 1,
      "min_queue_full_percent": 0,
      "log_at_most_n": 0,
      "queues": ["sb", "app", "db"]
    }
  ]

```


```

2024-02-08 10:34:10,705 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 1, min/avg/max size: 2488/2488.0/2488, first at: 2024-02-08 13:34:10.705708+00:00, last at: 2024-02-08 13:34:10.705708+00:00, delta secs: 1, min_hits: 1, min_size_threshold: 1
2024-02-08 10:34:11,707 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 1, min/avg/max size: 1976/1976.0/1976, first at: 2024-02-08 13:34:11.707078+00:00, last at: 2024-02-08 13:34:11.707078+00:00, delta secs: 1, min_hits: 1, min_size_threshold: 1
2024-02-08 10:34:12,710 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 1, min/avg/max size: 1464/1464.0/1464, first at: 2024-02-08 13:34:12.709970+00:00, last at: 2024-02-08 13:34:12.709970+00:00, delta secs: 1, min_hits: 1, min_size_threshold: 1
2024-02-08 10:34:13,711 - WARNING [kytos.core.queue_monitor] (MainThread) threadpool_app, counted: 1, min/avg/max size: 958/958.0/958, first at: 2024-02-08 13:34:13.711444+00:00, last at: 2024-02-08 13:34:13.711444+00:00, delta secs: 1, min_hits: 1, min_size_threshold: 1

```

### End-to-End Tests

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 257 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 233 passed, 8 skipped, 9 xfailed, 7 xpassed, 1143 warnings in 12325.92s (3:25:25) =
```