### PR TITLE
Upgraded Mongo to 7.0 from 5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ Changed
 =======
 - Updated python environment installation from 3.9 to 3.11
 - Updated test dependencies
+- MongoDB version has been updated to 7.0
+
+General Information
+===================
+- Kytos is tested and supported with mongo version 7.0. It can work with the lower versions 6.0 and 5.0 but they are not guaranteed to work flawlessly. To update mongo version follow these `steps <https://github.com/kytos-ng/kytos/pull/470>`_.
+
 
 [2023.2.0] - 2024-02-16
 ***********************

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
 ################################################################
 # This docker-compose file is meant for LOCAL development only #
 ################################################################
-
-version: '3.3'
-
 services:
   mongo-setup:
     container_name: mongo-rs-init

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3.3'
 services:
   mongo-setup:
     container_name: mongo-rs-init
-    image: mongo:5.0
+    image: mongo:7.0
     restart: on-failure
     volumes:
       - ./docker/scripts:/scripts
@@ -24,7 +24,7 @@ services:
       - mongo3
   mongo1:
     container_name: mongo1
-    image: mongo:5.0
+    image: mongo:7.0
     volumes:
       - mongo1_data:/data/db
     ports:
@@ -36,7 +36,7 @@ services:
       - mongo3
   mongo2:
     container_name: mongo2
-    image: mongo:5.0
+    image: mongo:7.0
     volumes:
       - mongo2_data:/data/db
     ports:
@@ -45,7 +45,7 @@ services:
     entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27018" ]
   mongo3:
     container_name: mongo3
-    image: mongo:5.0
+    image: mongo:7.0
     volumes:
       - mongo3_data:/data/db
     ports:

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -514,6 +514,7 @@ class Controller:
         if self.apm:
             self.log.info("Stopping APM server...")
             self.apm.close()
+            self.log.info("Stopped APM Server")
         self.log.info("Stopping API Server...")
         self.api_server.stop()
         self.log.info("Stopped API Server")


### PR DESCRIPTION
Closes #451

### Summary

Updated MongoDB to 7.0.

### Local Tests

Updated MongoDB and run some [tests](https://github.com/kytos-ng/kytos/pull/470#issuecomment-2104425533). No noticeable changes between the versions and data generation.

### Update steps

Before following the update procedure, be sure to download the latest Mongo package. To check on active database [mongosh](https://www.mongodb.com/docs/mongodb-shell/install/) can be installed (For Debian 12 follow Ubuntu 22.04 process).
To update follow this instructions:

1. Stop kytos
2. From mongosh, enter `db.adminCommand( { setFeatureCompatibilityVersion: "5.0" } )`. This change can be checked with `db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )`
3. Stop the containers that kytos creates: `mongo-rs-init`, `mongo1`, `mongo2` and `mongo3`. To check their status enter the console command `docker ps -a`. Example:
```
CONTAINER ID   IMAGE       COMMAND                  CREATED              STATUS                          PORTS                                                      NAMES
493d530e4104   mongo:6.0   "/scripts/rs-init.sh"    About a minute ago   Exited (0) About a minute ago                                                              mongo-rs-init
ad7a9149a38c   mongo:6.0   "/usr/bin/mongod --b…"   2 minutes ago        Up About a minute               0.0.0.0:27017->27017/tcp, :::27017->27017/tcp              mongo1
fbec48992a5d   mongo:6.0   "/usr/bin/mongod --b…"   2 minutes ago        Up About a minute               27017/tcp, 0.0.0.0:27018->27018/tcp, :::27018->27018/tcp   mongo2
607ee9359347   mongo:6.0   "/usr/bin/mongod --b…"   2 minutes ago        Up About a minute               27017/tcp, 0.0.0.0:27019->27019/tcp, :::27019->27019/tcp   mongo3
```
Stop each container with `docker stop $CONTAINER_ID`. E.g. `docker stop 493d530e4104`.

4. Change `kytos/docker-compose.yml` mongo images to 6.0 (There are 4).
5. Run Kytos and close Kytos. Or just run `docker compose up -d`.
6. To mongosh, enter `db.adminCommand( { setFeatureCompatibilityVersion: "6.0" } )`
7. Stop the containers that kytos creates
8. Change `kytos/docker-compose.yml` mongo images to 7.0
9. Run Kytos or `docker compose up -d`. The result can be verified with mongosh with the command `mongosh mongo1:27017,mongo2:27018,mongo3:27019`.
```
Current Mongosh Log ID: 6632a69a07964f2a047b2da8
Connecting to:          mongodb://127.0.0.1:27017/mongo1%3A27017%2Cmongo2%3A27018%2Cmongo3%3A27019?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.2.2
Using MongoDB:          7.0.8  # <-- HERE
Using Mongosh:          2.2.2
mongosh 2.2.5 is available for download: https://www.mongodb.com/try/download/shell
```

### Discrepancies

#### Kytos does not pass `"hello"` command on MongoDB
There maybe some problems with the version compatibility. To check this you can check the mongo1 container. Run `docker logs $CONTAINER_ID | grep "Invalid feature compatibility version"` to check settings. In the results check for:
```
Invalid feature compatibility version value '5.0'; expected '6.0' or '6.3' or '7.0'.
```
The compatibility version is set to 5.0 which means that the version `kytos/docker-compose.yml` needs to change to either 5.0 or 6.0 (in the case of 6.0, the containers are compatible with 6.0 and 7.0).
Change `docker-compose.yml` accordingly, stop and delete containers. Finally run kytos or execute `docker compose up -d` and continue with the update process

#### APM not working
Stop and delete the containers created from `docker-compose.es.yml`. And create them again.

#### Problems with creating containers after `docker compose up -d`
The problems could be errors while recreating container or a container ID already in use. Stop and delete the containers created from `docker-compose.yml`.

#### Port 27017 or 8181 is already in use
- Sometimes the port 27017/8181 will be in use when running Kytos. This port needs to be free. For Linux this command `sudo fuser -k 27017/tcp` worked (or `8181/tcp` depending on the error).

### Downgrade
Downgrading can be done depending on the compatibility version on the database.:
- 5.0 compatibility settings allows the container with mongo 5.0 and 6.0
- 6.0 compatibility settings allows the container with mongo 6.0 and 7.0

Before executing each time the containers with different version, stop the containers `mongo1, mongo2 and mongo3` with the previous version.

### Save and restore database
Command to export:
```
mongodump -d <database_name> -o <directory_backup>
```
It will create a folder with the database name, by default kytos database name is `napps`

Command to restore:
```
mongorestore -d <database_name> <directory_backup>
```

### End-to-End Tests
The e2e tests depend on this [PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/304)

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 263 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```