### PR TITLE
Pacing additions

### DIFF
--- a/kytos/core/pacing.py
+++ b/kytos/core/pacing.py
@@ -173,6 +173,7 @@ class Pacer:
         """
         return action_name in self.pace_config
 
+
 class PacerWrapper:
     """
     Applies a namespace to various operations related to pacing.

--- a/kytos/core/pacing.py
+++ b/kytos/core/pacing.py
@@ -167,6 +167,11 @@ class Pacer:
 
             time.sleep(sleep_time)
 
+    def is_configured(self, action_name):
+        """
+        Check if the given action has been configured.
+        """
+        return action_name in self.pace_config
 
 class PacerWrapper:
     """
@@ -213,6 +218,14 @@ class PacerWrapper:
         return await self.pacer.ahit(
             self._localized_key(action_name),
             *keys
+        )
+
+    def is_configured(self, action_name: str):
+        """
+        Check if the given action has been configured.
+        """
+        return self.pacer.is_configured(
+            self._localized_key(action_name)
         )
 
     def _localized_key(self, key):

--- a/kytos/core/pacing.py
+++ b/kytos/core/pacing.py
@@ -20,6 +20,7 @@ class EmptyStrategy(limits.strategies.FixedWindowRateLimiter):
         *identifiers: str,
         cost: int = 1
     ) -> bool:
+        # Increment storage, to collect data on usage rate of actions
         self.storage.incr(
             item.key_for(*identifiers),
             item.get_expiry(),
@@ -38,6 +39,7 @@ class AsyncEmptyStrategy(limits.aio.strategies.FixedWindowRateLimiter):
         *identifiers: str,
         cost: int = 1
     ) -> bool:
+        # Increment storage, to collect data on usage rate of actions
         await self.storage.incr(
             item.key_for(*identifiers),
             item.get_expiry(),
@@ -137,7 +139,7 @@ class Pacer:
                 *identifiers
             )
             sleep_time = window_reset - time.time()
-
+            LOG.info(f'Limited reached: {identifiers}')
             await asyncio.sleep(sleep_time)
 
     def hit(self, action_name: str, *keys):
@@ -161,7 +163,7 @@ class Pacer:
                 *identifiers
             )
             sleep_time = window_reset - time.time()
-
+            LOG.info(f'Limited reached: {identifiers}')
             if sleep_time <= 0:
                 continue
 

--- a/tests/unit/test_core/test_pacing.py
+++ b/tests/unit/test_core/test_pacing.py
@@ -19,6 +19,7 @@ class TestPacer:
     @pytest.fixture(
         params=[
             'fixed_window',
+            'ignore_pace',
         ]
     )
     def strategy(self, request):
@@ -47,9 +48,11 @@ class TestPacer:
         """Check which strategies are present."""
         assert set(pacer.sync_strategies) == {
             'fixed_window',
+            'ignore_pace'
         }
         assert set(pacer.async_strategies) == {
             'fixed_window',
+            'ignore_pace'
         }
 
     def test_missing_pace(self, pacer: Pacer):
@@ -70,7 +73,7 @@ class TestPacer:
         """Test what happens when a pace is set"""
         await configured_pacer.ahit("paced_action")
 
-    async def test_async_pace_limit(self, configured_pacer: Pacer):
+    async def test_async_pace_limit(self, strategy, configured_pacer: Pacer):
         """Test that actions are being properly paced"""
         async def micro_task():
             await configured_pacer.ahit("paced_action")
@@ -89,9 +92,12 @@ class TestPacer:
 
         elapsed = end - start
 
-        assert elapsed > 1
+        if strategy != 'ignore_pace':
+            assert elapsed > 1
+        else:
+            assert elapsed < 1
 
-    def test_pace_limit(self, configured_pacer: Pacer):
+    def test_pace_limit(self, strategy, configured_pacer: Pacer):
         """Test that actions are being properly paced"""
         actions_executed = 0
 
@@ -105,7 +111,10 @@ class TestPacer:
 
         elapsed = end - start
 
-        assert elapsed > 1
+        if strategy != 'ignore_pace':
+            assert elapsed > 1
+        else:
+            assert elapsed < 1
 
     def test_nonexistant_strategy(self, pacer: Pacer):
         """Make sure that nonexistant strategies raise an exception"""


### PR DESCRIPTION
### Summary

This PR adds additional tools to pacing, that weren't originally considered.
So far, this adds:
 - `ignore_pace` strategy, which ignores the pace, and always lets the action execute.
 - `is_configured` for checking if the pace for a given action has been
 
One potential inclusion to this PR is logging when the limit is reached. The reason it hasn't been included yet, is that this can quickly end up filling the log, when many actions with the same keys are queued.

### Local Tests

Everything seem to be working well here.

### End-to-End Tests

Haven't conducted yet.