### PR TITLE
EP039 Blueprint proposal for an event publisher NApp

### DIFF
--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -334,9 +334,9 @@ The following benchmarks were the product of sending a request to a REST API end
 
 EPS
 ---
-:Mean 510.3469387755102
-:Median 529.5
-:Standard Deviation 504.16585184252443
+:Mean: 510.3469387755102
+:Median: 529.5
+:Standard Deviation: 504.16585184252443
 
 XI. Open Questions / Future Work
 =================================

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -244,21 +244,16 @@ When ``handle_events()`` sends a Kafka message, the value is typically JSON-enco
 .. code-block:: json
 
     {
-      "event": "kytos/topology.switch.new",
-      "switch_id": "00:00:00:00:00:00:00:01",
-      "timestamp": 1707859200000,
-      "metadata": {
-        "dpid": "1",
-        "ip": "192.168.1.10",
-        "port_count": 48
-      }
+      "name": str,
+      "content": dict,
+      "timestamp": str,
+      "id": str
     }
 
-- **Key:** ``None`` (Kafka handles partitioning).
-- **Value:** JSON message (converted to ``bytes``).
-- **Headers:** May contain custom metadata (e.g., ``("source", "kytos".encode())``).
-- **Timestamp:** Generated automatically or set manually.
-- **Topic:** ``"kytos_events"`` (example).
+- **name** ``str`` The name of the KytosEvent being emitted.
+- **content** ``dict`` The contents of the message, preserved from the original KytosEvent.
+- **timestamp** ``str`` The ISO formatted (like 2025-04-15T20:49:05.196851) timestamp associated to when the KytosEvent was emitted.
+- **id:** ``str`` The UUID identifier (in str format) that the KytosEvent was originally emitted with.
 
 4. AIOKafkaProducer Example
 ----------------------------
@@ -331,11 +326,18 @@ The following requirements clarify certain details and expected behavior for ``k
 X. Benchmarks
 
 The following benchmarks were the product of sending 400 requests (split across 10 threads) to the `mef_eline` endpoint to create `kytos/mef_eline.created` events naturally through `kytos`.
+The following benchmarks were the product of sending a request to a REST API endpoint to create 50_000 `KytosEvents` like the following:
 
-| Implementation | VIRT | RES | Script time | `kafka_events` time |
-|--------|--------|--------|--------|--------|
-| MainThread | 3505340 | 234876 | 743.895 seconds | 775 seconds |
-| Separate Thread | 2887532 | 235164 | 488.687 seconds | 508 seconds |
+.. code-block:: python
+
+    KytosEvent("kytos/sample_ui.do_work", content={"value": "x" * 10_000})
+
+EPS
+---
+
+| Implementation | Mean | Median | Standard Deviation |
+|--------|--------|--------|--------|
+| MainThread | 510.3469387755102 | 529.5 | 504.16585184252443 |
 
 XI. Open Questions / Future Work
 =================================
@@ -352,4 +354,5 @@ XI. Open Questions / Future Work
     - This would allow `AIOKafkaProducer` to be awaited gracefully instead of awaiting within the event listener.
   7. If scalability becomes a concern, we can split topics are continue creating more partitions.
     - How this would work would be to logically split target events into specific topics and to add a key to each exported event so they have their own partition.
-    - For example, if the amount of unique events from `flow_manager` or `mef_eline` become to big to handle on one topic, we can make a separate topic for them and continue adding partitions.
+    - For example, if the amount of unique events from `flow_manager` or `mef_eline` become to big to handle on one topic, we can make a separate topic for them and continue adding partitions.\
+  8. In the case of a `Kafka` outage, memory consumption could spike and cause `Kytos` to freeze if not handled properly.

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -126,8 +126,6 @@ III. How kafka_events interacts with Kafka
 IV. Configurations in settings.py
 ==============================
 
-IV. Configurations in settings.py
-
 1. This section describes the key configuration parameters used by the kafka_events application. These constants define how the application connects to Kafka, manages topics, handles message delivery, and filters events.
 
 - Key Configuration Constants
