### PR TITLE
feat: integrated pymongo 4.2+ `timeoutms` feature and expose its env var configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Fixed
 =====
 - Execute routines like consistency checks will not trigger one more time after kytos shuts down.
 - Order in ``interface.special_available_tags`` and ``interface.special_tags`` does not matter anymore when looking for used special tag.
+- Exposed pymongo ``timeoutms`` via ``MONGO_OP_TIMEOUTMS`` env var, 20 seconds by default.
+- Exposed pymongo ``sockettimeoutms`` via ``MONGO_SOCKET_TIMEOUTMS`` env var, 30 seconds by default
 
 [2024.1.2] - 2024-09-16
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixed
 - Order in ``interface.special_available_tags`` and ``interface.special_tags`` does not matter anymore when looking for used special tag.
 - Exposed pymongo ``timeoutms`` via ``MONGO_OP_TIMEOUTMS`` env var, 20 seconds by default.
 - Exposed pymongo ``sockettimeoutms`` via ``MONGO_SOCKET_TIMEOUTMS`` env var, 30 seconds by default
+- Upgraded pymongo from 4.6.2 to 4.11.1
 
 [2024.1.2] - 2024-09-16
 ***********************

--- a/kytos/core/auth.py
+++ b/kytos/core/auth.py
@@ -15,7 +15,8 @@ import jwt
 import pymongo
 from pydantic import ValidationError
 from pymongo.collection import ReturnDocument
-from pymongo.errors import AutoReconnect, DuplicateKeyError
+from pymongo.errors import (ConnectionFailure, DuplicateKeyError,
+                            ExecutionTimeout)
 from pymongo.results import InsertOneResult
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -76,7 +77,7 @@ def authenticated(func):
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class UserController:
     """UserController"""

--- a/kytos/core/db.py
+++ b/kytos/core/db.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Tuple
 
 import pymongo.helpers_shared
 from pymongo import MongoClient
-from pymongo.errors import AutoReconnect, OperationFailure
+from pymongo.errors import ConnectionFailure, OperationFailure
 from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_random)
 
@@ -104,7 +104,7 @@ class Mongo:
             max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
         ),
         before_sleep=before_sleep,
-        retry=retry_if_exception_type((OperationFailure, AutoReconnect)),
+        retry=retry_if_exception_type((OperationFailure, ConnectionFailure)),
         reraise=True
     )
     def bootstrap_index(
@@ -142,7 +142,7 @@ def _mongo_conn_wait(mongo_client=mongo_client, retries=12,
         LOG.info("Trying to run 'hello' command on MongoDB...")
         client.db.command("hello")
         LOG.info("Ran 'hello' command on MongoDB successfully. It's ready!")
-    except (OperationFailure, AutoReconnect) as exc:
+    except (OperationFailure, ConnectionFailure) as exc:
         retries -= 1
         if retries > 0:
             time.sleep(max(timeout_ms / 1000, 1))

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -364,7 +364,7 @@ pylint==3.1.0
     # via
     #   kytos
     #   yala
-pymongo==4.6.2
+pymongo==4.11.1
     # via
     #   -r requirements/run.txt
     #   kytos

--- a/requirements/run.in
+++ b/requirements/run.in
@@ -8,7 +8,7 @@ janus==1.0.0
 jinja2==3.1.3
 watchdog==4.0.0
 pyjwt==2.8.0
-pymongo==4.6.2
+pymongo==4.11.1
 pydantic==2.6.3
 dnspython==2.6.1
 email-validator==2.1.1

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -145,7 +145,7 @@ pygments==2.17.2
     # via ipython
 pyjwt==2.8.0
     # via -r requirements/run.in
-pymongo==4.6.2
+pymongo==4.11.1
     # via -r requirements/run.in
 python-daemon==3.0.1
     # via -r requirements/run.in

--- a/tests/unit/test_core/test_db.py
+++ b/tests/unit/test_core/test_db.py
@@ -47,6 +47,8 @@ class TestDb:
             minpoolsize=30,
             readconcernlevel="majority",
             serverselectiontimeoutms=30000,
+            timeoutms=20000,
+            sockettimeoutms=30000,
         )
 
     @staticmethod
@@ -56,7 +58,8 @@ class TestDb:
         mongo_client = MagicMock(return_value=client)
         _mongo_conn_wait(mongo_client)
         mongo_client.assert_called_with(maxpoolsize=6, minpoolsize=3,
-                                        serverselectiontimeoutms=10000)
+                                        serverselectiontimeoutms=10000,
+                                        timeoutms=10000)
         assert client.db.command.mock_calls == [call("hello")]
 
     @patch("kytos.core.db.time.sleep")


