### PR TITLE
fix: validate duplicated dpid

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Changed
+=======
+- Controller method ``get_switch_or_create`` now validates dpid uniqueness. If an existing dpid is connected and enabled, it'll raise ``KytoDuplicatedSwitch``, which ``of_core`` will handle accordingly and log as an error and not allow it to overwrite the existing switch. An existing not connected is still assumed to be the same reconnecting switch.
+
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -44,6 +44,7 @@ from kytos.core.db import db_conn_wait
 from kytos.core.dead_letter import DeadLetter
 from kytos.core.events import KytosEvent
 from kytos.core.exceptions import (KytosAPMInitException, KytosDBInitException,
+                                   KytosDuplicatedSwitch,
                                    KytosNAppSetupException)
 from kytos.core.helpers import executors, now
 from kytos.core.interface import Interface
@@ -738,6 +739,10 @@ class Controller:
                 connection used by switch. If a switch has a connection that
                 will be updated.
 
+        Raises:
+            KytosDuplicatedSwitch if there's an existing connected switch
+            with the same dpid
+
         Returns:
             :class:`~kytos.core.switch.Switch`: new or existent switch.
 
@@ -754,6 +759,17 @@ class Controller:
                 self.add_new_switch(switch)
                 event_name += 'new'
             else:
+                if switch.is_enabled() and switch.is_connected():
+                    msg = (
+                        f"Duplicated connecting DPID {dpid}, "
+                        f"{connection} with existing "
+                        f"{switch}, {switch.connection}. "
+                        "New switch will be ignored. "
+                        "You should either use a new unique DPID or "
+                        "disconnect and decommission the existing one."
+                    )
+                    self.remove_connection(connection)
+                    raise KytosDuplicatedSwitch(msg)
                 event_name += 'reconnected'
             event = KytosEvent(name=event_name, content={'switch': switch})
 

