### PR TITLE
Added reverse option to range_intersection()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Added
+=====
+- Added option for links to obtained last TAG from ``interface.available_tags``
+
 Fixed
 =====
 - Execute routines like consistency checks will not trigger one more time after kytos shuts down.

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -143,7 +143,8 @@ class Link(GenericEntity):
     def get_next_available_tag(
         self,
         controller,
-        link_id,
+        link_id: str,
+        take_last: bool = False,
         tag_type: str = 'vlan'
     ) -> int:
         """Return the next available tag if exists."""
@@ -152,10 +153,11 @@ class Link(GenericEntity):
                 with self.endpoint_b._tag_lock:
                     ava_tags_a = self.endpoint_a.available_tags[tag_type]
                     ava_tags_b = self.endpoint_b.available_tags[tag_type]
-                    tags = range_intersection(ava_tags_a,
-                                              ava_tags_b)
+                    tags = range_intersection(ava_tags_a, ava_tags_b,
+                                              take_last)
                     try:
-                        tag, _ = next(tags)
+                        first, last = next(tags)
+                        tag = first if not take_last else last
                         self.endpoint_a.use_tags(
                             controller, tag, use_lock=False, check_order=False
                         )

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -106,35 +106,35 @@ def range_intersection(
             get_validated_tags() for also list[int]
     """
     a_i, b_i = 0, 0
-    common_diff = 1
+    index_diff = 1
     if reverse:
         a_i = len(ranges_a) - 1
         b_i = len(ranges_b) - 1
-        common_diff = -1
+        index_diff = -1
     while 0 <= a_i < len(ranges_a) and 0 <= b_i < len(ranges_b):
         fst_a, snd_a = ranges_a[a_i]
         fst_b, snd_b = ranges_b[b_i]
         # Moving forward with non-intersection
         if snd_a < fst_b:
             if not reverse:
-                a_i += common_diff
+                a_i += index_diff
             else:
-                b_i += common_diff
+                b_i += index_diff
         elif snd_b < fst_a:
             if not reverse:
-                b_i += common_diff
+                b_i += index_diff
             else:
-                a_i += common_diff
+                a_i += index_diff
         else:
             # Intersection
             intersection_start = max(fst_a, fst_b)
             intersection_end = min(snd_a, snd_b)
             yield [intersection_start, intersection_end]
-            if_statement = snd_a < snd_b if not reverse else fst_a > fst_b
-            if if_statement:
-                a_i += common_diff
+            move_from_a = snd_a < snd_b if not reverse else fst_a > fst_b
+            if move_from_a:
+                a_i += index_diff
             else:
-                b_i += common_diff
+                b_i += index_diff
 
 
 def range_difference(

--- a/kytos/core/tag_ranges.py
+++ b/kytos/core/tag_ranges.py
@@ -93,7 +93,8 @@ def get_validated_tags(
 
 def range_intersection(
     ranges_a: list[list[int]],
-    ranges_b: list[list[int]]
+    ranges_b: list[list[int]],
+    reverse: bool = False,
 ) -> Iterator[list[int]]:
     """Returns an iterator of an intersection between
     two validated list of ranges.
@@ -105,23 +106,35 @@ def range_intersection(
             get_validated_tags() for also list[int]
     """
     a_i, b_i = 0, 0
-    while a_i < len(ranges_a) and b_i < len(ranges_b):
+    common_diff = 1
+    if reverse:
+        a_i = len(ranges_a) - 1
+        b_i = len(ranges_b) - 1
+        common_diff = -1
+    while 0 <= a_i < len(ranges_a) and 0 <= b_i < len(ranges_b):
         fst_a, snd_a = ranges_a[a_i]
         fst_b, snd_b = ranges_b[b_i]
         # Moving forward with non-intersection
         if snd_a < fst_b:
-            a_i += 1
+            if not reverse:
+                a_i += common_diff
+            else:
+                b_i += common_diff
         elif snd_b < fst_a:
-            b_i += 1
+            if not reverse:
+                b_i += common_diff
+            else:
+                a_i += common_diff
         else:
             # Intersection
             intersection_start = max(fst_a, fst_b)
             intersection_end = min(snd_a, snd_b)
             yield [intersection_start, intersection_end]
-            if snd_a < snd_b:
-                a_i += 1
+            if_statement = snd_a < snd_b if not reverse else fst_a > fst_b
+            if if_statement:
+                a_i += common_diff
             else:
-                b_i += 1
+                b_i += common_diff
 
 
 def range_difference(

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -209,14 +209,15 @@ class TestLink():
         link = Link(self.iface1, self.iface2)
         tag = link.get_next_available_tag(controller, "link_id")
         next_tag = link.get_next_available_tag(controller, "link_id")
-
+        assert tag == 1
         assert tag != next_tag
 
-    def test_get_tag_multiple_calls(self, controller):
-        """Test get next available tags returns different tags"""
+    def test_get_next_available_tag_reverse(self, controller):
+        """Test get last available tags returns different tags"""
         link = Link(self.iface1, self.iface2)
-        tag = link.get_next_available_tag(controller, "link_id")
-        next_tag = link.get_next_available_tag(controller, "link_id")
+        tag = link.get_next_available_tag(controller, "link_id", True)
+        next_tag = link.get_next_available_tag(controller, "link_id", True)
+        assert tag == 4095
         assert next_tag != tag
 
     def test_tag_life_cicle(self, controller):

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -210,7 +210,7 @@ class TestLink():
         tag = link.get_next_available_tag(controller, "link_id")
         next_tag = link.get_next_available_tag(controller, "link_id")
         assert tag == 1
-        assert tag != next_tag
+        assert next_tag == 2
 
     def test_get_next_available_tag_reverse(self, controller):
         """Test get last available tags returns different tags"""
@@ -218,7 +218,7 @@ class TestLink():
         tag = link.get_next_available_tag(controller, "link_id", True)
         next_tag = link.get_next_available_tag(controller, "link_id", True)
         assert tag == 4095
-        assert next_tag != tag
+        assert next_tag == 4094
 
     def test_tag_life_cicle(self, controller):
         """Test get next available tags returns different tags"""

--- a/tests/unit/test_core/test_tag_ranges.py
+++ b/tests/unit/test_core/test_tag_ranges.py
@@ -96,6 +96,23 @@ def test_range_intersection():
     ]
     assert result == expected
 
+    result = []
+    iterator_result = range_intersection(tags_a, tags_b, reverse=True)
+    for tag_range in iterator_result:
+        result.append(tag_range)
+    expected = [
+        [30, 30], [27, 28], [25, 25], [22, 23], [15, 15], [12, 13], [3, 3]
+    ]
+    assert result == expected
+
+    tags = range_intersection(tags_a, tags_b)
+    first, _ = next(tags)
+    assert first == 3
+
+    tags = range_intersection(tags_a, tags_b, reverse=True)
+    _, last = next(tags)
+    assert last == 30
+
 
 def test_range_difference():
     """Test range_difference"""


### PR DESCRIPTION
Closes #514

### Summary

Added a reverse option to `range_intersection()` so EVCs links have the option to get it.
This PR is necessary for `mef_eline` [PR](https://github.com/kytos-ng/mef_eline/pull/563), new `last_tag` feature.

### Local Tests
Uni tests

### End-to-End Tests
N/A
