### PR TITLE
[fix]: Event handler now yields process from MainThread

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixed
 - Exposed pymongo ``timeoutms`` via ``MONGO_OP_TIMEOUTMS`` env var, 20 seconds by default.
 - Exposed pymongo ``sockettimeoutms`` via ``MONGO_SOCKET_TIMEOUTMS`` env var, 30 seconds by default
 - Upgraded pymongo from 4.6.2 to 4.11.1
+- TCP server does not longer reset connections after approximately ~32,000 events are concurrently sent to the queue. From tests, TCP server is more resilient to resets with a cap around 120,000 events.
 
 General Information
 ===================

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -605,6 +605,12 @@ class Controller:
         self.log.info(f"Event handler {buffer_name} started")
         while True:
             try:
+                # After hitting issues with a large amount of flows being
+                # installed (16k which sends 32k events), this task was
+                # hooging resources in the MainThread causing disconnections
+                # and socket exceptions. With the following sleep, this task
+                # yields to other loops mitigating the disconnection issues.
+                # Now the cap for flow installation at the same time is 50k.
                 await asyncio.sleep(0)
                 event = await event_buffer.aget()
                 self.notify_listeners(event)

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -607,7 +607,7 @@ class Controller:
             try:
                 # After hitting issues with a large amount of flows being
                 # installed (16k which sends 32k events), this task was
-                # hooging resources in the MainThread causing disconnections
+                # hogging resources in the MainThread causing disconnections
                 # and socket exceptions. With the following sleep, this task
                 # yields to other loops mitigating the disconnection issues.
                 # Now the cap for flow installation at the same time is 50k.

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -569,7 +569,7 @@ class Controller:
         """
         return now() - self.started_at if self.started_at else 0
 
-    def notify_listeners(self, event):
+    async def notify_listeners(self, event):
         """Send the event to the specified listeners.
 
         Loops over self.events_listeners matching (by regexp) the attribute
@@ -606,7 +606,7 @@ class Controller:
         while True:
             try:
                 event = await event_buffer.aget()
-                self.notify_listeners(event)
+                await self.loop.create_task(self.notify_listeners(event))
 
                 if event.name == "kytos/core.shutdown":
                     self.log.debug(f"Event handler {buffer_name} stopped")
@@ -656,7 +656,7 @@ class Controller:
                                    message.header.message_type,
                                    message.header.xid,
                                    packet.hex())
-                    self.notify_listeners(triggered_event)
+                    await self.notify_listeners(triggered_event)
             except OSError:
                 await self.publish_connection_error(triggered_event)
                 self.log.info("connection closed. Cannot send message")

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -569,7 +569,7 @@ class Controller:
         """
         return now() - self.started_at if self.started_at else 0
 
-    async def notify_listeners(self, event):
+    def notify_listeners(self, event):
         """Send the event to the specified listeners.
 
         Loops over self.events_listeners matching (by regexp) the attribute
@@ -605,8 +605,9 @@ class Controller:
         self.log.info(f"Event handler {buffer_name} started")
         while True:
             try:
+                await asyncio.sleep(0)
                 event = await event_buffer.aget()
-                await self.loop.create_task(self.notify_listeners(event))
+                self.notify_listeners(event)
 
                 if event.name == "kytos/core.shutdown":
                     self.log.debug(f"Event handler {buffer_name} stopped")
@@ -656,7 +657,7 @@ class Controller:
                                    message.header.message_type,
                                    message.header.xid,
                                    packet.hex())
-                    await self.notify_listeners(triggered_event)
+                    self.notify_listeners(triggered_event)
             except OSError:
                 await self.publish_connection_error(triggered_event)
                 self.log.info("connection closed. Cannot send message")


### PR DESCRIPTION
Closes #546

### Summary

- The cause for the error `socket.exception()` was that a huge amount of events was stopping loops like the Uvicorn server tick, everything stopped [here](https://github.com/kytos-ng/kytos/blob/d6370e067af50c44b142fd88f789b28580ecbc04/kytos/core/controller.py#L609). The problem was the time that the loop was interrupted therefore now `notify_listener()` yields the loop with `await asyncio.sleep(0)`

### Local Tests
#### Check uvicorn loop
- To see if Uvicorn tick is interrupted from its loop. Localize `server.py` from uvicorn package (used from import in kytos/core/api_server.py). Add a log inside `main_loop()` like so:

```
    async def main_loop(self) -> None:
        counter = 0
        should_exit = await self.on_tick(counter)
        while self.uvi_aldo and not should_exit:
            logger.info("RUNNING UVICORN LOOP")
            counter += 1
            counter = counter % 864000
            await asyncio.sleep(0.1)
            should_exit = await self.on_tick(counter)
```

#### Replicate how it was discovered
Add this sniped code to any NApp, for example `flow_manager`:

```
    def sending(self, n=12000):
        name = "kytos/flow_manager.flow.aldo"
        flow = {'cookie': 12295027070226168905, 'match': {'in_port': 3, 'dl_vlan': 1}, 'owner': 'mef_eline', 'cookie_mask': 18446744073709551615}
        content = {"datapath": "00:00:00:00:00:00:00:02", "flow": flow}
        event_app = KytosEvent(name, content)
        for i in range(n):
            self.controller.buffers.app.put(event_app)
        log.info("DONE WITH THE EVENTS")

    def test_me(self, n):
        t = []
        for i in range(n):
            th = threading.Thread(target=self.sending, args=())
            t.append(th)
        for i in t:
            i.start()
        for i in t:
            i.join()
```

This can be run on Kytos console as `controller.napps[('kytos', 'flow_manager')].test_me(9)`.

#### More direct method
Add a sleep for an new event inside `Controller.event_handler()`:
```
    async def event_handler(self, buffer_name: str):
        """Default event handler that gets from an event buffer."""
        event_buffer = getattr(self.buffers, buffer_name)
        self.log.info(f"Event handler {buffer_name} started")
        while True:
            try:
                
                event = await event_buffer.aget()
                if event.name == "kytos/testing":
                    time.sleep(10) # <---- Sleep
                await self.loop.create_task(self.notify_listeners(event))

                if event.name == "kytos/core.shutdown":
                    self.log.debug(f"Event handler {buffer_name} stopped")
                    break
            except Exception as exc:
                self.log.exception(f"Unhandled exception on {buffer_name}",
                                   exc_info=exc)
```
In Kytos console copy the following:
```
from kytos.core.events import KytosEvent
controller.buffers.app.put(KytosEvent(name="kytos/testing"))
```

### End-to-End Tests
N/A
