### PR TITLE
Changed the default api threadpool size to 512

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,12 @@ Changed
 - Updated test dependencies
 - MongoDB version has been updated to 7.0
 - Queue buffers event handlers will now handle and log broad exceptions keeping the task execution alive
+- Raised the ``api`` threadpool workers to 512.
 
 General Information
 ===================
 - Kytos is tested and supported with mongo version 7.0. It can work with the lower versions 6.0 and 5.0 but they are not guaranteed to work flawlessly. To update mongo version follow these `steps <https://github.com/kytos-ng/kytos/pull/470>`_.
+- If you encounter problems with the http api being unavailable (return code 503), then you should boost the ``api`` threadpool size. As a general rule of thumb you should have two ``api`` threads for every three EVCs.
 
 
 [2023.2.0] - 2024-02-16

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -62,7 +62,7 @@ class APIServer:
         )
         kytos_conf = KytosConfig().options["daemon"]
 
-        api_threadpool_size = get_thread_pool_max_workers().get('api', 160)
+        api_threadpool_size = get_thread_pool_max_workers().get('api', 512)
 
         concurrency_limit = kytos_conf.api_concurrency_limit
         if concurrency_limit == 'threadpool':

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -72,8 +72,8 @@ jwt_secret = {{ jwt_secret }}
 # - sb: it's used automatically by kytos/of_core.* events, it's meant for southbound related messages
 # - app: it's meant for general NApps event, it's default pool if no other one has been specified
 # - db: it can be used by for higher priority db related tasks (need to be parametrized on decorator)
-# - api: Not used by events, but instead API requests.
-thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512, "api": 160}
+# - api: Not used by events, but instead API requests. For worst case scenario, should be equal to two thirds of the total EVCs.
+thread_pool_max_workers = {"sb": 256, "db": 256, "app": 512, "api": 512}
 
 # Queue monitors are for detecting and alerting certain queuing thresholds over a delta time.
 # Each queue size will be sampled every second. min_hits / delta_secs needs to be <= 1


### PR DESCRIPTION
Closes #489

### Summary

Raises the default API threadpool size to 512. See comments on issue #489 for reasoning on this change.

### Local Tests

With 800 EVCs kytos is able to process the link down event for all EVCs without causing an HTTP 503 error.
