### PR TITLE
feat: handled broad exception on event handler looped execution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changed
 - Updated python environment installation from 3.9 to 3.11
 - Updated test dependencies
 - MongoDB version has been updated to 7.0
+- Queue buffers event handlers will now handle and log broad exceptions keeping the task execution alive
 
 General Information
 ===================


### PR DESCRIPTION
Closes #484 

### Summary

See updated changelog file 

### Local Tests

- Simulated unhandled exc on both type of handlers. The traceback was logged as expected, and tasks were kept alive, so this gives a chance to potentially auto recover, and if it doesn't at least the tracebacks are explicit now for these tasks (and then it can get report as bug for us to fix):

```
2024-07-18 16:04:10,364 - ERROR [kytos.core.controller] (MainThread) Unhandled exception on raw
Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 594, in event_handler
    raise ValueError("boom2")
ValueError: boom2
2024-07-18 16:04:10,365 - ERROR [kytos.core.controller] (MainThread) Unhandled exception on msg_out
Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 625, in msg_out_event_handler
    raise ValueError("boom1")
ValueError: boom1
2024-07-18 16:04:10,365 - ERROR [kytos.core.controller] (MainThread) Unhandled exception on msg_out
Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 625, in msg_out_event_handler
    raise ValueError("boom1")
ValueError: boom1
asks2024-07-18 16:04:10,860 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:54626. Reason: Request closed by client
2024-07-18 16:04:10,861 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:54632. Reason: Request closed by client
2024-07-18 16:04:10,862 - ERROR [kytos.core.controller] (MainThread) Unhandled exception on conn
Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 594, in event_handler
    raise ValueError("boom2")
ValueError: boom2
2024-07-18 16:04:10,863 - ERROR [kytos.core.controller] (MainThread) Unhandled exception on conn
Traceback (most recent call last):
  File "/home/viniarck/repos/kytos/kytos/core/controller.py", line 594, in event_handler
    raise ValueError("boom2")
ValueError: boom2

kytos $> controller._tasks
Out[1]: 
[<Task pending name='Task-3' coro=<APIServer.serve() running at /home/viniarck/repos/kytos/kytos/core/api_server.py:113> wait_for=<Future pending cb=[Task.task_wakeup()]>>,
 <Task pending name='Task-4' coro=<Controller.event_handler() running at /home/viniarck/repos/kytos/kytos/core/controller.py:592> wait_for=<Future pending cb=[Task.task_wakeup()]>>,
 <Task pending name='Task-5' coro=<Controller.event_handler() running at /home/viniarck/repos/kytos/kytos/core/controller.py:592> wait_for=<Future pending cb=[Task.task_wakeup()]>>,
 <Task pending name='Task-6' coro=<Controller.event_handler() running at /home/viniarck/repos/kytos/kytos/core/controller.py:592> wait_for=<Future pending cb=[Task.task_wakeup()]>>,
 <Task pending name='Task-7' coro=<Controller.msg_out_event_handler() running at /home/viniarck/repos/kytos/kytos/core/controller.py:624> wait_for=<Future pending cb=[Task.task_wakeup()
]>>,
 <Task pending name='Task-8' coro=<Controller.event_handler() running at /home/viniarck/repos/kytos/kytos/core/controller.py:592> wait_for=<Future pending cb=[Task.task_wakeup()]>>,
 <Task pending name='Task-9' coro=<Controller.event_handler() running at /home/viniarck/repos/kytos/kytos/core/controller.py:592> wait_for=<Future pending cb=[Task.task_wakeup()]>>]


```

### End-to-End Tests

With this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 266 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 242 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings in 12509.15s (3:28:29) =
```
