### PR TITLE
Added headers that stop browsers from caching NApp UI files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Fixed
 =====
 - Enhanced docker mongo setup script (rs-init.sh) to properly run on PRIMARY node
 
+Added
+=====
+- Added headers to NApp file response which tells browsers not to cache them.
+
 [2025.1.0] - 2025-04-15
 ***********************
 

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -180,7 +180,12 @@ class APIServer:
         filename = request.path_params["filename"]
         path = f"{self.napps_dir}/{username}/{napp_name}/ui/{filename}"
         if os.path.exists(path):
-            return FileResponse(path)
+            headers = {
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma": "no-cache",
+                "Expires": "0"
+            }
+            return FileResponse(path, headers=headers)
         return JSONResponse("", status_code=HTTPStatus.NOT_FOUND.value)
 
     def get_ui_components(self, request: Request) -> JSONResponse:


### PR DESCRIPTION
Closes #595 

### Summary

The NApp UI files are no longer cached because of headers added to the file response within the API server.

### Local Tests

NApp UI files are no longer cached.

<img width="882" height="652" alt="image" src="https://github.com/user-attachments/assets/342b8f1a-2e3a-43be-bd48-f08e45d22d3c" />