### PR DESCRIPTION
Closes #532 

### Summary

- See updated changelog file 

> These new default values are expected to be plenty, MongoDB normally should perform in a few to hundreds of milliseconds in most operations, https://www.mongodb.com/resources/compare/mongodb-benchmark, anything that deviates much from this is something that we as developers need to also investigate and see if indexes are being used correctly, so the timeouts here are very generous and only supposed to help broadly to avoid hanging indefinitely which could lead to critical issues for certain NApps who are managing application runtime locks while doing IO operations. 

### Notes for developers

- For future reference, [check out this comment](https://github.com/kytos-ng/kytos/issues/532#issuecomment-2675118448) to learn how to use `pymongo.timeout(int)`, you normally won't need it much, but for cases where you want force lower timeouts that's a context manager available on `pymongo`. 

```
kytos $> with pymongo.timeout(1):
    ...:     time.sleep(1.1)
    ...:     _ = list(flow_manager.flow_controller.find_flows())
    ...: 

2025-02-26 13:52:08,335 - WARNING [kytos.core.retry] (ThreadPoolExecutor-3_0) Retry #1 for find_flows, args: (<napps.kytos.flow_manager.controllers.FlowController object at 0x7d934879bb
10>,), kwargs: {}, seconds since start: 0.00
2025-02-26 13:52:08,472 - WARNING [kytos.core.retry] (ThreadPoolExecutor-3_0) Retry #2 for find_flows, args: (<napps.kytos.flow_manager.controllers.FlowController object at 0x7d934879bb
10>,), kwargs: {}, seconds since start: 0.14
---------------------------------------------------------------------------
ExecutionTimeout                          Traceback (most recent call last)
File ~/repos/kytos/.direnv/python-3.11/lib/python3.11/site-packages/tenacity/__init__.py:382, in Retrying.__call__(self, fn, *args, **kwargs)
    381 try:
--> 382     result = fn(*args, **kwargs)
    383 except BaseException:  # noqa: B902

...

ExecutionTimeout: operation would exceed time limit, remaining timeout:-0.25597 <= network round trip time:0.00055  (configured timeouts: timeoutMS: 1000.0ms, connectTimeoutMS: 20000.0m
s), full error: {'ok': 0, 'errmsg': 'operation would exceed time limit, remaining timeout:-0.25597 <= network round trip time:0.00055  (configured timeouts: timeoutMS: 1000.0ms, connect
TimeoutMS: 20000.0ms)', 'code': 50}

```

### Local Tests

I ran the following exploratory tests with **MongoDB 7.0** (the current major supported version since 2024.1):

- Ran IO stress tests with link flap with EVCs, worked normally as you'd expect.
- I also forced a wrong and very low value for `MONGO_OP_TIMEOUTMS` 1ms to see the timeouts and retries on NApps working as intended and they did, including the traceback message was clear too and with the values (the last retry handling though still is a tech debt to be fixed in the future https://github.com/kytos-ng/kytos/issues/535). 
- Also simulated node cluster failures, and the tracebacks were clear too and they won't be confused with the `ExecutionTimeout` exc. 
- Also exercised the dead letter queue to re-inject certain events, worked as expected too. 

All of these tests were executed with `flow_manager`, `mef_eline`, `topology`, `maintenance`, and `of_lldp` branches too.

Here a few more tracebacks for the record, notice you can see `timed out (configured timeouts: timeoutMS: 1.0ms, connectTimeoutMS: 20000.0ms)`:

```
kytos $> 2025-02-26 13:49:13,208 - WARNING [kytos.core.retry] (thread_pool_sb_5) Retry #2 for upsert_flow_check, args: (<napps.kytos.flow_manager.controllers.FlowController object at 0x
7d934879bb10>, '00:00:00:00:00:00:00:01'), kwargs: {}, seconds since start: 0.77
2025-02-26 13:49:13,614 - ERROR [kytos.core.helpers] (thread_pool_sb_5) listen_to handler: <function Main.on_flow_stats_check_consistency at 0x7d93487731a0>, args: (<Main(flow_manager, 
stopped 138067797063360)>, KytosEvent('kytos/of_core.flow_stats.received', {'switch': Switch('00:00:00:00:00:00:00:01'), 'replies_flows': [<napps.kytos.of_core.v0x04.flow.Flow object at
 0x7d92c852e150>, <napps.kytos.of_core.v0x04.flow.Flow object at 0x7d92a87a4150>, <napps.kytos.of_core.v0x04.flow.Flow object at 0x7d92a87a4e50>, <napps.kytos.of_core.v0x04.flow.Flow ob
ject at 0x7d92e82a7490>, <napps.kytos.of_core.v0x04.flow.Flow object at 0x7d92e82a77d0>, <napps.kytos.of_core.v0x04.flow.Flow object at 0x7d92c8526250>]}, 0)) traceback: Traceback (most
...
ytos/.direnv/python-3.11/lib/python3.11/site-packages/pymongo/synchronous/pool.py", line 763, in _raise_connection_failure,     _raise_connection_failure(self.address, error, timeout_de
tails=details),   File "/home/viniarck/repos/kytos/.direnv/python-3.11/lib/python3.11/site-packages/pymongo/synchronous/pool.py", line 203, in _raise_connection_failure,     raise Netwo
rkTimeout(msg) from error, pymongo.errors.NetworkTimeout: mongo1:27017: timed out (configured timeouts: timeoutMS: 1.0ms, connectTimeoutMS: 20000.0ms), , The above exception was the dir
ect cause of the following exception:, , Traceback (most recent call last):,   File "/home/viniarck/repos/kytos/kytos/core/helpers.py", line 141, in handler_context,     result = handle
r(*args),              ^^^^^^^^^^^^^^,   File "/home/viniarck/repos/napps/napps/kytos/flow_manager/main.py", line 168, in on_flow_stats_check_consistency,     self.check_consistency(eve
nt.content["switch"]),   File "/home/viniarck/repos/napps/napps/kytos/flow_manager/main.py", line 383, in check_consistency,     self.flow_controller.upsert_flow_check(switch.id),   Fil
e "/home/viniarck/repos/kytos/.direnv/python-3.11/lib/python3.11/site-packages/tenacity/__init__.py", line 289, in wrapped_f,     return self(f, *args, **kw),            ^^^^^^^^^^^^^^^
^^^^^,   File "/home/viniarck/repos/kytos/.direnv/python-3.11/lib/python3.11/site-packages/tenacity/__init__.py", line 379, in __call__,     do = self.iter(retry_state=retry_state),    
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^,   File "/home/viniarck/repos/kytos/.direnv/python-3.11/lib/python3.11/site-packages/tenacity/__init__.py", line 326, in iter,     raise retry_e
xc from fut.exception(), tenacity.RetryError: RetryError[<Future at 0x7d92c85b6b10 state=finished raised NetworkTimeout>], 

```

### End-to-End Tests

In progress, I'll update here in a few hours:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 282 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 23%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 42%]
.                                                                        [ 43%]
tests/test_e2e_14_mef_eline.py x....                                     [ 45%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_17_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py ................
....
```