### PR TITLE
Replaced search for .kytos files with .vue

### DIFF
--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -198,13 +198,13 @@ class APIServer:
         """
         section_name = request.path_params["section_name"]
         section_name = '*' if section_name == "all" else section_name
-        path = f"{self.napps_dir}/*/*/ui/{section_name}/*.kytos"
+        path = f"{self.napps_dir}/*/*/ui/{section_name}/*.vue"
         components = []
         for name in glob(path):
             dirs_name = name.split('/')
             dirs_name.remove('ui')
 
-            component_name = '-'.join(dirs_name[-4:]).replace('.kytos', '')
+            component_name = '-'.join(dirs_name[-4:]).replace('.vue', '')
             url = f'ui/{"/".join(dirs_name[-4:])}'
             component = {'name': component_name, 'url': url}
             components.append(component)


### PR DESCRIPTION
Closes #524

### Summary

Since we are moving from utilizing the `httpvueloader` to now using the `vue3-sfc-loader`, we must now change the napp ui file extension from `.kytos` to `.vue`. This is because the vue3-sfc-loader only works on `.vue` files.

### Local Tests

Kytos now detects `.vue` files.
