### PR TITLE
chore: Refactors log message `Limited reached:` to `Limit reached:`

### DIFF
--- a/kytos/core/pacing.py
+++ b/kytos/core/pacing.py
@@ -167,7 +167,7 @@ class Pacer:
                 *identifiers
             )
             sleep_time = window_reset - time.time()
-            LOG.info(f'Limited reached: {identifiers}')
+            LOG.info(f'Limit reached: {identifiers}')
             if sleep_time <= 0:
                 continue
 


### PR DESCRIPTION
Closes #498

### Summary

Refactors a logging grammar mistake.

### Local Tests

Seems to still work the same.

### End-to-End Tests

(Probably) Not necessary.