### PR TITLE
Added feature to avoid tags when selecting `s_vlan`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ UNRELEASED - Under development
 
 Added
 =====
-- Added option for links to obtained last TAG from ``interface.available_tags``
+- Added option for links to obtained last TAG from ``interface.available_tags``.
+- Added option for links to avoid a TAG value from ``interface.available_tags``.
 
 Fixed
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@ UNRELEASED - Under development
 
 Added
 =====
-- Added option for links to obtained last TAG from ``interface.available_tags``.
-- Added option for links to avoid a TAG value from ``interface.available_tags``.
+- Added option for links to get last TAG from ``interface.available_tags``.
+- Added option for links to try to avoid a TAG value from ``interface.available_tags``.
 
 Fixed
 =====

--- a/kytos/core/link.py
+++ b/kytos/core/link.py
@@ -14,7 +14,7 @@ from kytos.core.common import EntityStatus, GenericEntity
 from kytos.core.exceptions import (KytosLinkCreationError,
                                    KytosNoTagAvailableError)
 from kytos.core.id import LinkID
-from kytos.core.interface import TAG, Interface, TAGType
+from kytos.core.interface import Interface, TAGType
 from kytos.core.tag_ranges import range_intersection
 
 
@@ -146,9 +146,16 @@ class Link(GenericEntity):
         link_id: str,
         take_last: bool = False,
         tag_type: str = 'vlan',
-        avoid_tag: TAG = None,
+        try_avoid_value: int = None,
     ) -> int:
-        """Return the next available tag if exists."""
+        """Return the next available tag if exists. By default this
+         method returns the smallest tag available. Apply options to
+         change behavior.
+         Options:
+           - take_last (bool): Choose the largest tag available.
+           - try_avoid_value (int): Avoid given tag if possible. Otherwise
+             return what is available.
+        """
         with self._get_available_vlans_lock[link_id]:
             with self.endpoint_a._tag_lock:
                 with self.endpoint_b._tag_lock:
@@ -158,8 +165,8 @@ class Link(GenericEntity):
                                               take_last)
                     try:
                         tag_range: list = next(tags)
-                        if (avoid_tag and
-                                tag_range[take_last] == avoid_tag.value):
+                        if (try_avoid_value is not None and
+                                tag_range[take_last] == try_avoid_value):
                             if (tag_range[take_last] !=
                                     tag_range[not take_last]):
                                 tag = tag_range[take_last]

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -7,7 +7,7 @@ import pytest
 
 from kytos.core.common import EntityStatus
 from kytos.core.exceptions import KytosLinkCreationError
-from kytos.core.interface import TAG, Interface, TAGType
+from kytos.core.interface import Interface, TAGType
 from kytos.core.link import Link
 from kytos.core.switch import Switch
 
@@ -223,44 +223,44 @@ class TestLink():
     def test_get_next_available_tag_avoid_tag(self, controller):
         """Test get next available tag avoiding a tag"""
         link = Link(self.iface1, self.iface2)
-        avoid_tag = TAG('vlan', 1)
+        avoid_vlan = 1
 
         # Tag different that avoid tag is available in the same range
         link.endpoint_a.available_tags['vlan'] = [[1, 5]]
         tag = link.get_next_available_tag(
-            controller, "link_id", avoid_tag=avoid_tag
+            controller, "link_id", try_avoid_value=avoid_vlan
         )
         assert tag == 2
 
         # The next tag is the next range
         link.endpoint_a.available_tags['vlan'] = [[1, 1], [100, 300]]
         tag = link.get_next_available_tag(
-            controller, "link_id", avoid_tag=avoid_tag
+            controller, "link_id", try_avoid_value=avoid_vlan
         )
         assert tag == 100
 
         # No more tags available
         link.endpoint_a.available_tags['vlan'] = [[1, 1]]
         tag = link.get_next_available_tag(
-            controller, "link_id", avoid_tag=avoid_tag
+            controller, "link_id", try_avoid_value=avoid_vlan
         )
         assert tag == 1
 
         # Same cases but with reversed
-        avoid_tag = TAG('vlan', 50)
+        avoid_vlan = 50
         link.endpoint_a.available_tags['vlan'] = [[3, 50]]
         tag = link.get_next_available_tag(
-            controller, "link_id", take_last=True, avoid_tag=avoid_tag
+            controller, "link_id", True, try_avoid_value=avoid_vlan
         )
         assert tag == 49
         link.endpoint_a.available_tags['vlan'] = [[1, 20], [50, 50]]
         tag = link.get_next_available_tag(
-            controller, "link_id", take_last=True, avoid_tag=avoid_tag
+            controller, "link_id", True, try_avoid_value=avoid_vlan
         )
         assert tag == 20
         link.endpoint_a.available_tags['vlan'] = [[50, 50]]
         tag = link.get_next_available_tag(
-            controller, "link_id", take_last=True, avoid_tag=avoid_tag
+            controller, "link_id", True, try_avoid_value=avoid_vlan
         )
         assert tag == 50
 


### PR DESCRIPTION
Closes #516

### Summary

Added argument to accept a TAG to be avoided.

### Local Tests
Tested with calling `link.get_next_available_tag(controller, link.id, avoid_tag=tag)` on Kytos console.
Added unit test to cover all possible scenarios.

### End-to-End Tests
N/A