### PR TITLE
 Adjusted default tag ranges

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Added
 - Added option for links to get last TAG from ``interface.available_tags``.
 - Added option for links to try to avoid a TAG value from ``interface.available_tags``.
 
+Changed
+=======
+- Changed the default vlan tag range from [[1,4095]] to [[1, 4094]]
+
 Fixed
 =====
 - Execute routines like consistency checks will not trigger one more time after kytos shuts down.

--- a/kytos/core/interface.py
+++ b/kytos/core/interface.py
@@ -230,8 +230,8 @@ class Interface(GenericEntity):  # pylint: disable=too-many-instance-attributes
         """Return a default list of ranges. Applicable to
         available_tags and tag_ranges."""
         default_values = {
-            "vlan": [[1, 4095]],
-            "vlan_qinq": [[1, 4095]],
+            "vlan": [[1, 4094]],
+            "vlan_qinq": [[1, 4094]],
             "mpls": [[1, 1048575]],
         }
         return default_values

--- a/tests/unit/test_core/test_interface.py
+++ b/tests/unit/test_core/test_interface.py
@@ -154,8 +154,8 @@ class TestInterface():
 
     async def test_interface_available_tags_tag_ranges(self):
         """Test available_tags and tag_ranges on Interface class."""
-        default_available = {'vlan': [[1, 4095]]}
-        default_tag_ranges = {'vlan': [[1, 4095]]}
+        default_available = {'vlan': [[1, 4094]]}
+        default_tag_ranges = {'vlan': [[1, 4094]]}
         default_special_vlans = {'vlan': ["untagged", "any"]}
         default_special_tags = {'vlan': ["untagged", "any"]}
         assert self.iface.available_tags == default_available
@@ -163,8 +163,8 @@ class TestInterface():
         assert self.iface.special_available_tags == default_special_vlans
         assert self.iface.special_tags == default_special_tags
 