@@ -173,6 +171,7 @@ IV. Configurations in settings.py
     - Usage: Reduces network load and improves performance by compressing message data.
 
 V. `managers/``
+=============
 
 This folder contains the relevant domain specific classes that manage data accordingly.
 
@@ -191,16 +190,37 @@ VI. Events
     - Events are to be filtered using regular expressions (regex)
       - This allows for flexibility in rejecting some or all of a given producer's events.
     - Some events may not be necessary to downstream consumers, thus ignoring them would reduce Kafka's burden and improve throughput.
+    - Events can be dynamically added/listed/removed at runtime by interacting with the endpoints `/v1/create`, `/v1/list`, and `/v1/delete` respectively.
 
+VII. Endpoints
+==============
 
-VII. Dependencies
+  1. `/v1/create`
+
+  - Allows operators to create new filters to allow different NApps to be serialized.
+  - Requires JSON data to work
+    - Mandatory: "pattern": The regex pattern to be added
+    - Optional: "description": The human readable description for the Filter
+
+  2. `/v1/list`
+
+  - Allows operators to list the currently running filters
+  - Does not require JSON data
+
+  3. `/v1/delete`
+
+  - Allows operators to remove filters from the pipeline, restricting what is allowed.
+  - Requires JSON data to work
+    - Mandatory: "pattern": The regex pattern to be removed
+
+VIII. Dependencies
 =================
 
  * kytos
  * aiokafka - [0.12.0]
 
 
-VIII. Kafka message structure
+IX. Kafka message structure
 ======================
 
 1. Overview
@@ -293,7 +313,7 @@ A consumer reads the message and decodes it:
         print(f"Received: {event}")
 
 
-IX. Implementation details ``v1``
+X. Implementation details ``v1``
 ===================================
 
 The following requirements clarify certain details and expected behavior for ``kafka_events`` v1:

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -3,7 +3,7 @@
 :Authors:
     - Austin Uwate <auwate AT fiu DOT edu>
 :Created: 2025-02-12
-:Status: Draft
+:Status: Accepted
 :Type: Standard
 
 ****************************************

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -345,33 +345,68 @@ The following requirements clarify certain details and expected behavior for ``k
 
 X. Benchmarks
 
-The following benchmarks were the product of sending 400 requests (split across 10 threads) to the `mef_eline` endpoint to create `kytos/mef_eline.created` events naturally through `kytos`.
-The following benchmarks were the product of sending a request to a REST API endpoint to create 50_000 `KytosEvents` like the following:
+The following scenarios were tested in a virtual machine used a Intel(R) Xeon(R) Gold 5420+ to have a minimum baseline for throughput figures, mimicking average and worse case loads.
 
-.. code-block:: python
+  1. Results
 
-    KytosEvent("kytos/sample_ui.do_work", content={"value": "x" * 10_000})
+  Scenario 1: Linearly increasing load of 10,000 messages, where each message is 1000 characters long (~1KB each).
 
-EPS
----
-:Mean: 510.3469387755102
-:Median: 529.5
-:Standard Deviation: 504.16585184252443
+  EPS
+  ---
+  :Mean: 1811.1379310344828
+  :Median: 2217.0
+  :Standard Deviation: 1090.3425505439811
+
+  CPU Usage
+  ---
+  :Mean: 71.06896551724138%
+  :Median: 91.9%
+  :Standard Deviation: 39.322610004303314%
+
+  Memory Usage
+  ---
+  :Mean: 172.5926724137931 MB
+  :Median: 174.55859375 MB
+  :Standard Deviation: 16.31160414466545 MB
+
+  Scenario 2: 500 EVCs converging due to a link down event.
+
+  EPS:
+  ---
+  :Mean: 453.25
+  :Median: 498.0
+  :Standard Deviation: 120.59099261553493
+
+  CPU Usage:
+  ---
+  :Mean: 107.95500000000001%
+  :Median: 108.25 % 
+  :Standard Deviation: 3.128494046662067 % 
+
+  Memory Usage:
+  ---
+  :Mean: 241.7111328125 MB
+  :Median: 241.93359375 MB
+  :Standard Deviation: 2.7810921202007104 MB
+
+  2. Conclusions
+
+  Data drawn from *scenario 1* indicates a strong performance for a moderately heavy load on Kytos with a moderately performant CPU core. A median score of 2217 events per second while not consuming all CPU resources would indicate that the new `kafka_events` would not bottleneck `Kytos` with its addition, albeit with a higher memory utilization due to serialization and network requests. It should also be noted that performance increased as other higher priority `async` in `Kytos` finished, such as the processing `KytosEvents` or processing the requests received at REST API endpoints.
+
+  Looking at *scenario 2*, we see an acceptable performance for a worse-case scenario, where 500 ethernet virtual circuits (EVCs) that all share a common path must perform a topology search for a new path during a link down event. Even with `Kytos` consuming a high ratio resources (including the CPU) as it searches for new paths, `kafka_events` still performs to desired expectations, hitting a ~500 EPS through this event. Similarly to *scenario 1*, the EPS picked up speed after higher-priority processing was finished. 
 
 XI. Open Questions / Future Work
 =================================
 
   1. Error codes
   2. Route messages to their partitions based on key usage
-  3. When filtering events, use Regex patterns instead of Set.
-    - Eliminates redundancy by excluding all events from particular groups, instead of listing each individually.
-  4. Add endpoints that provide clients with useful data
+  3. Add endpoints that provide clients with useful data
     - Currently the endpoints have been removed as there is no use. However, this can change with future work.
-  5. Use a TBD `async shutdown` method instead of the synchronous version
+  4. Use a TBD `async shutdown` method instead of the synchronous version
     - This would allow `AIOKafkaProducer` to be shut down gracefully
-  6. Use a TBD `async setup` method instead of the synchronous version
+  5. Use a TBD `async setup` method instead of the synchronous version
     - This would allow `AIOKafkaProducer` to be awaited gracefully instead of awaiting within the event listener.
-  7. If scalability becomes a concern, we can split topics are continue creating more partitions.
+  6. If scalability becomes a concern, we can split topics are continue creating more partitions.
     - How this would work would be to logically split target events into specific topics and to add a key to each exported event so they have their own partition.
     - For example, if the amount of unique events from `flow_manager` or `mef_eline` become to big to handle on one topic, we can make a separate topic for them and continue adding partitions.\
-  8. In the case of a `Kafka` outage, memory consumption could spike and cause `Kytos` to freeze if not handled properly.
+  7. In the case of a `Kafka` outage, memory consumption could spike and cause `Kytos` to freeze if not handled properly.

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -172,8 +172,17 @@ IV. Configurations in settings.py
     - Example: "gzip"
     - Usage: Reduces network load and improves performance by compressing message data.
 
+V. `managers/``
 
-V. Events
+This folder contains the relevant domain specific classes that manage data accordingly.
+
+1. `kafka_ops.py`
+
+- This contains the KafkaSendOperations class, which handles data serialization and transfer to `Kafka`.
+- Mainly `async`, following conventions and directives from `kytos` advances in `asyncio`.
+  - Uses the `aiokafka` framework instead of `kafka-python` or `kafka-python-ng`.
+
+VI. Events
 ==========
 
   1. This section describes the how and why events are to be filtered in kafka_events
@@ -184,14 +193,14 @@ V. Events
     - Some events may not be necessary to downstream consumers, thus ignoring them would reduce Kafka's burden and improve throughput.
 
 
-VI. Dependencies
+VII. Dependencies
 =================
 
  * kytos
  * aiokafka - [0.12.0]
 
 
-VII. Kafka message structure
+VIII. Kafka message structure
 ======================
 
 1. Overview
@@ -289,7 +298,7 @@ A consumer reads the message and decodes it:
         print(f"Received: {event}")
 
 
-VIII. Implementation details ``v1``
+IX. Implementation details ``v1``
 ===================================
 
 The following requirements clarify certain details and expected behavior for ``kafka_events`` v1:
@@ -319,7 +328,7 @@ The following requirements clarify certain details and expected behavior for ``k
   - Cancel all pending async tasks. 
   - Wait for the AIOKafkaProducer's shutdown sequence to be successful.
 
-XI. Benchmarks
+X. Benchmarks
 
 The following benchmarks were the product of sending 400 requests (split across 10 threads) to the `mef_eline` endpoint to create `kytos/mef_eline.created` events naturally through `kytos`.
 
