### PR TITLE
Applied asyncio shutdown

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changed
 - ``controller`` now holds the dictionary of ``links`` and it can be accessed by other NApps by calling ``self.controller.links``.
 - Each ``Link`` now has a ``threading.Lock`` to perform any change or check on its attributes.
 - Kytos shutdown will now wait for every NApp to shutdown completely.
+- Kytos shutdowns asynchronouly now. This allows NApps to wait for their tasks to finish properly when shutting down.
 
 Fixed
 =====

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -178,6 +178,7 @@ class Controller:
                                          self.detect_mismatched_link)
         Link.register_status_func("controller_mismatched_status",
                                   self.link_status_mismatched)
+        self.api_task = None
 
     def start_auth(self):
         """Initialize Auth() and its services"""
@@ -393,8 +394,7 @@ class Controller:
                                   self.options.protocol_name)
 
         self.log.info("Starting API server")
-        task = self.loop.create_task(self.api_server.serve())
-        self._tasks.append(task)
+        self.api_task = self.loop.create_task(self.api_server.serve())
         await self._wait_api_server_started()
 
         self.log.info(f"Starting TCP server: {self.server}")
@@ -489,7 +489,7 @@ class Controller:
 
         self.start(restart=True)
 
-    def stop(self, graceful=True):
+    async def stop(self, graceful=True):
         """Shutdown all services used by kytos.
 
         This method should:
@@ -498,9 +498,9 @@ class Controller:
             - stop the Controller
         """
         if self.started_at:
-            self.stop_controller(graceful)
+            await self.stop_controller(graceful)
 
-    def stop_controller(self, graceful=True):
+    async def stop_controller(self, graceful=True):
         """Stop the controller.
 
         This method should:
@@ -531,7 +531,7 @@ class Controller:
         # self.server.socket.close()
 
         self.started_at = None
-        napps = self.unload_napps()
+        napps = await self.unload_napps()
         self.log.info(
             f"Waiting for {len(napps)} NApps shutdown confirmation..."
         )
@@ -540,9 +540,16 @@ class Controller:
             napp.__dict__['_KytosNApp__event'].wait()
             self.log.info(f"{napp} was shutdown")
 
+        self.log.info("Stopping API Server...")
+        self.api_server.stop()
+        if self.api_task:
+            await self.api_task
+        self.log.info("Stopped API Server")
+
         # Cancel all async tasks (event handlers and servers)
         for task in self._tasks:
             task.cancel()
+            await task
 
         # ASYNC TODO: close connections
         # self.server.server_close()
@@ -552,9 +559,6 @@ class Controller:
             self.log.info("Stopping APM server...")
             self.apm.close()
             self.log.info("Stopped APM Server")
-        self.log.info("Stopping API Server...")
-        self.api_server.stop()
-        self.log.info("Stopped API Server")
         self.log.info("Stopping TCP Server...")
         self.server.shutdown()
         self.log.info("Stopped TCP Server")
@@ -621,24 +625,28 @@ class Controller:
         """Default event handler that gets from an event buffer."""
         event_buffer = getattr(self.buffers, buffer_name)
         self.log.info(f"Event handler {buffer_name} started")
-        while True:
-            try:
-                # After hitting issues with a large amount of flows being
-                # installed (16k which sends 32k events), this task was
-                # hogging resources in the MainThread causing disconnections
-                # and socket exceptions. With the following sleep, this task
-                # yields to other loops mitigating the disconnection issues.
-                # Now the cap for flow installation at the same time is 50k.
-                await asyncio.sleep(0)
-                event = await event_buffer.aget()
-                self.notify_listeners(event)
+        try:
+            while True:
+                try:
+                    # After hitting issues with a large amount of flows being
+                    # installed (16k which sends 32k events), this task was
+                    # hogging resources in the MainThread causing
+                    # disconnections and socket exceptions. With the following
+                    # sleep, this task yields to other loops mitigating the
+                    # disconnection issues. Now the cap for flow installation
+                    # at the same time is 50k.
+                    await asyncio.sleep(0)
+                    event = await event_buffer.aget()
+                    self.notify_listeners(event)
 
-                if event.name == "kytos/core.shutdown":
-                    self.log.debug(f"Event handler {buffer_name} stopped")
-                    break
-            except Exception as exc:
-                self.log.exception(f"Unhandled exception on {buffer_name}",
-                                   exc_info=exc)
+                    if event.name == "kytos/core.shutdown":
+                        self.log.debug(f"Event handler {buffer_name} stopped")
+                        break
+                except Exception as exc:
+                    self.log.exception(f"Unhandled exception on {buffer_name}",
+                                       exc_info=exc)
+        except asyncio.CancelledError:
+            self.log.debug(f"Event handler {buffer_name} cancelled.")
 
     async def publish_connection_error(self, event):
         """Publish connection error event.
