### PR TITLE
Stop execute to be triggered one last time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Fixed
+=====
+- Execute routines like consistency checks will not trigger one more time after kytos shuts down.
+
 [2024.1.2] - 2024-09-16
 ***********************
 

--- a/kytos/core/napps/base.py
+++ b/kytos/core/napps/base.py
@@ -251,8 +251,10 @@ class KytosNApp(Thread, metaclass=ABCMeta):
         except Exception:
             traceback_str = traceback.format_exc(chain=False)
             LOG.error(f"NApp: {self} unhandled exception {traceback_str}")
-        while self.__interval > 0 and not self.__event.is_set():
+        while self.__interval > 0:
             self.__event.wait(self.__interval)
+            if self.__event.is_set():
+                break
             try:
                 self.execute()
             except Exception:
@@ -276,8 +278,8 @@ class KytosNApp(Thread, metaclass=ABCMeta):
             event (:class:`KytosEvent`): event to be listened.
         """
         if not self.__event.is_set():
-            self.__event.set()
             self.shutdown()
+            self.__event.set()
 
     @abstractmethod
     def setup(self):


### PR DESCRIPTION
Closes #502 

### Summary

Break loop before `NApp.execute()` triggers again.

### Local Tests
Add log for `execute()`s and shutting down kytos.

### End-to-End Tests
N/A