--- a/kytos/core/exceptions.py
+++ b/kytos/core/exceptions.py
@@ -58,6 +58,10 @@ class KytosWrongEventType(KytosEventException):
     """
 
 
+class KytosDuplicatedSwitch(Exception):
+    """Raised when a duplicated Switch DPID tries to connect."""
+
+
 class KytosNoTagAvailableError(Exception):
     """Exception raised when a link has no vlan available."""
 

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -18,7 +18,8 @@ from kytos.core.buffers import KytosBuffers, KytosEventBuffer
 from kytos.core.common import EntityStatus
 from kytos.core.config import KytosConfig
 from kytos.core.events import KytosEvent
-from kytos.core.exceptions import KytosNAppSetupException
+from kytos.core.exceptions import (KytosDuplicatedSwitch,
+                                   KytosNAppSetupException)
 from kytos.core.logs import LogManager
 from kytos.core.rest_api import Request
 from kytos.lib.helpers import (get_interface_mock, get_link_mock,
@@ -363,10 +364,11 @@ class TestController:
 
         assert resp_switch == switch
 
-    def test_get_switch_or_create__exists(self):
-        """Test status_api method when switch exists."""
+    def test_get_switch_or_create__exists_not_connected(self):
+        """Test status_api method when switch exists but not connected."""
         dpid = '00:00:00:00:00:00:00:01'
         switch = MagicMock(dpid=dpid)
+        switch.is_connected = MagicMock(return_value=False)
         self.controller.switches = {dpid: switch}
         self.controller.buffers.conn = MagicMock()
 
@@ -377,6 +379,41 @@ class TestController:
         self.controller.buffers.conn.put.assert_called()
         ev_name = "kytos/core.switch.reconnected"
         assert self.controller.buffers.conn.put.call_args[0][0].name == ev_name
+
+    def test_get_switch_or_create__exists_connected_not_enabled(self):
+        """Test status_api method when a connected switch exists."""
+        dpid = '00:00:00:00:00:00:00:01'
+        switch = MagicMock(dpid=dpid)
+        switch.is_connected = MagicMock(return_value=True)
+        switch.is_enabled = MagicMock(return_value=False)
+        self.controller.switches = {dpid: switch}
+        self.controller.buffers.conn = MagicMock()
+
+        connection = MagicMock()
+        resp_switch = self.controller.get_switch_or_create(dpid, connection)
+
+        assert resp_switch == switch
+        self.controller.buffers.conn.put.assert_called()
+        ev_name = "kytos/core.switch.reconnected"
+        assert self.controller.buffers.conn.put.call_args[0][0].name == ev_name
+
+    def test_get_switch_or_create__exists_connected_enabled(self):
+        """Test status_api method when a connected switch exists."""
+        dpid = '00:00:00:00:00:00:00:01'
+        switch = MagicMock(dpid=dpid)
+        switch.is_connected = MagicMock(return_value=True)
+        switch.is_enabled = MagicMock(return_value=True)
+        self.controller.switches = {dpid: switch}
+        self.controller.buffers.conn = MagicMock()
+        self.controller.remove_connection = MagicMock()
+
+        connection = MagicMock()
+        with pytest.raises(KytosDuplicatedSwitch) as exc:
+            self.controller.get_switch_or_create(dpid, connection)
+        assert f"Duplicated connecting DPID {dpid}" in str(exc)
+
+        assert self.controller.remove_connection.call_count == 1
+        self.controller.buffers.conn.put.assert_not_called()
 
     def test_get_switch_or_create__not_exists(self):
         """Test status_api method when switch does not exist."""


### PR DESCRIPTION
Closes https://github.com/kytos-ng/of_core/issues/114

### Summary

See updated changelog file 

### Local Tests

I explored the following cases:

- Reconnecting enabled dpid, reinserted as expected

```
kytos $> 

kytos $> 

kytos $> 2026-05-06 18:37:02,515 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:56656. Reason: Request closed by client
kytos $> 

kytos $> 2026-05-06 18:37:05,829 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:56661
2026-05-06 18:37:05,839 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_1) Connection ('127.0.0.1', 56661), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2026-05-06 18:37:05,859 - INFO [uvicorn.access] (MainThread) 127.0.0.1:56662 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&cookie_range=12321848580485677056&cookie_range=12393906174523604991
&dpid=00:00:00:00:00:00:00:01 HTTP/1.1" 200
2026-05-06 18:37:05,952 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_5) Event handle_interface_link_up Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2026-05-06 18:37:05,953 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_16) Event handle_interface_link_up Interface('s1', 4294967294, Switch('00:00:00:00:00:00:00:01'))
2026-05-06 18:37:05,955 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_9) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2026-05-06 18:37:05,955 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_4) Event handle_interface_link_up Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01'))
2026-05-06 18:37:05,958 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_2) Event handle_interface_link_up Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01'))
kytos $> 

kytos $> 
```

- Connecting duplicated dpid, discarded as expected, plus no connections being leaked. Also confirmed the log error message is clear (needs of_core PR that will be linked here)

```
kytos $> contr2026-05-06 18:49:08,560 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:57766
2026-05-06 18:49:08,565 - ERROR [kytos.napps.kytos/of_core] (thread_pool_sb_1) Duplicated connecting DPID 00:00:00:00:00:00:00:01, Connection('127.0.0.1', 57766) with existing Switch('00:00:00:00:00:00:00:01
'), Connection('127.0.0.1', 57695). New switch will be ignored. You should either use a new unique DPID or disconnect and decommission the existing one.
2026-05-06 18:49:08,566 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:57766. Reason: Request closed by client
kytos $> controller.connections
Out[1]: 
{('127.0.0.1',
  57695): Connection('127.0.0.1', 57695, <_SelectorSocketTransport fd=124 read=polling write=<idle, bufsize=0>>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLISHED: 2>),
 ('127.0.0.1',
  57698): Connection('127.0.0.1', 57698, <_SelectorSocketTransport fd=127 read=polling write=<idle, bufsize=0>>, Switch('00:00:00:00:00:00:00:02'), <ConnectionState.ESTABLISHED: 2>),
 ('127.0.0.1',
  57697): Connection('127.0.0.1', 57697, <_SelectorSocketTransport fd=126 read=polling write=<idle, bufsize=0>>, Switch('00:00:00:00:00:00:00:03'), <ConnectionState.ESTABLISHED: 2>)}

kytos $> 2026-05-06 18:49:09,571 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:57767
2026-05-06 18:49:09,581 - ERROR [kytos.napps.kytos/of_core] (thread_pool_sb_2) Duplicated connecting DPID 00:00:00:00:00:00:00:01, Connection('127.0.0.1', 57767) with existing Switch('00:00:00:00:00:00:00:01
'), Connection('127.0.0.1', 57695). New switch will be ignored. You should either use a new unique DPID or disconnect and decommission the existing one.
2026-05-06 18:49:09,581 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:57767. Reason: Request closed by client
kytos $> 


```

- I also installed flows on the existing switch:

```
2026-05-06 18:48:57,561 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:57753. Reason: Request closed by client
2026-05-06 18:48:58,037 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request command: add, force: True, dpids: ['00:00:00:00:00:00:00:01'], flows[0, 1]: [{'cookie': 3, 'tab
le_id': 2, 'match': {'in_port': 1, 'dl_vlan': 2001, 'dl_type': 2048}}]
2026-05-06 18:48:58,037 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Flows received summary:  switches:['00:00:00:00:00:00:00:01'], flows_by_switch:1,  total_flows_length: 1
2026-05-06 18:48:58,047 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57754 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2026-05-06 18:48:58,557 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:57756

root@docker-desktop:~# ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0xab00000000000001, duration=49.229s, table=0, n_packets=34, n_bytes=1428, send_flow_rem pri
ority=50000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
 cookie=0xac00000000000001, duration=49.228s, table=0, n_packets=0, n_bytes=0, send_flow_rem priorit
y=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0xac00000000000001, duration=49.226s, table=0, n_packets=0, n_bytes=0, send_flow_rem priorit
y=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0x3, duration=49.226s, table=2, n_packets=0, n_bytes=0, send_flow_rem ip,in_port="s1-eth1",d
l_vlan=2000 actions=drop
 cookie=0x3, duration=3.392s, table=2, n_packets=0, n_bytes=0, send_flow_rem ip,in_port="s1-eth1",dl
_vlan=2001 actions=drop
root@docker-desktop:~# 

```

### End-to-End Tests

I'll leave in draft until e2e tests are passing:

https://github.com/kytos-ng/kytos-end-to-end-tests/pull/428