@@ -937,7 +945,7 @@ class Controller:
                 msg = f"NApp {napp.id} exception {str(exception)}"
                 raise KytosNAppSetupException(msg) from exception
 
-    def unload_napp(self, username, napp_name):
+    async def unload_napp(self, username, napp_name):
         """Unload a specific NApp.
 
         Args:
@@ -954,7 +962,7 @@ class Controller:
             event = KytosEvent(name='kytos/core.shutdown.' + napp_id)
             napp_shutdown_fn = self.events_listeners[event.name][0]
             # Call listener before removing it from events_listeners
-            napp_shutdown_fn(event)
+            await napp_shutdown_fn(event)
 
             # Remove rest endpoints from that napp
             self.api_server.remove_napp_endpoints(napp)
@@ -971,7 +979,7 @@ class Controller:
 
         return napp
 
-    def unload_napps(self):
+    async def unload_napps(self):
         """Unload all loaded NApps that are not core NApps
 
         NApps are unloaded in the reverse order that they are enabled to
@@ -979,7 +987,7 @@ class Controller:
         """
         napps = []
         for napp in reversed(self.napps_manager.get_enabled_napps()):
-            if napp := self.unload_napp(napp.username, napp.name):
+            if napp := await self.unload_napp(napp.username, napp.name):
                 napps.append(napp)
         return napps
 

--- a/kytos/core/kytosd.py
+++ b/kytos/core/kytosd.py
@@ -101,6 +101,20 @@ def main():
             async_main(config)
 
 
+async def async_stop_controller(controller, shell_task=None):
+    """Stop the controller asynchronously."""
+    loop = asyncio.get_running_loop()
+    if loop:
+        # If stop() hangs, old ctrl+c behaviour will be restored
+        loop.remove_signal_handler(signal.SIGINT)
+        loop.remove_signal_handler(signal.SIGTERM)
+
+    controller.log.info("Stopping Kytos controller...")
+    await controller.stop()
+    if shell_task:
+        shell_task.cancel()
+
+
 def stop_controller(controller, shell_task=None):
     """Stop the controller before quitting."""
     loop = asyncio.get_running_loop()
@@ -142,7 +156,7 @@ async def start_shell_async(controller, executor):
     try:
         data = await loop.run_in_executor(executor, _start_shell)
     finally:
-        stop_controller(controller)
+        await async_stop_controller(controller)
     return data
 
 

--- a/kytos/core/napps/base.py
+++ b/kytos/core/napps/base.py
@@ -1,4 +1,5 @@
 """Kytos Napps Module."""
+import inspect
 import json
 import os
 import re
@@ -186,8 +187,8 @@ class KytosNApp(Thread, metaclass=ABCMeta):
 
         # Force a listener with a private method.
         self._listeners = {
-            'kytos/core.shutdown': [self._shutdown_handler],
-            'kytos/core.shutdown.' + self.napp_id: [self._shutdown_handler]}
+            'kytos/core.shutdown.' + self.napp_id: [self._shutdown_handler]
+        }
 
         self.__event = Event()
         #: int: Seconds to sleep before next call to :meth:`execute`. If
@@ -270,17 +271,22 @@ class KytosNApp(Thread, metaclass=ABCMeta):
         self.controller.buffers.meta.put(event)
 
     # all listeners receive event
-    def _shutdown_handler(self, event):  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument
+    async def _shutdown_handler(self, event):
         """Listen shutdown event from kytos.
 
-        This method listens the kytos/core.shutdown event and call the shutdown
-        method from napp subclass implementation.
+        This method listens the kytos/core.shutdown event and call the
+        (asyncio or synchronous) shutdown method from napp subclass
+        implementation.
 
-        Paramters
+        Parameters
             event (:class:`KytosEvent`): event to be listened.
         """
         if not self.__event.is_set():
-            self.shutdown()
+            if inspect.iscoroutinefunction(self.shutdown):
+                await self.shutdown()
+            else:
+                self.shutdown()
             self.__event.set()
 
     @abstractmethod

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,8 @@ class TestCoverage(Test):
 
     def run(self):
         """Run tests quietly and display coverage report."""
-        cmd = f"python3 -m pytest --cov=. tests/ {self.get_args()}"
+        cmd = "python3 -m pytest --cov=. tests/ "
+        cmd += f"{self.get_args()} --cov-report term-missing"
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -65,30 +65,30 @@ class TestController:
         logging.root.handlers = handlers_bak
 
     @patch('kytos.core.api_server.APIServer.remove_napp_endpoints')
-    def test_unload_napp_listener(self, _):
+    async def test_unload_napp_listener(self, _):
         """Call NApp shutdown listener on unload."""
         username, napp_name = 'test', 'napp'
         listener = self._add_napp(username, napp_name)
 
         listener.assert_not_called()
-        self.controller.unload_napp(username, napp_name)
+        await self.controller.unload_napp(username, napp_name)
         listener.assert_called()
 
     @patch('kytos.core.api_server.APIServer.remove_napp_endpoints')
-    def test_unload_napp_other_listener(self, _):
+    async def test_unload_napp_other_listener(self, _):
         """Should not call other NApps' shutdown listener on unload."""
         username, napp_name = 'test', 'napp1'
         self._add_napp(username, napp_name)
         other_listener = self._add_napp('test', 'napp2')
 