-        custom_available = {'vlan': [[10, 200], [210, 4095]]}
-        custom_tag_ranges = {'vlan': [[1, 100], [200, 4095]]}
+        custom_available = {'vlan': [[10, 200], [210, 4094]]}
+        custom_tag_ranges = {'vlan': [[1, 100], [200, 4094]]}
         custom_special_vlans = {'vlan': ["any"]}
         custom_special_tags = {'vlan': ["any"]}
         self.iface.set_available_tags_tag_ranges(
@@ -178,7 +178,7 @@ class TestInterface():
 
     async def test_interface_is_tag_available(self):
         """Test is_tag_available on Interface class."""
-        max_range = 4096
+        max_range = 4095
         for tag in range(1, max_range):
             next_tag = self.iface.is_tag_available(tag)
             assert next_tag
@@ -325,8 +325,8 @@ class TestInterface():
     async def test_default_tag_values(self) -> None:
         """Test default_tag_values property"""
         expected = {
-            "vlan": [[1, 4095]],
-            "vlan_qinq": [[1, 4095]],
+            "vlan": [[1, 4094]],
+            "vlan_qinq": [[1, 4094]],
             "mpls": [[1, 1048575]],
         }
         assert self.iface.default_tag_values == expected
@@ -394,7 +394,7 @@ class TestInterface():
             self.iface.remove_tag_ranges('vlan_qinq')
 
         self.iface.remove_tag_ranges('vlan')
-        default = [[1, 4095]]
+        default = [[1, 4094]]
         assert self.iface.tag_ranges['vlan'] == default
 
     def test_set_special_tags(self) -> None:

--- a/tests/unit/test_core/test_link.py
+++ b/tests/unit/test_core/test_link.py
@@ -217,8 +217,8 @@ class TestLink():
         link = Link(self.iface1, self.iface2)
         tag = link.get_next_available_tag(controller, "link_id", True)
         next_tag = link.get_next_available_tag(controller, "link_id", True)
-        assert tag == 4095
-        assert next_tag == 4094
+        assert tag == 4094
+        assert next_tag == 4093
 
     def test_get_next_available_tag_avoid_tag(self, controller):
         """Test get next available tag avoiding a tag"""


### PR DESCRIPTION
Closes #550 

### Summary

Added configurable parameter ``default_tag_ranges``, for configuring the default tag ranges. In addition, adjusted the default range for vlans from [1, 4095] to [1, 4094].

### Local Tests

Ran locally, available tags and tag ranges are appropriately set.

### End-to-End Tests

Ran the E2E tests and here are the results:

```
kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-1  | Starting ovsdb-server.
kytos-1  | rsyslogd: error during config processing: omfile: chown for file '/var/log/syslog' failed: Operation not permitted [v8.2302.0 try https://www.rsyslog.com/e/2207 ]
kytos-1  | Configuring Open vSwitch system IDs.
kytos-1  | Starting ovs-vswitchd.
kytos-1  | Enabling remote OVSDB managers.
kytos-1  | + '[' -z '' ']'
kytos-1  | + '[' -z '' ']'
kytos-1  | There is no NAPPS_PATH specified. Default will be used.
kytos-1  | + echo 'There is no NAPPS_PATH specified. Default will be used.'
kytos-1  | + NAPPS_PATH=
kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + kytosd --help
kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-1  | + test -z ''
kytos-1  | + TESTS=tests/
kytos-1  | + test -z ''
kytos-1  | + RERUNS=2
kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-1  | Trying to run hello command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-1  | + python3 -m pytest tests/ --reruns 2 -r fEr
kytos-1  | ============================= test session starts ==============================
kytos-1  | platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
kytos-1  | rootdir: /tests
kytos-1  | plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
kytos-1  | collected 282 items
kytos-1  | 
kytos-1  | tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
kytos-1  | tests/test_e2e_05_topology.py ..................                         [  7%]
kytos-1  | tests/test_e2e_06_topology.py ....                                       [  8%]
kytos-1  | tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 23%]
kytos-1  | .                                                                        [ 23%]
kytos-1  | tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
kytos-1  | tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
kytos-1  | tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 42%]
kytos-1  | .                                                                        [ 43%]
kytos-1  | tests/test_e2e_14_mef_eline.py x....                                     [ 45%]
kytos-1  | tests/test_e2e_15_mef_eline.py ..RRFRRFRRFRRF                            [ 47%]
kytos-1  | tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
kytos-1  | tests/test_e2e_17_mef_eline.py ....                                      [ 49%]
kytos-1  | tests/test_e2e_20_flow_manager.py ..........................             [ 58%]
kytos-1  | tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
kytos-1  | tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
kytos-1  | tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
kytos-1  | tests/test_e2e_30_of_lldp.py ....                                        [ 71%]
kytos-1  | tests/test_e2e_31_of_lldp.py ...                                         [ 72%]
kytos-1  | tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
kytos-1  | tests/test_e2e_40_sdntrace.py ................                           [ 79%]
kytos-1  | tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
kytos-1  | tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
kytos-1  | tests/test_e2e_50_maintenance.py ............................            [ 92%]
kytos-1  | tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
kytos-1  | tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
kytos-1  | tests/test_e2e_80_pathfinder.py ss......                                 [100%]
kytos-1  | 
kytos-1  | =================================== FAILURES ===================================
kytos-1  | _________________ TestE2EMefEline.test_003_evc_vlan_allocation _________________
kytos-1  | 
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c95d0>
kytos-1  | 
kytos-1  |     def test_003_evc_vlan_allocation(self):
kytos-1  |         """Test patch an evc with a duplicated tag value"""
kytos-1  |         evc_1 = {
kytos-1  |             "name": "EVC_1",
kytos-1  |             "enabled": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 100},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 100},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:2",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=evc_1)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         assert 'circuit_id' in response.json()
kytos-1  |     
kytos-1  |         # Verify if EVC tag has been allocated
kytos-1  |         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
kytos-1  |         response = requests.get(topo_url)
kytos-1  |         data = response.json()
kytos-1  |         actual = data["00:00:00:00:00:00:00:02:1"]["available_tags"]["vlan"]
kytos-1  |         actual_tr = data["00:00:00:00:00:00:00:02:1"]["tag_ranges"]["vlan"]
kytos-1  |         expected = [[1, 99], [101, 3798], [3800, 4095]]
kytos-1  |         expected_tr = [[1, 4095]]
kytos-1  | >       assert actual == expected
kytos-1  | E       assert [[1, 99], [10... [3800, 4094]] == [[1, 99], [10... [3800, 4095]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4094] != [3800, 4095]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:253: AssertionError
kytos-1  | ___________________ TestE2EMefEline.test_004_tag_restriction ___________________
kytos-1  | 
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c99d0>
kytos-1  | 
kytos-1  |     def test_004_tag_restriction(self):
kytos-1  |         """Test restrict tag range"""
kytos-1  |         payload = {
kytos-1  |             "name": "evc_1",
kytos-1  |             "enabled": True,
kytos-1  |             "dynamic_backup_path": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 200},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 200},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:2",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |     
kytos-1  |         intf_id = '00:00:00:00:00:00:00:01:1'
kytos-1  |         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         expected = [[1, 199], [201, 3798], [3800, 4095]]
kytos-1  | >       assert expected == data[intf_id]["available_tags"]["vlan"]
kytos-1  | E       assert [[1, 199], [2... [3800, 4095]] == [[1, 199], [2... [3800, 4094]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4095] != [3800, 4094]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:356: AssertionError
kytos-1  | ___________________ TestE2EMefEline.test_005_evc_vlan_range ____________________
kytos-1  | 
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c9d90>
kytos-1  | 
kytos-1  |     def test_005_evc_vlan_range(self):
kytos-1  |         """Create a circuit with a valn as range"""
kytos-1  |         payload = {
kytos-1  |             "name": "evc_1",
kytos-1  |             "enabled": True,
kytos-1  |             "dynamic_backup_path": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": [[10, 15]]},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": [[10, 15]]},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:1",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         circuit_id = response.json()["circuit_id"]
kytos-1  |     
kytos-1  |         expected = [[1, 9], [16, 3798], [3800, 4095]]
kytos-1  |         intf_id = '00:00:00:00:00:00:00:01:1'
kytos-1  |         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  | >       assert expected == data[intf_id]["available_tags"]["vlan"]
kytos-1  | E       assert [[1, 9], [16,... [3800, 4095]] == [[1, 9], [16,... [3800, 4094]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4095] != [3800, 4094]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:455: AssertionError
kytos-1  | ---------------------------- Captured stdout setup -----------------------------
kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-1  | ---------------------------- Captured stdout setup -----------------------------
kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-1  | __________ TestE2EMefEline.test_006_evc_vlan_allocation_not_available __________
kytos-1  | 
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1ca150>
kytos-1  | 
kytos-1  |     def test_006_evc_vlan_allocation_not_available(self):
kytos-1  |         """Test trying to allocate an EVC over a link that doesn't have available vlans"""
kytos-1  |     
kytos-1  |         # only of_lldp to simulate no tags available
kytos-1  |         payload = {
kytos-1  |             "tag_type": "vlan",
kytos-1  |             "tag_ranges": [[3799, 3799]]
kytos-1  |         }
kytos-1  |         for intf_id in (
kytos-1  |             "00:00:00:00:00:00:00:03:2",
kytos-1  |             "00:00:00:00:00:00:00:03:3"
kytos-1  |         ):
kytos-1  |             api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |             response = requests.post(api_url, json=payload)
kytos-1  |             assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         evc_1 = {
kytos-1  |             "name": "epl_static",
kytos-1  |             "dynamic_backup_path": False,
kytos-1  |             "uni_a": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1"
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:03:1"
kytos-1  |             },
kytos-1  |             "primary_path": [
kytos-1  |                 {
kytos-1  |                     "endpoint_a": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:01:3"
kytos-1  |                     },
kytos-1  |                     "endpoint_b": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:02:2"
kytos-1  |                     }
kytos-1  |                 },
kytos-1  |                 {
kytos-1  |                     "endpoint_a": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:02:3"
kytos-1  |                     },
kytos-1  |                     "endpoint_b": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:03:2"
kytos-1  |                     }
kytos-1  |                 }
kytos-1  |             ]
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=evc_1)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         data = response.json()
kytos-1  |         assert 'circuit_id' in data
kytos-1  |         assert not data['deployed']
kytos-1  |     
kytos-1  |         # Verify that tags haven't been allocated
kytos-1  |         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
kytos-1  |         response = requests.get(topo_url)
kytos-1  |         data = response.json()
kytos-1  |         expected = [[1, 3798], [3800, 4095]]
kytos-1  |         for intf_id in (
kytos-1  |             "00:00:00:00:00:00:00:01:1",
kytos-1  |             "00:00:00:00:00:00:00:01:3",
kytos-1  |             "00:00:00:00:00:00:00:02:2",
kytos-1  |             "00:00:00:00:00:00:00:03:1",
kytos-1  |         ):
kytos-1  |             actual = data[intf_id]["available_tags"]["vlan"]
kytos-1  |             actual_tr = data[intf_id]["tag_ranges"]["vlan"]
kytos-1  | >           assert actual == expected, actual
kytos-1  | E           AssertionError: [[1, 3798], [3800, 4094]]
kytos-1  | E           assert [[1, 3798], [3800, 4094]] == [[1, 3798], [3800, 4095]]
kytos-1  | E             
kytos-1  | E             At index 1 diff: [3800, 4094] != [3800, 4095]
kytos-1  | E             Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:611: AssertionError
kytos-1  | ---------------------------- Captured stdout setup -----------------------------
kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-1  | =============================== warnings summary ===============================
kytos-1  | usr/local/lib/python3.11/dist-packages/kytos/core/config.py:259
kytos-1  |   /usr/local/lib/python3.11/dist-packages/kytos/core/config.py:259: UserWarning: Unknown arguments: ['tests/', '--reruns', '2', '-r', 'fEr']
kytos-1  |     warnings.warn(f"Unknown arguments: {unknown}")
kytos-1  | 
kytos-1  | test_e2e_01_kytos_startup.py: 17 warnings
kytos-1  | test_e2e_05_topology.py: 17 warnings
kytos-1  | test_e2e_06_topology.py: 76 warnings
kytos-1  | test_e2e_10_mef_eline.py: 17 warnings
kytos-1  | test_e2e_11_mef_eline.py: 25 warnings
kytos-1  | test_e2e_12_mef_eline.py: 17 warnings
kytos-1  | test_e2e_13_mef_eline.py: 17 warnings
kytos-1  | test_e2e_14_mef_eline.py: 76 warnings
kytos-1  | test_e2e_15_mef_eline.py: 17 warnings
kytos-1  | test_e2e_16_mef_eline.py: 17 warnings
kytos-1  | test_e2e_17_mef_eline.py: 37 warnings
kytos-1  | test_e2e_20_flow_manager.py: 17 warnings
kytos-1  | test_e2e_21_flow_manager.py: 17 warnings
kytos-1  | test_e2e_22_flow_manager.py: 17 warnings
kytos-1  | test_e2e_23_flow_manager.py: 17 warnings
kytos-1  | test_e2e_30_of_lldp.py: 17 warnings
kytos-1  | test_e2e_31_of_lldp.py: 17 warnings
kytos-1  | test_e2e_32_of_lldp.py: 11 warnings
kytos-1  | test_e2e_40_sdntrace.py: 49 warnings
kytos-1  | test_e2e_41_kytos_auth.py: 17 warnings
kytos-1  | test_e2e_42_sdntrace.py: 84 warnings
kytos-1  | test_e2e_50_maintenance.py: 17 warnings
kytos-1  | test_e2e_60_of_multi_table.py: 17 warnings
kytos-1  | test_e2e_70_kytos_stats.py: 17 warnings
kytos-1  | test_e2e_80_pathfinder.py: 37 warnings
kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-1  |     return ( StrictVersion( cls.OVSVersion ) <
kytos-1  | 
kytos-1  | test_e2e_01_kytos_startup.py: 17 warnings
kytos-1  | test_e2e_05_topology.py: 17 warnings
kytos-1  | test_e2e_06_topology.py: 76 warnings
kytos-1  | test_e2e_10_mef_eline.py: 17 warnings
kytos-1  | test_e2e_11_mef_eline.py: 25 warnings
kytos-1  | test_e2e_12_mef_eline.py: 17 warnings
kytos-1  | test_e2e_13_mef_eline.py: 17 warnings
kytos-1  | test_e2e_14_mef_eline.py: 76 warnings
kytos-1  | test_e2e_15_mef_eline.py: 17 warnings
kytos-1  | test_e2e_16_mef_eline.py: 17 warnings
kytos-1  | test_e2e_17_mef_eline.py: 37 warnings
kytos-1  | test_e2e_20_flow_manager.py: 17 warnings
kytos-1  | test_e2e_21_flow_manager.py: 17 warnings
kytos-1  | test_e2e_22_flow_manager.py: 17 warnings
kytos-1  | test_e2e_23_flow_manager.py: 17 warnings
kytos-1  | test_e2e_30_of_lldp.py: 17 warnings
kytos-1  | test_e2e_31_of_lldp.py: 17 warnings
kytos-1  | test_e2e_32_of_lldp.py: 11 warnings
kytos-1  | test_e2e_40_sdntrace.py: 49 warnings
kytos-1  | test_e2e_41_kytos_auth.py: 17 warnings
kytos-1  | test_e2e_42_sdntrace.py: 84 warnings
kytos-1  | test_e2e_50_maintenance.py: 17 warnings
kytos-1  | test_e2e_60_of_multi_table.py: 17 warnings
kytos-1  | test_e2e_70_kytos_stats.py: 17 warnings
kytos-1  | test_e2e_80_pathfinder.py: 37 warnings
kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-1  |     StrictVersion( '1.10' ) )
kytos-1  | 
kytos-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
kytos-1  | ------------------------------- start/stop times -------------------------------
kytos-1  | rerun: 0
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_003_evc_vlan_allocation: 2025-03-19,23:53:05.571473 - 2025-03-19,23:53:05.666147
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c95d0>
kytos-1  | 
kytos-1  |     def test_003_evc_vlan_allocation(self):
kytos-1  |         """Test patch an evc with a duplicated tag value"""
kytos-1  |         evc_1 = {
kytos-1  |             "name": "EVC_1",
kytos-1  |             "enabled": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 100},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 100},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:2",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=evc_1)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         assert 'circuit_id' in response.json()
kytos-1  |     
kytos-1  |         # Verify if EVC tag has been allocated
kytos-1  |         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
kytos-1  |         response = requests.get(topo_url)
kytos-1  |         data = response.json()
kytos-1  |         actual = data["00:00:00:00:00:00:00:02:1"]["available_tags"]["vlan"]
kytos-1  |         actual_tr = data["00:00:00:00:00:00:00:02:1"]["tag_ranges"]["vlan"]
kytos-1  |         expected = [[1, 99], [101, 3798], [3800, 4095]]
kytos-1  |         expected_tr = [[1, 4095]]
kytos-1  | >       assert actual == expected
kytos-1  | E       assert [[1, 99], [10... [3800, 4094]] == [[1, 99], [10... [3800, 4095]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4094] != [3800, 4095]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:253: AssertionError
kytos-1  | rerun: 1
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_003_evc_vlan_allocation: 2025-03-19,23:53:35.764090 - 2025-03-19,23:53:35.860644
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c95d0>
kytos-1  | 
kytos-1  |     def test_003_evc_vlan_allocation(self):
kytos-1  |         """Test patch an evc with a duplicated tag value"""
kytos-1  |         evc_1 = {
kytos-1  |             "name": "EVC_1",
kytos-1  |             "enabled": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 100},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 100},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:2",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=evc_1)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         assert 'circuit_id' in response.json()
kytos-1  |     
kytos-1  |         # Verify if EVC tag has been allocated
kytos-1  |         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
kytos-1  |         response = requests.get(topo_url)
kytos-1  |         data = response.json()
kytos-1  |         actual = data["00:00:00:00:00:00:00:02:1"]["available_tags"]["vlan"]
kytos-1  |         actual_tr = data["00:00:00:00:00:00:00:02:1"]["tag_ranges"]["vlan"]
kytos-1  |         expected = [[1, 99], [101, 3798], [3800, 4095]]
kytos-1  |         expected_tr = [[1, 4095]]
kytos-1  | >       assert actual == expected
kytos-1  | E       assert [[1, 99], [10... [3800, 4094]] == [[1, 99], [10... [3800, 4095]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4094] != [3800, 4095]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:253: AssertionError
kytos-1  | rerun: 0
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_004_tag_restriction: 2025-03-19,23:54:26.109093 - 2025-03-19,23:54:26.210787
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c99d0>
kytos-1  | 
kytos-1  |     def test_004_tag_restriction(self):
kytos-1  |         """Test restrict tag range"""
kytos-1  |         payload = {
kytos-1  |             "name": "evc_1",
kytos-1  |             "enabled": True,
kytos-1  |             "dynamic_backup_path": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 200},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 200},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:2",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |     
kytos-1  |         intf_id = '00:00:00:00:00:00:00:01:1'
kytos-1  |         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         expected = [[1, 199], [201, 3798], [3800, 4095]]
kytos-1  | >       assert expected == data[intf_id]["available_tags"]["vlan"]
kytos-1  | E       assert [[1, 199], [2... [3800, 4095]] == [[1, 199], [2... [3800, 4094]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4095] != [3800, 4094]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:356: AssertionError
kytos-1  | rerun: 1
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_004_tag_restriction: 2025-03-19,23:54:46.226786 - 2025-03-19,23:54:46.328851
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c99d0>
kytos-1  | 
kytos-1  |     def test_004_tag_restriction(self):
kytos-1  |         """Test restrict tag range"""
kytos-1  |         payload = {
kytos-1  |             "name": "evc_1",
kytos-1  |             "enabled": True,
kytos-1  |             "dynamic_backup_path": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 200},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": 200},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:2",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |     
kytos-1  |         intf_id = '00:00:00:00:00:00:00:01:1'
kytos-1  |         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         expected = [[1, 199], [201, 3798], [3800, 4095]]
kytos-1  | >       assert expected == data[intf_id]["available_tags"]["vlan"]
kytos-1  | E       assert [[1, 199], [2... [3800, 4095]] == [[1, 199], [2... [3800, 4094]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4095] != [3800, 4094]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:356: AssertionError
kytos-1  | rerun: 0
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_005_evc_vlan_range: 2025-03-19,23:55:35.555920 - 2025-03-19,23:55:35.658294
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c9d90>
kytos-1  | 
kytos-1  |     def test_005_evc_vlan_range(self):
kytos-1  |         """Create a circuit with a valn as range"""
kytos-1  |         payload = {
kytos-1  |             "name": "evc_1",
kytos-1  |             "enabled": True,
kytos-1  |             "dynamic_backup_path": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": [[10, 15]]},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": [[10, 15]]},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:1",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         circuit_id = response.json()["circuit_id"]
kytos-1  |     
kytos-1  |         expected = [[1, 9], [16, 3798], [3800, 4095]]
kytos-1  |         intf_id = '00:00:00:00:00:00:00:01:1'
kytos-1  |         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  | >       assert expected == data[intf_id]["available_tags"]["vlan"]
kytos-1  | E       assert [[1, 9], [16,... [3800, 4095]] == [[1, 9], [16,... [3800, 4094]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4095] != [3800, 4094]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:455: AssertionError
kytos-1  | rerun: 1
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_005_evc_vlan_range: 2025-03-19,23:55:53.783832 - 2025-03-19,23:55:53.879397
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1c9d90>
kytos-1  | 
kytos-1  |     def test_005_evc_vlan_range(self):
kytos-1  |         """Create a circuit with a valn as range"""
kytos-1  |         payload = {
kytos-1  |             "name": "evc_1",
kytos-1  |             "enabled": True,
kytos-1  |             "dynamic_backup_path": True,
kytos-1  |             "uni_a": {
kytos-1  |                 "tag": {"tag_type": 1, "value": [[10, 15]]},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1",
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "tag": {"tag_type": 1, "value": [[10, 15]]},
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:1",
kytos-1  |             }
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         circuit_id = response.json()["circuit_id"]
kytos-1  |     
kytos-1  |         expected = [[1, 9], [16, 3798], [3800, 4095]]
kytos-1  |         intf_id = '00:00:00:00:00:00:00:01:1'
kytos-1  |         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  | >       assert expected == data[intf_id]["available_tags"]["vlan"]
kytos-1  | E       assert [[1, 9], [16,... [3800, 4095]] == [[1, 9], [16,... [3800, 4094]]
kytos-1  | E         
kytos-1  | E         At index 2 diff: [3800, 4095] != [3800, 4094]
kytos-1  | E         Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:455: AssertionError
kytos-1  | rerun: 0
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_006_evc_vlan_allocation_not_available: 2025-03-19,23:56:34.039417 - 2025-03-19,23:56:34.079514
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1ca150>
kytos-1  | 
kytos-1  |     def test_006_evc_vlan_allocation_not_available(self):
kytos-1  |         """Test trying to allocate an EVC over a link that doesn't have available vlans"""
kytos-1  |     
kytos-1  |         # only of_lldp to simulate no tags available
kytos-1  |         payload = {
kytos-1  |             "tag_type": "vlan",
kytos-1  |             "tag_ranges": [[3799, 3799]]
kytos-1  |         }
kytos-1  |         for intf_id in (
kytos-1  |             "00:00:00:00:00:00:00:03:2",
kytos-1  |             "00:00:00:00:00:00:00:03:3"
kytos-1  |         ):
kytos-1  |             api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |             response = requests.post(api_url, json=payload)
kytos-1  |             assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         evc_1 = {
kytos-1  |             "name": "epl_static",
kytos-1  |             "dynamic_backup_path": False,
kytos-1  |             "uni_a": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1"
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:03:1"
kytos-1  |             },
kytos-1  |             "primary_path": [
kytos-1  |                 {
kytos-1  |                     "endpoint_a": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:01:3"
kytos-1  |                     },
kytos-1  |                     "endpoint_b": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:02:2"
kytos-1  |                     }
kytos-1  |                 },
kytos-1  |                 {
kytos-1  |                     "endpoint_a": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:02:3"
kytos-1  |                     },
kytos-1  |                     "endpoint_b": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:03:2"
kytos-1  |                     }
kytos-1  |                 }
kytos-1  |             ]
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=evc_1)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         data = response.json()
kytos-1  |         assert 'circuit_id' in data
kytos-1  |         assert not data['deployed']
kytos-1  |     
kytos-1  |         # Verify that tags haven't been allocated
kytos-1  |         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
kytos-1  |         response = requests.get(topo_url)
kytos-1  |         data = response.json()
kytos-1  |         expected = [[1, 3798], [3800, 4095]]
kytos-1  |         for intf_id in (
kytos-1  |             "00:00:00:00:00:00:00:01:1",
kytos-1  |             "00:00:00:00:00:00:00:01:3",
kytos-1  |             "00:00:00:00:00:00:00:02:2",
kytos-1  |             "00:00:00:00:00:00:00:03:1",
kytos-1  |         ):
kytos-1  |             actual = data[intf_id]["available_tags"]["vlan"]
kytos-1  |             actual_tr = data[intf_id]["tag_ranges"]["vlan"]
kytos-1  | >           assert actual == expected, actual
kytos-1  | E           AssertionError: [[1, 3798], [3800, 4094]]
kytos-1  | E           assert [[1, 3798], [3800, 4094]] == [[1, 3798], [3800, 4095]]
kytos-1  | E             
kytos-1  | E             At index 1 diff: [3800, 4094] != [3800, 4095]
kytos-1  | E             Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:611: AssertionError
kytos-1  | rerun: 1
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_006_evc_vlan_allocation_not_available: 2025-03-19,23:57:01.147582 - 2025-03-19,23:57:01.188913
kytos-1  | self = <tests.test_e2e_15_mef_eline.TestE2EMefEline object at 0x78c7de1ca150>
kytos-1  | 
kytos-1  |     def test_006_evc_vlan_allocation_not_available(self):
kytos-1  |         """Test trying to allocate an EVC over a link that doesn't have available vlans"""
kytos-1  |     
kytos-1  |         # only of_lldp to simulate no tags available
kytos-1  |         payload = {
kytos-1  |             "tag_type": "vlan",
kytos-1  |             "tag_ranges": [[3799, 3799]]
kytos-1  |         }
kytos-1  |         for intf_id in (
kytos-1  |             "00:00:00:00:00:00:00:03:2",
kytos-1  |             "00:00:00:00:00:00:00:03:3"
kytos-1  |         ):
kytos-1  |             api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
kytos-1  |             response = requests.post(api_url, json=payload)
kytos-1  |             assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         evc_1 = {
kytos-1  |             "name": "epl_static",
kytos-1  |             "dynamic_backup_path": False,
kytos-1  |             "uni_a": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1"
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:03:1"
kytos-1  |             },
kytos-1  |             "primary_path": [
kytos-1  |                 {
kytos-1  |                     "endpoint_a": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:01:3"
kytos-1  |                     },
kytos-1  |                     "endpoint_b": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:02:2"
kytos-1  |                     }
kytos-1  |                 },
kytos-1  |                 {
kytos-1  |                     "endpoint_a": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:02:3"
kytos-1  |                     },
kytos-1  |                     "endpoint_b": {
kytos-1  |                         "id": "00:00:00:00:00:00:00:03:2"
kytos-1  |                     }
kytos-1  |                 }
kytos-1  |             ]
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + '/mef_eline/v2/evc/'
kytos-1  |         response = requests.post(api_url, json=evc_1)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         data = response.json()
kytos-1  |         assert 'circuit_id' in data
kytos-1  |         assert not data['deployed']
kytos-1  |     
kytos-1  |         # Verify that tags haven't been allocated
kytos-1  |         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
kytos-1  |         response = requests.get(topo_url)
kytos-1  |         data = response.json()
kytos-1  |         expected = [[1, 3798], [3800, 4095]]
kytos-1  |         for intf_id in (
kytos-1  |             "00:00:00:00:00:00:00:01:1",
kytos-1  |             "00:00:00:00:00:00:00:01:3",
kytos-1  |             "00:00:00:00:00:00:00:02:2",
kytos-1  |             "00:00:00:00:00:00:00:03:1",
kytos-1  |         ):
kytos-1  |             actual = data[intf_id]["available_tags"]["vlan"]
kytos-1  |             actual_tr = data[intf_id]["tag_ranges"]["vlan"]
kytos-1  | >           assert actual == expected, actual
kytos-1  | E           AssertionError: [[1, 3798], [3800, 4094]]
kytos-1  | E           assert [[1, 3798], [3800, 4094]] == [[1, 3798], [3800, 4095]]
kytos-1  | E             
kytos-1  | E             At index 1 diff: [3800, 4094] != [3800, 4095]
kytos-1  | E             Use -v to get more diff
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py:611: AssertionError
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_003_evc_vlan_allocation: 2025-03-19,23:53:55.879935 - 2025-03-19,23:53:55.979061
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_004_tag_restriction: 2025-03-19,23:55:16.415865 - 2025-03-19,23:55:16.518246
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_005_evc_vlan_range: 2025-03-19,23:56:15.916766 - 2025-03-19,23:56:16.017128
kytos-1  | test_e2e_15_mef_eline.py::TestE2EMefEline::test_006_evc_vlan_allocation_not_available: 2025-03-19,23:57:31.279390 - 2025-03-19,23:57:31.325953
kytos-1  | =========================== rerun test summary info ============================
kytos-1  | RERUN test_e2e_15_mef_eline.py::TestE2EMefEline::test_003_evc_vlan_allocation
kytos-1  | RERUN test_e2e_15_mef_eline.py::TestE2EMefEline::test_003_evc_vlan_allocation
kytos-1  | RERUN test_e2e_15_mef_eline.py::TestE2EMefEline::test_004_tag_restriction
kytos-1  | RERUN test_e2e_15_mef_eline.py::TestE2EMefEline::test_004_tag_restriction
kytos-1  | RERUN test_e2e_15_mef_eline.py::TestE2EMefEline::test_005_evc_vlan_range
kytos-1  | RERUN test_e2e_15_mef_eline.py::TestE2EMefEline::test_005_evc_vlan_range
kytos-1  | RERUN test_e2e_15_mef_eline.py::TestE2EMefEline::test_006_evc_vlan_allocation_not_available
kytos-1  | RERUN test_e2e_15_mef_eline.py::TestE2EMefEline::test_006_evc_vlan_allocation_not_available
kytos-1  | =========================== short test summary info ============================
kytos-1  | FAILED tests/test_e2e_15_mef_eline.py::TestE2EMefEline::test_003_evc_vlan_allocation
kytos-1  | FAILED tests/test_e2e_15_mef_eline.py::TestE2EMefEline::test_004_tag_restriction
kytos-1  | FAILED tests/test_e2e_15_mef_eline.py::TestE2EMefEline::test_005_evc_vlan_range
kytos-1  | FAILED tests/test_e2e_15_mef_eline.py::TestE2EMefEline::test_006_evc_vlan_allocation_not_available
kytos-1  | = 4 failed, 255 passed, 8 skipped, 8 xfailed, 7 xpassed, 1369 warnings, 8 rerun in 11958.59s (3:19:18) =

[Kkytos-1 exited with code 1

```
It seems that there are some tests which use the previous default vlan range, which need to be adjusted to the new range, or to compute the expected ranges.