### PR TITLE
chore: upgraded ES and its related docker development services from 7.17.3 to 7.17.28

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Fixed
 - Exposed pymongo ``sockettimeoutms`` via ``MONGO_SOCKET_TIMEOUTMS`` env var, 30 seconds by default
 - Upgraded pymongo from 4.6.2 to 4.11.1
 
+General Information
+===================
+- If you are running Linux Kernel 6.12+, you need to upgrade Elasticsearch (ES) patch version from 7.17.3 to 7.17.28
+
 [2024.1.2] - 2024-09-16
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Fixed
 
 General Information
 ===================
-- If you are running Linux Kernel 6.12+, you need to upgrade Elasticsearch (ES) patch version from 7.17.3 to 7.17.28
+- If you are running Linux Kernel 6+, you need to upgrade Elasticsearch (ES) patch version to 7.17.28. This ES version has been tested in development with Kernel versions: 5.10, 5.15, 6.6, 6.8, and 6.12.
 
 [2024.1.2] - 2024-09-16
 ***********************

--- a/docker-compose.es.yml
+++ b/docker-compose.es.yml
@@ -7,7 +7,7 @@ version: '3.3'
 services:
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
     environment:
       - bootstrap.memory_lock=true
       - cluster.name=es-cluster
@@ -28,7 +28,7 @@ services:
         hard: -1
   kibana:
     container_name: kibana
-    image: docker.elastic.co/kibana/kibana:7.17.3
+    image: docker.elastic.co/kibana/kibana:7.17.28
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
       - ELASTICSEARCH_URL=http://elasticsearch:9200
@@ -43,7 +43,7 @@ services:
       - elasticsearch
   filebeat:
     container_name: filebeat
-    image: docker.elastic.co/beats/filebeat:7.17.3
+    image: docker.elastic.co/beats/filebeat:7.17.28
     command: >
        filebeat -e
          --strict.perms=false
@@ -61,7 +61,7 @@ services:
       - elasticsearch
   apm-server:
     container_name: apm
-    image: docker.elastic.co/apm/apm-server:7.17.3
+    image: docker.elastic.co/apm/apm-server:7.17.28
     cap_add: ["CHOWN", "DAC_OVERRIDE", "SETGID", "SETUID"]
     cap_drop: ["ALL"]
     environment:


### PR DESCRIPTION
Closes #542 

### Summary

See updated changelog file 

### Local Tests

- I tested it with the following Kernel versions: 6.12, 6.6 and 5.15, they all worked with ES 7.17.28, observed on Kibana and APM. David also confirmed on Kernel 6.8 and 5.10, thanks, David. 

### End-to-End Tests

We don't have e2e tests for ES yet