-        self.controller.unload_napp(username, napp_name)
+        await self.controller.unload_napp(username, napp_name)
         other_listener.assert_not_called()
 
     def _add_napp(self, username, napp_name):
         """Add a mocked NApp to the controller."""
         napp_id = f'{username}/{napp_name}'
         event_name = f'kytos/core.shutdown.{napp_id}'
-        listener = Mock()
+        listener = AsyncMock()
         self.controller.events_listeners[event_name] = [listener]
         napp = Mock(_listeners={})
         self.controller.napps[(username, napp_name)] = napp
@@ -272,12 +272,12 @@ class TestController:
         mock_start.assert_called_with(restart=True)
 
     @patch('kytos.core.controller.Controller.stop_controller')
-    def test_stop(self, mock_stop_controller):
+    async def test_stop(self, mock_stop_controller):
         """Test stop method."""
         self.controller.started_at = 1
 
         graceful = True
-        self.controller.stop(graceful)
+        await self.controller.stop(graceful)
 
         mock_stop_controller.assert_called_with(graceful)
 
@@ -577,7 +577,7 @@ class TestController:
         mock_load.assert_called_with('kytos', 'name')
 
     @patch('kytos.core.controller.Controller.unload_napp')
-    def test_unload_napps(self, mock_unload):
+    async def test_unload_napps(self, mock_unload):
         """Test un_load_napps method."""
         napp_tuples = [("kytos", "of_core"), ("kytos", "mef_eline")]
         enabled_napps = []
@@ -591,7 +591,7 @@ class TestController:
         self.napps_manager.get_enabled_napps.return_value = enabled_napps
         mock_unload.side_effect = enabled_napps
 
-        napps = self.controller.unload_napps()
+        napps = await self.controller.unload_napps()
         assert mock_unload.call_count == len(enabled_napps)
         assert mock_unload.mock_calls == list(reversed(expected_calls))
         assert napps == enabled_napps
@@ -921,9 +921,11 @@ class TestControllerAsync:
 
         controller.server.serve_forever.assert_called()
         all_buffers = controller.buffers.get_all_buffers()
-        # It's expected that all buffers have a task + the api server task
+        # It's expected that all buffers have a task
         assert controller.loop.create_task.call_count == len(all_buffers) + 1
-        assert len(controller._tasks) == len(all_buffers) + 1
+        # API server task is not inside _tasks anymore
+        assert len(controller._tasks) == len(all_buffers)
+        assert controller.api_task is not None
         controller.pre_install_napps.assert_called_with([napp])
         controller.load_napps.assert_called()
         controller.api_server.start_web_ui.assert_called()
@@ -940,14 +942,14 @@ class TestControllerAsync:
         api_server = MagicMock()
         napp_dir_listener = MagicMock()
         controller.server = MagicMock()
-        controller.unload_napps = MagicMock()
+        controller.unload_napps = AsyncMock()
         controller._buffers = MagicMock()
         controller.api_server = api_server
         controller.napp_dir_listener = napp_dir_listener
         controller.stop_queue_monitors = MagicMock()
         controller.apm = MagicMock()
 
-        controller.stop_controller()
+        await controller.stop_controller()
         controller.apm.close.assert_called()
         controller.buffers.send_stop_signal.assert_called()
         api_server.stop.assert_called()

--- a/tests/unit/test_core/test_napps_base.py
+++ b/tests/unit/test_core/test_napps_base.py
@@ -193,11 +193,3 @@ class TestKytosNApp:
         self.kytos_napp.run()
 
         assert self.kytos_napp.execute.call_count == 2
-
-    def test_shutdown_handler(self):
-        """Test _shutdown_handler method."""
-        self.event.is_set.return_value = False
-
-        self.kytos_napp._shutdown_handler(MagicMock())
-
-        self.kytos_napp.shutdown.assert_called_once()


### PR DESCRIPTION
Closes #556

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests
Updated unit tests
Shut down kytos session with high load of flows

### End-to-End Tests
To be run.

### To be continued
- Shutting down with signal will post an error.
- When kytos pacing for flows kick in, the shutdown can hang if shut down is rushed.