@@ -328,7 +337,7 @@ The following benchmarks were the product of sending 400 requests (split across 
 | MainThread | 3505340 | 234876 | 743.895 seconds | 775 seconds |
 | Separate Thread | 2887532 | 235164 | 488.687 seconds | 508 seconds |
 
-X. Open Questions / Future Work
+XI. Open Questions / Future Work
 =================================
 
   1. Error codes

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -334,10 +334,9 @@ The following benchmarks were the product of sending a request to a REST API end
 
 EPS
 ---
-
-| Implementation | Mean | Median | Standard Deviation |
-|--------|--------|--------|--------|
-| MainThread | 510.3469387755102 | 529.5 | 504.16585184252443 |
+:Mean 510.3469387755102
+:Median 529.5
+:Standard Deviation 504.16585184252443
 
 XI. Open Questions / Future Work
 =================================

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -27,12 +27,33 @@ Motivation
 Rationale
 =========
 
-The implementation took a simple, object-oriented approach in development. The main reasons behind this were:
+The implementation took a simple, object-oriented approach in development. Certain architectural decisions were made and the following sections discuss the motives behind them:
 
-  1. Encapsulation of Concerns - Each component is self-contained with a clear boundary, reducing unintended side effects and making debugging easier.
-  2. Code Reusability & Maintainability - By encapsulating logic within classes and methods, components can be reused when the project is extended or updated without modifying core functionality.
-  3. Improved Readability & Organization - Object-oriented code structures the application into well-defined classes, making it easier to navigate, understand, and modify.
-  4. Testability - With an object-oriented approach, dependencies can be injected, making unit testing and mocking easier.
+- **Kafka for High-Volume Event Exporting**
+  
+  - Kafka was selected due to its high throughput, durability, and fault-tolerant architecture, making it well-suited for exporting large volumes of events quickly and reliably.
+    - Kafka is already leveraged by other projects within the AmLight consortium, which allows us to build on existing infrastructure and expertise, reducing operational overhead and increasing interoperability.
+  - Unlike RabbitMQ, which is optimized for low-latency message delivery and supports complex routing, Kafka excels in handling large-scale streaming data with horizontal scalability and log-based persistence.
+  - Kafka enables better replay and auditing capabilities, as consumers can re-read streams at will, which is particularly valuable for debugging or downstream processing.
+
+- **Asynchronous Architecture for the NApp**
+
+  - Kytos is progressively evolving toward an asynchronous architecture for its NApps to better handle I/O-bound operations and network events, aligning with modern event-driven design.
+  - An async-dominant approach improves throughput by allowing the NApp to process multiple tasks concurrently without being blocked by synchronous waits or thread contention.
+  - Async code uses cooperative multitasking, which typically consumes less memory than thread-based concurrency models, resulting in improved performance under high load.
+  - This design choice enhances the NApp's scalability and responsiveness, particularly when interacting with external services like Kafka or device APIs, which benefit from non-blocking I/O operations.
+
+- **NApp Configuration: Acknowledgements and Idempotent Producers**
+
+  - While developing the NApp, it become necessary to specify `acks=all` in `settings.py` to ensure that a message is only considered successfully written when all in-sync replicas acknowledge receipt. This provides the strongest delivery guarantee Kafka offers.
+    - This works by waiting for all replicas to confirm they received the data. It mitigates the risk of message loss significantly, even in the event of a broker failure immediately after write.
+  - This setting is critical in our use case where event reliability is prioritized over latency—especially when exporting high-value or state-sensitive data.
+  - Combined with Kafka's log-based persistence model, this acknowledgment strategy ensures robustness in message delivery and stream integrity.
+
+  - To further improve reliability and fault tolerance, `enable.idempotence=true` was also enabled in the Kafka producer configuration.
+  - Idempotent producers ensure that even if a message is retried due to a network error or broker issue, it will not be duplicated in the Kafka topic.
+    - This is achieved by assigning sequence numbers to messages per producer session, allowing Kafka to detect and discard duplicates.
+  - Enabling idempotence is especially useful in asynchronous systems where retries are common; it ensures at-least-once delivery does not turn into more-than-once, preserving data correctness and consistency in downstream consumers.
 
 I. Requirements
 ===============
@@ -50,28 +71,28 @@ This blueprint has the following characteristics:
   2. - This NApp requires a Kafka topic to be created with suitable partitions available.
       - To reduce dependency reliance, the NApp will not rely on `kafka-python-ng` to create topics, but rather will manually do this.
 
-II. How kafka_napp works with Kytos
+II. How kafka_events works with Kytos
 ===============================
 
-This section provides an in-depth explanation of how the kafka_napp integrates with Kytos, detailing its workflow, event handling, and interactions with Kafka.
+This section provides an in-depth explanation of how the kafka_events integrates with Kytos, detailing its workflow, event handling, and interactions with Kafka.
 
-1. The kafka_napp serves as a listener for Kytos, enabling efficient event-driven communication by filtering, processing, and forwarding network events. It ensures that only relevant events are published to Kafka topics while discarding unnecessary ones based on configuration.
+1. The kafka_events serves as a listener for Kytos, enabling efficient event-driven communication by filtering, processing, and forwarding network events. It ensures that only relevant events are published to Kafka topics while discarding unnecessary ones based on configuration.
 
 - Workflow
   - Initialization
-    - Kafka_napp starts execution through the setup() function.
+    - kafka_events starts execution through the setup() function.
     - Within setup(), an instance of KafkaSendOperations is created.
     - Within setup(), the running event loop is retrieved and used to run KafkaSendOperations' setup.
   - Event Listening and Filtering
-    - Kafka_napp listens to all Kytos network events by subscribing to the event bus.
+    - kafka_events listens to all Kytos network events by subscribing to the event bus.
     - It checks each event against a predefined configuration to determine whether it should be processed.
       - Event filtering should be done using regular expressions, instead of manually inserting each name.
     - Events that are not configured for processing are filtered out and discarded.
   - Sending Data
-    - In the event loop, kafka_napp will serialize the JSON message, grab an asyncio Lock, then use `aiokafka` to append the message to the batch.
+    - In the event loop, kafka_events will serialize the JSON message, grab an asyncio Lock, then use `aiokafka` to append the message to the batch.
     - If `aiokafka` throws an exception, tenacity's retry mechanic will continuously send data until we reach `ALLOWED_RETRIES`.
   - Shutdown
-    - Kafka_napp receives starts the shutdown() function
+    - kafka_events receives starts the shutdown() function
     - Within shutdown(), all tasks are canceled as the event loop has been stopped
     - Within shutdown(), the producer is shut down and messages should be flushed to Kafka.
   - Key Components
@@ -79,15 +100,15 @@ This section provides an in-depth explanation of how the kafka_napp integrates w
     - KafkaSendOperations: Handles functionality for interfacing with Kafka.
 
 
-III. How kafka_napp interacts with Kafka
+III. How kafka_events interacts with Kafka
 ===============================================
 
-1. The kafka_napp also serves as an asynchronous producer of events, producing serialization and network submission functionality.
+1. The kafka_events also serves as an asynchronous producer of events, producing serialization and network submission functionality.
 
 - Publishing to Kafka
   - Serialization
-    - Once filtered, kafka_napp will add a task to be completed in the MainThread event loop.
-    - Events are serialized using JSON and appended to `aiokafka's` batch to be published to the corresponding Kafka topic. This is to be completed before kafka_napp is run.
+    - Once filtered, kafka_events will add a task to be completed in the MainThread event loop.
+    - Events are serialized using JSON and appended to `aiokafka's` batch to be published to the corresponding Kafka topic. This is to be completed before kafka_events is run.
       - The topic name is configured in `settings.py`.
       - The default is `event_logs`.
       - Kafka ensures these events are durably stored and available for consumption by downstream services.
@@ -107,7 +128,7 @@ IV. Configurations in settings.py
 
 IV. Configurations in settings.py
 
-1. This section describes the key configuration parameters used by the kafka_napp application. These constants define how the application connects to Kafka, manages topics, handles message delivery, and filters events.
+1. This section describes the key configuration parameters used by the kafka_events application. These constants define how the application connects to Kafka, manages topics, handles message delivery, and filters events.
 
 - Key Configuration Constants
   - BOOTSTRAP_SERVERS
@@ -155,7 +176,7 @@ IV. Configurations in settings.py
 V. Events
 ==========
 
-  1. This section describes the how and why events are to be filtered in kafka_napp
+  1. This section describes the how and why events are to be filtered in kafka_events
 
   - Filtering
     - Events are to be filtered using regular expressions (regex)
@@ -163,7 +184,7 @@ V. Events
     - Some events may not be necessary to downstream consumers, thus ignoring them would reduce Kafka's burden and improve throughput.
 
 
-VII. Dependencies
+VI. Dependencies
 =================
 
  * kytos
@@ -209,7 +230,7 @@ Each message follows this structure:
 
 3. Example Message Structure (JSON Payload)
 --------------------------------------------
-When ``handle_new_switch()`` sends a Kafka message, the value is typically JSON-encoded, like this:
+When ``handle_events()`` sends a Kafka message, the value is typically JSON-encoded, like this:
 
 .. code-block:: json
 
@@ -268,10 +289,10 @@ A consumer reads the message and decodes it:
         print(f"Received: {event}")
 
 
-XIII. Implementation details ``v1``
+VIII. Implementation details ``v1``
 ===================================
 
-The following requirements clarify certain details and expected behavior for ``kafka_napp`` v1:
+The following requirements clarify certain details and expected behavior for ``kafka_events`` v1:
 
 1. Initialization (setup())
   - Log the startup process: "SETUP Kytos/Kafka"
@@ -282,7 +303,7 @@ The following requirements clarify certain details and expected behavior for ``k
     - Retrieves the MainThread event loop for usage on KafkaSendOperations.
     - Enqueue's KafkaSendOperations' setup() function.
 
-2. Event Handling (handle_new_switch())
+2. Event Handling (handle_events())
   - Triggered when a switch connects (or other event matches the regex pattern .*).
   - Check if the event needs to be filtered out; if so, ignore it.
   - Send the event data to Kafka via _send_ops.send_message()
@@ -298,7 +319,16 @@ The following requirements clarify certain details and expected behavior for ``k
   - Cancel all pending async tasks. 
   - Wait for the AIOKafkaProducer's shutdown sequence to be successful.
 
-XIV. Open Questions / Future Work
+XI. Benchmarks
+
+The following benchmarks were the product of sending 400 requests (split across 10 threads) to the `mef_eline` endpoint to create `kytos/mef_eline.created` events naturally through `kytos`.
+
+| Implementation | VIRT | RES | Script time | `kafka_events` time |
+|--------|--------|--------|--------|--------|
+| MainThread | 3505340 | 234876 | 743.895 seconds | 775 seconds |
+| Separate Thread | 2887532 | 235164 | 488.687 seconds | 508 seconds |
+
+X. Open Questions / Future Work
 =================================
 
   1. Error codes
@@ -311,3 +341,6 @@ XIV. Open Questions / Future Work
     - This would allow `AIOKafkaProducer` to be shut down gracefully
   6. Use a TBD `async setup` method instead of the synchronous version
     - This would allow `AIOKafkaProducer` to be awaited gracefully instead of awaiting within the event listener.
+  7. If scalability becomes a concern, we can split topics are continue creating more partitions.
+    - How this would work would be to logically split target events into specific topics and to add a key to each exported event so they have their own partition.
+    - For example, if the amount of unique events from `flow_manager` or `mef_eline` become to big to handle on one topic, we can make a separate topic for them and continue adding partitions.

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -1,0 +1,313 @@
+:EP: 39
+:Title: Exporting Kytos events
+:Authors:
+    - Austin Uwate <auwate AT fiu DOT edu>
+:Created: 2025-02-12
+:Status: Draft
+:Type: Standard
+
+****************************************
+EP039 - Kafka NApp Proposal
+****************************************
+
+
+Abstract
+========
+
+This blueprint, EP 039, seeks to outline the requirements, features, and implementation of a NApp designed for exporting Kytos events to external applications. Without this NApp, external applications must to interact with Kytos APIs and log entries to obtain the network state, which leads to traffic engineering delays and extra load for Kytos to manage. By pushing data to an event broker, external application can consume data in real time without any impacts to Kytos. 
+
+
+Motivation
+==========
+
+- As Kytos grows and the number of external applications consuming data from Kytos's API increases, maintaining a high-performance system becomes critical. Relying on constant API requests and synchronous data retrieval can overwhelm the application, causing performance degradation. By pushing events to Kafka, external applications can receive the data asynchronously, which reduces the load on Kytos, improves its scalability, and ensures that the system remains fault-tolerant.
+- In case of a critical error or debugging cycle, engineers need consistent and reliable logging. By leveraging a lightweight data producer via Kafka, engineers can see exactly what happens in real-time.
+
+
+Rationale
+=========
+
+The implementation took a simple, object-oriented approach in development. The main reasons behind this were:
+
+  1. Encapsulation of Concerns - Each component is self-contained with a clear boundary, reducing unintended side effects and making debugging easier.
+  2. Code Reusability & Maintainability - By encapsulating logic within classes and methods, components can be reused when the project is extended or updated without modifying core functionality.
+  3. Improved Readability & Organization - Object-oriented code structures the application into well-defined classes, making it easier to navigate, understand, and modify.
+  4. Testability - With an object-oriented approach, dependencies can be injected, making unit testing and mocking easier.
+
+I. Requirements
+===============
+
+This blueprint has the following characteristics:
+
+  1. - This NApp requires a reachable Kafka cluster to be fully operational.
+      - For normal cluster conditions, the NApp should start up and shut down gracefully, using available async methods.
+      - In the case of an unreachable cluster, this NApp should follow the following behaviors, based on when the outage occurs:
+        - 1: On start-up: The NApp should retry connection, up to a limit of 3 times (with a 10 second connection timeout). If connection fails, then processed events should be dropped.
+        - 2: In operation: The NApp should retry connection, up to a limit of 3 times. The NApp is designed to buffer up to 32MB (max) before it sends, so if the connection fails when the buffer is full, it should log a warning and drop the message.
+          - If a message cannot be sent or appended to the bufer within that time, use tenacity's retry mechanic and async locking to retry message delivery. If the connection cannot be processed, drop the message.
+        - 3: On shut-down: The NApp should retry connection, up to a limit of 3 times. The shutdown mechanic tries to close a connection and flush any remaining messages. If connection fails, then the messages should be dropped.
+
+  2. - This NApp requires a Kafka topic to be created with suitable partitions available.
+      - To reduce dependency reliance, the NApp will not rely on `kafka-python-ng` to create topics, but rather will manually do this.
+
+II. How kafka_napp works with Kytos
+===============================
+
+This section provides an in-depth explanation of how the kafka_napp integrates with Kytos, detailing its workflow, event handling, and interactions with Kafka.
+
+1. The kafka_napp serves as a listener for Kytos, enabling efficient event-driven communication by filtering, processing, and forwarding network events. It ensures that only relevant events are published to Kafka topics while discarding unnecessary ones based on configuration.
+
+- Workflow
+  - Initialization
+    - Kafka_napp starts execution through the setup() function.
+    - Within setup(), an instance of KafkaSendOperations is created.
+    - Within setup(), the running event loop is retrieved and used to run KafkaSendOperations' setup.
+  - Event Listening and Filtering
+    - Kafka_napp listens to all Kytos network events by subscribing to the event bus.
+    - It checks each event against a predefined configuration to determine whether it should be processed.
+      - Event filtering should be done using regular expressions, instead of manually inserting each name.
+    - Events that are not configured for processing are filtered out and discarded.
+  - Sending Data
+    - In the event loop, kafka_napp will serialize the JSON message, grab an asyncio Lock, then use `aiokafka` to append the message to the batch.
+    - If `aiokafka` throws an exception, tenacity's retry mechanic will continuously send data until we reach `ALLOWED_RETRIES`.
+  - Shutdown
+    - Kafka_napp receives starts the shutdown() function
+    - Within shutdown(), all tasks are canceled as the event loop has been stopped
+    - Within shutdown(), the producer is shut down and messages should be flushed to Kafka.
+  - Key Components
+    - Event Listener: Listens to all Kytos events and applies filtering rules.
+    - KafkaSendOperations: Handles functionality for interfacing with Kafka.
+
+
+III. How kafka_napp interacts with Kafka
+===============================================
+
+1. The kafka_napp also serves as an asynchronous producer of events, producing serialization and network submission functionality.
+
+- Publishing to Kafka
+  - Serialization
+    - Once filtered, kafka_napp will add a task to be completed in the MainThread event loop.
+    - Events are serialized using JSON and appended to `aiokafka's` batch to be published to the corresponding Kafka topic. This is to be completed before kafka_napp is run.
+      - The topic name is configured in `settings.py`.
+      - The default is `event_logs`.
+      - Kafka ensures these events are durably stored and available for consumption by downstream services.
+  - Production
+    - Events are sent in batches asynchronously, ensuring maximum efficiency in network requests and processing.
+    - We rely on batching to enqueue data in the case of a cluster outage.
+    - Each message is sent to the same topic, but divided into their respective partitions based on keys.
+      - The amount of partitions is equal to the amount of different event types that need to be consumed.
+      - The amount of partitions that can be created safely is relatively high, so short-term to medium-term concerns over scalability are covered.
+        - If scalability becomes a concern, we can split topics are continue creating more partitions.
+  - Key Components
+    - KafkaSendOperations: Handles the Kafka functionality like event publishing.
+
+
+IV. Configurations in settings.py
+==============================
+
+IV. Configurations in settings.py
+
+1. This section describes the key configuration parameters used by the kafka_napp application. These constants define how the application connects to Kafka, manages topics, handles message delivery, and filters events.
+
+- Key Configuration Constants
+  - BOOTSTRAP_SERVERS
+    - Description: Specifies the Kafka server's address (hostname and port).
+    - Usage: This setting is critical for establishing the connection with the Kafka broker.
+  - ACKS
+    - Description: Determines the level of message acknowledgements required by Kafka.
+    - Available Options:
+      - 0: No acknowledgements required.
+      - 1: Only the leader broker must acknowledge.
+      - "all": All in-sync replicas must acknowledge the message.
+      - Usage: Controls the reliability and durability of message delivery.
+      - Note: This may increase latency between the application during sends. To add this functionality, ensure tolerance for when the application is sending to kafka but the also wants to enqueue new requests.
+  - ENABLE_ITEMPOTENCE
+    - Description: Tells aiokafka to keep track of all messages
+    - Requires ACKS == "all"
+    - Available Options:
+      - True: Enabled
+      - False: Disabled
+  - REQUEST_TIMEOUT_MS
+    - Description: The amount of time aiokafka waits while trying to send requests to Kafka
+    - Takes an integer (minimum 1)
+  - ALLOWED_RETRIES
+    - Description: The amount of retries that tenacity's retry mechanic will try until
+    - Takes an integer (minimum 0)
+  - DEFAULT_NUM_PARTITIONS
+    - Description: Sets the default number of partitions per Kafka topic.
+    - Usage: Influences the parallelism and throughput of message processing.
+  - IGNORED_EVENTS
+    - Description: Defines a set of event names that should be filtered out and not processed.
+    - Usage: Helps in ignoring events that are not relevant to the application's processing logic.
+  - REPLICATION_FACTOR
+    - Description: Specifies the number of times each partition is replicated across Kafka brokers.
+    - Usage: Enhances data redundancy and fault tolerance.
+    - Note: The value should not exceed the number of available Kafka brokers.
+  - TOPIC_NAME
+    - Description: The Kafka topic from which messages are sent and/or consumed.
+    - Usage: Acts as the central channel for event logging and communication between components.
+  - COMPRESSION_TYPE
+    - Description: The type of compression applied to messages sent to Kafka.
+    - Example: "gzip"
+    - Usage: Reduces network load and improves performance by compressing message data.
+
+
+V. Events
+==========
+
+  1. This section describes the how and why events are to be filtered in kafka_napp
+
+  - Filtering
+    - Events are to be filtered using regular expressions (regex)
+      - This allows for flexibility in rejecting some or all of a given producer's events.
+    - Some events may not be necessary to downstream consumers, thus ignoring them would reduce Kafka's burden and improve throughput.
+
+
+VII. Dependencies
+=================
+
+ * kytos
+ * aiokafka - [0.12.0]
+
+
+VII. Kafka message structure
+======================
+
+1. Overview
+------------
+A Kafka message consists of **a key, value, headers, timestamp, and metadata**. The **AIOKafkaProducer** sends messages as **ProducerRecord** objects.
+
+2. Kafka Message Format
+------------------------
+Each message follows this structure:
+
+.. list-table:: Kafka Message Fields
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Description
+   * - **Key**
+     - ``bytes`` or ``None``
+     - Used for partitioning. If ``None``, Kafka assigns a random partition.
+   * - **Value**
+     - ``bytes``
+     - The actual message payload (usually JSON in our case).
+   * - **Headers**
+     - ``list[(str, bytes)]``
+     - Optional metadata as key-value pairs.
+   * - **Timestamp**
+     - ``int`` (ms) or ``None``
+     - Event creation time (epoch milliseconds).
+   * - **Topic**
+     - ``str``
+     - Destination topic name.
+   * - **Partition**
+     - ``int`` or ``None``
+     - If specified, sends the message to that partition; otherwise, Kafka decides.
+
+3. Example Message Structure (JSON Payload)
+--------------------------------------------
+When ``handle_new_switch()`` sends a Kafka message, the value is typically JSON-encoded, like this:
+
+.. code-block:: json
+
+    {
+      "event": "kytos/topology.switch.new",
+      "switch_id": "00:00:00:00:00:00:00:01",
+      "timestamp": 1707859200000,
+      "metadata": {
+        "dpid": "1",
+        "ip": "192.168.1.10",
+        "port_count": 48
+      }
+    }
+
+- **Key:** ``None`` (Kafka handles partitioning).
+- **Value:** JSON message (converted to ``bytes``).
+- **Headers:** May contain custom metadata (e.g., ``("source", "kytos".encode())``).
+- **Timestamp:** Generated automatically or set manually.
+- **Topic:** ``"kytos_events"`` (example).
+
+4. AIOKafkaProducer Example
+----------------------------
+How the message is sent inside the Kytos event handler:
+
+.. code-block:: python
+
+    await self._producer.send(
+        topic="kytos_events",
+        key=None,  # Kafka decides the partition
+        value=json.dumps(event_data).encode(),  # Convert JSON to bytes
+        headers=[("source", "kytos".encode())],  # Custom headers
+        timestamp_ms=int(time.time() * 1000)  # Timestamp in ms
+    )
+
+5. How Kafka Stores the Message
+--------------------------------
+Kafka writes the message to a partition inside a topic. The message is stored in **binary format** with an **offset**:
+
+.. code-block:: text
+
+    Topic: kytos_events, Partition: 2
+    --------------------------------------------------
+    Offset | Key   | Value (JSON)                    | Timestamp
+    --------------------------------------------------
+    1023   | None  | { "event": "kytos/..." }        | 1707859200000
+    1024   | None  | { "event": "kytos/..." }        | 1707859210000
+
+6. Message Retrieval (Kafka Consumer Example)
+----------------------------------------------
+A consumer reads the message and decodes it:
+
+.. code-block:: python
+
+    async for msg in consumer:
+        event = json.loads(msg.value.decode())
+        print(f"Received: {event}")
+
+
+XIII. Implementation details ``v1``
+===================================
+
+The following requirements clarify certain details and expected behavior for ``kafka_napp`` v1:
+
+1. Initialization (setup())
+  - Log the startup process: "SETUP Kytos/Kafka"
+  - Create Kafka Producer and Admin Client:
+  - Instantiate KafkaSendOperations, which sets up:
+    - _setup_admin(): Creates a KafkaAdminClient, retrying up to 3 times if Kafka isn't available.
+  - Grab MainThread event loop.
+    - Retrieves the MainThread event loop for usage on KafkaSendOperations.
+    - Enqueue's KafkaSendOperations' setup() function.
+
+2. Event Handling (handle_new_switch())
+  - Triggered when a switch connects (or other event matches the regex pattern .*).
+  - Check if the event needs to be filtered out; if so, ignore it.
+  - Send the event data to Kafka via _send_ops.send_message()
+    - Message sending is to be enqueued on the event loop.
+
+  - send_message():
+    - Converts the event to JSON.
+    - Acquires an asyncio semaphore Lock to ensure sequential delivery
+    - Uses AIOKafkaProducer.send() to append to the batch and later publish it to the Kafka topic.
+
+3. Shutdown (shutdown())
+  - Log the shutdown process: "SHUTDOWN Kafka/Kytos"
+  - Cancel all pending async tasks. 
+  - Wait for the AIOKafkaProducer's shutdown sequence to be successful.
+
+XIV. Open Questions / Future Work
+=================================
+
+  1. Error codes
+  2. Route messages to their partitions based on key usage
+  3. When filtering events, use Regex patterns instead of Set.
+    - Eliminates redundancy by excluding all events from particular groups, instead of listing each individually.
+  4. Add endpoints that provide clients with useful data
+    - Currently the endpoints have been removed as there is no use. However, this can change with future work.
+  5. Use a TBD `async shutdown` method instead of the synchronous version
+    - This would allow `AIOKafkaProducer` to be shut down gracefully
+  6. Use a TBD `async setup` method instead of the synchronous version
+    - This would allow `AIOKafkaProducer` to be awaited gracefully instead of awaiting within the event listener.

--- a/docs/blueprints/EP039.rst
+++ b/docs/blueprints/EP039.rst
@@ -118,7 +118,7 @@ III. How kafka_events interacts with Kafka
     - Each message is sent to the same topic, but divided into their respective partitions based on keys.
       - The amount of partitions is equal to the amount of different event types that need to be consumed.
       - The amount of partitions that can be created safely is relatively high, so short-term to medium-term concerns over scalability are covered.
-        - If scalability becomes a concern, we can split topics are continue creating more partitions.
+        - If scalability becomes a concern, we can split topics and create more partitions.
   - Key Components
     - KafkaSendOperations: Handles the Kafka functionality like event publishing.
 
@@ -155,9 +155,14 @@ IV. Configurations in settings.py
   - DEFAULT_NUM_PARTITIONS
     - Description: Sets the default number of partitions per Kafka topic.
     - Usage: Influences the parallelism and throughput of message processing.
-  - IGNORED_EVENTS
-    - Description: Defines a set of event names that should be filtered out and not processed.
-    - Usage: Helps in ignoring events that are not relevant to the application's processing logic.
+  - RULE_SET
+    - Description: Sets the default, immutable Filters that should be applied on every launch.
+    - Usage: Using regular expressions, it establishes patterns that should be allowed to be sent to Kafka.\
+    - Syntax: Each dictionary entry acts as its own filter, using the format:
+      - "pattern": str
+        - A regular expression pattern. This is what is used as the Filter
+      - "description": str
+        - A human-readable description of the Filter. Does not affect the Filter logic.
   - REPLICATION_FACTOR
     - Description: Specifies the number of times each partition is replicated across Kafka brokers.
     - Usage: Enhances data redundancy and fault tolerance.
@@ -169,6 +174,16 @@ IV. Configurations in settings.py
     - Description: The type of compression applied to messages sent to Kafka.
     - Example: "gzip"
     - Usage: Reduces network load and improves performance by compressing message data.
+  - BATCH_SIZE
+    - Description: The total size (in bytes) allocated per batch request
+    - Usage: Reduces total network activity and improves performance by sending more data per request.
+  - LINGER_MS
+    - Description: The amount of time (in milliseconds) the producer will wait before sending a batch request
+    - Usage: Reduces total network requests by making the producer wait before sending each batch.
+      - By default, this is set to 0. This does not mean that batching is turned off however, as 
+  - MAX_REQUEST_SIZE
+    - Description: The maximum amount (in bytes) allowed to be sent per request.
+    - Usage: The producer will try and send messages up to BATCH_SIZE, but this setting allows for rare, massive messages to also be sent (beyond 1,2 or 3 MB).
 
 V. `managers/``
 =============
@@ -181,6 +196,11 @@ This folder contains the relevant domain specific classes that manage data accor
 - Mainly `async`, following conventions and directives from `kytos` advances in `asyncio`.
   - Uses the `aiokafka` framework instead of `kafka-python` or `kafka-python-ng`.
 
+2. `regex.py`
+
+- This contains the RegexOperations class, which handles Filter logic, allowing specific events to be processed.
+- Mainly `async`, similar in logic to `kafka_ops.py`.
+
 VI. Events
 ==========
 
@@ -190,28 +210,22 @@ VI. Events
     - Events are to be filtered using regular expressions (regex)
       - This allows for flexibility in rejecting some or all of a given producer's events.
     - Some events may not be necessary to downstream consumers, thus ignoring them would reduce Kafka's burden and improve throughput.
-    - Events can be dynamically added/listed/removed at runtime by interacting with the endpoints `/v1/create`, `/v1/list`, and `/v1/delete` respectively.
+    - Filters can be listed at runtime by interacting with the GET endpoint at `/v1/filters`.
+      - Adding or removing filters is explained below.
 
-VII. Endpoints
+  2. This section describes how filters are to be stored in `Kytos`
+
+  - Storage
+    - Filters are to be stored statically in `settings.py`, removing the need for persistence.
+    - To change filters, network operators indicated that they would schedule a maintainence window and quickly add regex rules to export NApps to Kafka.
+
+VII. Endpoint
 ==============
 
-  1. `/v1/create`
-
-  - Allows operators to create new filters to allow different NApps to be serialized.
-  - Requires JSON data to work
-    - Mandatory: "pattern": The regex pattern to be added
-    - Optional: "description": The human readable description for the Filter
-
-  2. `/v1/list`
+  1. `/v1/filters` - GET
 
   - Allows operators to list the currently running filters
   - Does not require JSON data
-
-  3. `/v1/delete`
-
-  - Allows operators to remove filters from the pipeline, restricting what is allowed.
-  - Requires JSON data to work
-    - Mandatory: "pattern": The regex pattern to be removed
 
 VIII. Dependencies
 =================
@@ -225,7 +239,7 @@ IX. Kafka message structure
 
 1. Overview
 ------------
-A Kafka message consists of **a key, value, headers, timestamp, and metadata**. The **AIOKafkaProducer** sends messages as **ProducerRecord** objects.
+A Kafka message consists of a **topic, partition, offset, headers, timestamp, key, value**. The **AIOKafkaProducer** sends messages as **ProducerRecord** objects.
 
 2. Kafka Message Format
 ------------------------
@@ -235,27 +249,32 @@ Each message follows this structure:
    :widths: 20 20 60
    :header-rows: 1
 
-   * - Field
-     - Type
-     - Description
-   * - **Key**
-     - ``bytes`` or ``None``
-     - Used for partitioning. If ``None``, Kafka assigns a random partition.
-   * - **Value**
-     - ``bytes``
-     - The actual message payload (usually JSON in our case).
-   * - **Headers**
-     - ``list[(str, bytes)]``
+ConsumerRecord(topic='event_logs', partition=0, offset=159360, timestamp=1749654862640, timestamp_type=0, key=None, value=b'{"event": "kytos/mef_eline.evcs_loaded", "type": "kytos/mef_eline.evcs_loaded", "message": {}}',
+checksum=None, serialized_key_size=-1, serialized_value_size=94, headers=())                 
+
+{'event': 'kytos/mef_eline.evcs_loaded', 'type': 'kytos/mef_eline.evcs_loaded', 'message': {}}
+
+   * - **topic**
+     - ``str``
+     - Name of the topic you pulled the data from.
+   * - **partition**
+     - ``int``
+     - The partition you pulled the data from. Mostly considered metadata unless you need to pull from a specific partition.
+   * - **offset**
+     - ``int``
+     - The position in the list of data that you pull from.
+   * - **headers**
+     - ``list[(str, str)]``
      - Optional metadata as key-value pairs.
-   * - **Timestamp**
+   * - **timestamp**
      - ``int`` (ms) or ``None``
      - Event creation time (epoch milliseconds).
-   * - **Topic**
-     - ``str``
-     - Destination topic name.
-   * - **Partition**
-     - ``int`` or ``None``
-     - If specified, sends the message to that partition; otherwise, Kafka decides.
+   * - **key**
+     - ``bytes`` or ``None``
+     - Used for partitioning. If ``None``, Kafka assigns a random partition.
+   * - **value**
+     - ``bytes``
+     - Payload message sent from Kytos
 
 3. Example Message Structure (JSON Payload)
 --------------------------------------------
@@ -264,29 +283,22 @@ When ``handle_events()`` sends a Kafka message, the value is typically JSON-enco
 .. code-block:: json
 
     {
-      "name": str,
-      "content": dict,
-      "timestamp": str,
-      "id": str
+      'event': 'kytos/mef_eline.evcs_loaded',
+      'message': {}
     }
 
-- **name** ``str`` The name of the KytosEvent being emitted.
-- **content** ``dict`` The contents of the message, preserved from the original KytosEvent.
-- **timestamp** ``str`` The ISO formatted (like 2025-04-15T20:49:05.196851) timestamp associated to when the KytosEvent was emitted.
-- **id:** ``str`` The UUID identifier (in str format) that the KytosEvent was originally emitted with.
+- **event** ``str`` The name of the KytosEvent being emitted.
+- **message** ``None`` or ``dict[(str, str)]`` The message being emitted.
 
 4. AIOKafkaProducer Example
 ----------------------------
-How the message is sent inside the Kytos event handler:
+How the message is sent inside the KafkaSendOperations handler:
 
 .. code-block:: python
 
     await self._producer.send(
-        topic="kytos_events",
-        key=None,  # Kafka decides the partition
-        value=json.dumps(event_data).encode(),  # Convert JSON to bytes
-        headers=[("source", "kytos".encode())],  # Custom headers
-        timestamp_ms=int(time.time() * 1000)  # Timestamp in ms
+      topic=topic,
+      value=value
     )
 
 5. How Kafka Stores the Message
@@ -304,7 +316,7 @@ Kafka writes the message to a partition inside a topic. The message is stored in
 
 6. Message Retrieval (Kafka Consumer Example)
 ----------------------------------------------
-A consumer reads the message and decodes it:
+While consumers may need to use the accompanying metadata (such as timestamp, offset, etc.), the actual data will be found in the ``value`` component:
 
 .. code-block:: python
 
@@ -320,16 +332,16 @@ The following requirements clarify certain details and expected behavior for ``k
 
 1. Initialization (setup())
   - Log the startup process: "SETUP Kytos/Kafka"
-  - Create Kafka Producer and Admin Client:
-  - Instantiate KafkaSendOperations, which sets up:
-    - _setup_admin(): Creates a KafkaAdminClient, retrying up to 3 times if Kafka isn't available.
+  - Create a KafkaSendOperations instance
+  - Create a RegexOperations instance
   - Grab MainThread event loop.
-    - Retrieves the MainThread event loop for usage on KafkaSendOperations.
-    - Enqueue's KafkaSendOperations' setup() function.
+    - Instantiate KafkaSendOperations by enqueueing into the event loop, setting up the producer.
+    - Instantiate RegexOperations by enqueueing into the event loop, grabbing all Filters from RULE_SET.
 
 2. Event Handling (handle_events())
-  - Triggered when a switch connects (or other event matches the regex pattern .*).
-  - Check if the event needs to be filtered out; if so, ignore it.
+  - Triggered when any KytosEvent is fired
+  - Check if the event is allowed to be filtered; If not, ignore it.
+    - Uses regular expressions to implement filters.
   - Send the event data to Kafka via _send_ops.send_message()
     - Message sending is to be enqueued on the event loop.
 
@@ -341,7 +353,7 @@ The following requirements clarify certain details and expected behavior for ``k
 3. Shutdown (shutdown())
   - Log the shutdown process: "SHUTDOWN Kafka/Kytos"
   - Cancel all pending async tasks. 
-  - Wait for the AIOKafkaProducer's shutdown sequence to be successful.
+  - Currently does not have an async shutdown sequence, thus AIOKafkaProducer is not sufficiently stopped.
 
 X. Benchmarks
 
@@ -395,18 +407,26 @@ The following scenarios were tested in a virtual machine used a Intel(R) Xeon(R)
 
   Looking at *scenario 2*, we see an acceptable performance for a worse-case scenario, where 500 ethernet virtual circuits (EVCs) that all share a common path must perform a topology search for a new path during a link down event. Even with `Kytos` consuming a high ratio resources (including the CPU) as it searches for new paths, `kafka_events` still performs to desired expectations, hitting a ~500 EPS through this event. Similarly to *scenario 1*, the EPS picked up speed after higher-priority processing was finished. 
 
-XI. Open Questions / Future Work
+XI. Testing
+
+To address testing validation, `kafka_events` will be shipped with a `docker-compose.yml` file to launch a `Kafka` cluster for testing. This would be primarily used in E2E testing, but also in integration tests within the application itself. The cluster will try and mirror what is running currently, but will strive to have the following properties:
+
+  1. Multi-broker
+  2. Fault tolerant
+  3. Highly available
+
+These objectives would allow us to simulate broker issues, going from single instance to entire cluster failures. This would allow us to validate that the NApp will still be operational during slight outages, as well as validating that `Kytos` would continue to be operational when a cluster failure occurs.
+
+XII. Open Questions / Future Work
 =================================
 
   1. Error codes
   2. Route messages to their partitions based on key usage
-  3. Add endpoints that provide clients with useful data
-    - Currently the endpoints have been removed as there is no use. However, this can change with future work.
-  4. Use a TBD `async shutdown` method instead of the synchronous version
+  3. Use a TBD `async shutdown` method instead of the synchronous version
     - This would allow `AIOKafkaProducer` to be shut down gracefully
-  5. Use a TBD `async setup` method instead of the synchronous version
+  4. Use a TBD `async setup` method instead of the synchronous version
     - This would allow `AIOKafkaProducer` to be awaited gracefully instead of awaiting within the event listener.
-  6. If scalability becomes a concern, we can split topics are continue creating more partitions.
+  5. If scalability becomes a concern, we can split topics are continue creating more partitions.
     - How this would work would be to logically split target events into specific topics and to add a key to each exported event so they have their own partition.
-    - For example, if the amount of unique events from `flow_manager` or `mef_eline` become to big to handle on one topic, we can make a separate topic for them and continue adding partitions.\
-  7. In the case of a `Kafka` outage, memory consumption could spike and cause `Kytos` to freeze if not handled properly.
+    - For example, if the amount of unique events from `flow_manager` or `mef_eline` become to big to handle on one topic, we can make a separate topic for them and continue adding partitions.
+  6. In the case of a `Kafka` outage, memory consumption could spike and cause `Kytos` to freeze if not handled properly.


### PR DESCRIPTION
Closes #457

### Summary

This adds the blueprint to `kafka_napp` that explains and outlines the potential NApp for use in event publishing. In addition, it discusses potential work necessary in the `Future Work` section.

See updated changelog file and/or add any other summarized helpful information for reviewers
