### PR TITLE
Logging/fixes tweaks

### DIFF
--- a/kytos/core/helpers.py
+++ b/kytos/core/helpers.py
@@ -141,7 +141,7 @@ def listen_to(event, *events, pool=None):
                 result = handler(*args)
             except Exception:
                 result = None
-                traceback_str = traceback.format_exc().replace("\n", ", ")
+                traceback_str = traceback.format_exc()
                 LOG.error(f"listen_to handler: {handler}, "
                           f"args: {args} traceback: {traceback_str}")
                 if hasattr(cls, "controller"):
@@ -162,7 +162,7 @@ def listen_to(event, *events, pool=None):
                 tx.result = result
             except Exception as exc:
                 result = None
-                traceback_str = traceback.format_exc().replace("\n", ", ")
+                traceback_str = traceback.format_exc()
                 LOG.error(f"listen_to handler: {handler}, "
                           f"args: {args} traceback: {traceback_str}")
                 if hasattr(cls, "controller"):
@@ -231,7 +231,7 @@ def alisten_to(event, *events):
                 result = await handler(*args)
             except Exception:
                 result = None
-                traceback_str = traceback.format_exc().replace("\n", ", ")
+                traceback_str = traceback.format_exc()
                 LOG.error(f"alisten_to handler: {handler}, "
                           f"args: {args} traceback: {traceback_str}")
                 if hasattr(cls, "controller"):
@@ -252,7 +252,7 @@ def alisten_to(event, *events):
                 tx.result = result
             except Exception as exc:
                 result = None
-                traceback_str = traceback.format_exc().replace("\n", ", ")
+                traceback_str = traceback.format_exc()
                 LOG.error(f"alisten_to handler: {handler}, "
                           f"args: {args} traceback: {traceback_str}")
                 if hasattr(cls, "controller"):

--- a/kytos/core/retry.py
+++ b/kytos/core/retry.py
@@ -12,6 +12,10 @@ def before_sleep(state) -> None:
     """Before sleep function for tenacity to also logs args and kwargs."""
     LOG.warning(
         f"Retry #{state.attempt_number} for {state.fn.__name__}, "
+        f"seconds since start: {state.seconds_since_start:.2f}",
+    )
+    LOG.debug(
+        f"Retry #{state.attempt_number} for {state.fn.__name__}, "
         f"args: {state.args}, kwargs: {state.kwargs}, "
         f"seconds since start: {state.seconds_since_start:.2f}",
     )

--- a/kytos/templates/logging.ini.template
+++ b/kytos/templates/logging.ini.template
@@ -8,7 +8,7 @@ keys: console,syslog,file
 keys: root,kytos,api_server,socket
 
 [formatter_syslog]
-format: %(name)s:%(levelname)s %(module)s:%(lineno)d:  %(message)s
+format: %(name)s:%(levelname)s %(module)s:%(lineno)d:  %(message).16000s
 
 [formatter_console]
 format: %(asctime)s - %(levelname)s [%(name)s] (%(threadName)s) %(message)s


### PR DESCRIPTION
Closes #543

### Summary

Some basic tweaks to logging.

 - Set max message size limit on default syslog handler to 16000 characters. Messages longer than that will be truncated.
 - Made it so logged tracebacks will use newline `\n`, instead of replacing it with `, `.
 - Moved problematic log statement log to `DEBUG`, and replaced with a far shorter version at `WARNING`

### Local Tests

Logs work as expected, the `16000` character message limit does indeed stop messages from causing a crash when logging to the syslog. On my system the max unix socket message size is `212992`, and could accommodate significantly larger messages than `16000`. This number can be adjusted, if desired.

### End-to-End Tests

Not relevant to E2E