### PR TITLE
fix: kytos.conf increased event buffer queue sizes by default; decreased min utilization threshold for queue_monitors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Changed
+=======
+- kytos.conf: event buffers queue sizes are now 5 to 10 times by default to provide better elasticity.
+- kytos.conf: event buffers and thread pools queue_monitor reduced its ``min_queue_full_percent`` to 90, so now it'll log high sustained utilization more reliably
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/kytos/core/config.py
+++ b/kytos/core/config.py
@@ -175,28 +175,28 @@ class KytosConfig():
                     "queue": {
                         "type": "priority",
                         "maxsize": "threadpool_sb",
-                        "maxsize_multiplier": 2,
+                        "maxsize_multiplier": 10,
                     }
                 },
                 "msg_in": {
                     "queue": {
                         "type": "priority",
                         "maxsize": "threadpool_sb",
-                        "maxsize_multiplier": 2,
+                        "maxsize_multiplier": 10,
                     }
                 },
                 "raw": {
                     "queue": {
                         "type": "queue",
                         "maxsize": "threadpool_sb",
-                        "maxsize_multiplier": 2,
+                        "maxsize_multiplier": 10,
                     }
                 },
                 "app": {
                     "queue": {
                         "type": "queue",
                         "maxsize": "threadpool_app",
-                        "maxsize_multiplier": 2,
+                        "maxsize_multiplier": 20,
                     }
                 },
             },
@@ -204,7 +204,7 @@ class KytosConfig():
               {
                 "min_hits": 5,
                 "delta_secs": 5,
-                "min_queue_full_percent": 150,
+                "min_queue_full_percent": 90,
                 "log_at_most_n": 0,
                 "queues": ["sb", "app", "db"]
               }
@@ -213,7 +213,7 @@ class KytosConfig():
               {
                 "min_hits": 5,
                 "delta_secs": 5,
-                "min_queue_full_percent": 100,
+                "min_queue_full_percent": 90,
                 "log_at_most_n": 0,
                 "buffers": ["msg_in", "msg_out", "raw", "app"]
               }

--- a/kytos/templates/kytos.conf.template
+++ b/kytos/templates/kytos.conf.template
@@ -86,7 +86,7 @@ thread_pool_queue_monitors =
     {
       "min_hits": 5,
       "delta_secs": 5,
-      "min_queue_full_percent": 100,
+      "min_queue_full_percent": 90,
       "log_at_most_n": 0,
       "queues": ["sb", "app", "db"]
     }
@@ -98,7 +98,7 @@ event_buffer_monitors =
     {
       "min_hits": 5,
       "delta_secs": 5,
-      "min_queue_full_percent": 100,
+      "min_queue_full_percent": 90,
       "log_at_most_n": 0,
       "buffers": ["msg_in", "msg_out", "raw", "app"]
     }
@@ -116,28 +116,28 @@ event_buffer_conf =
             "queue": {
                 "type": "priority",
                 "maxsize": "threadpool_sb",
-                "maxsize_multiplier": 2
+                "maxsize_multiplier": 10
             }
         },
         "msg_in": {
             "queue": {
                 "type": "priority",
                 "maxsize": "threadpool_sb",
-                "maxsize_multiplier": 2
+                "maxsize_multiplier": 10
             }
         },
         "raw": {
             "queue": {
                 "type": "queue",
                 "maxsize": "threadpool_sb",
-                "maxsize_multiplier": 2
+                "maxsize_multiplier": 10
             }
         },
         "app": {
             "queue": {
                 "type": "queue",
                 "maxsize": "threadpool_app",
-                "maxsize_multiplier": 2
+                "maxsize_multiplier": 20
             }
         }
     }

--- a/tests/unit/test_core/test_controller.py
+++ b/tests/unit/test_core/test_controller.py
@@ -705,10 +705,11 @@ class TestController:
         """Test KytosConfig default maxsize multiplier."""
         event_buffer_conf = self.controller.options.event_buffer_conf
         assert event_buffer_conf
-        queues = event_buffer_conf.values()
+        queues = event_buffer_conf
         assert queues
-        for queue in queues:
-            assert queue["queue"]["maxsize_multiplier"] == 2
+        for name, queue in queues.items():
+            multiplier = 10 if name != "app" else 20
+            assert queue["queue"]["maxsize_multiplier"] == multiplier
 
     def test_get_links_from_interfaces(self) -> None:
         """Test get_links_from_interfaces."""


### PR DESCRIPTION
Closes #618 

### Summary

This PR fixes/enhances two issues:

1) Event buffer queue sizes were relatively small to their thread pool sizes, but were struggling to accommodate more spiky elasticity. So now event buffer queue sizes are now 5-10x bigger. 

> These queues have to be bound to provide backpressure otherwise it'd lead to overall system instability much quicker, any full misbehaved client not only could would compete with others but would also contribute to significant memory. We don't expect any core NApp to be misbehaving, but for those who are publishing a lot of events either they'll need to be paced or event buffer queue sizes will need to be increased.

Rationale to find a good number: on my machine, with a CPU core @ 4GHz full blasting KytosEvents I can get around 7k events / sec, so this is an initial good number to have an idea of a extreme misbehaving full blasting event producer would look like:

<img width="821" height="355" alt="Screenshot 2026-05-07 at 4 01 16 PM" src="https://github.com/user-attachments/assets/ffb9130f-d1a3-4205-8900-c8666b31912b" />

Now that the `app` event buffer queue size is around 10k, that implies that the queue will start with back pressure only when something is really at full blast, which in normal cases for our core NApps that shouldn't normally happens, so this should be a good initial figure I think to have by default. 

2) `min_queue_full_percent = 100` on kytos.conf for queue monitors were too high, the value made sense, but since it's sampling every second it would only detect cases where the overflow was extreme severe, so now reducing to 90 queue monitor will do its job out the box as you'd expect, if you see warning messages from queue monitor you should analyze APM and see which events are contributing the most and if it's reasonable then consider increasing queue sizes

3) Regarding potential starvation on MainThread or overall unresponsiveness from core queues I haven't manage to reproduce that, so I'll keep researching it, but 1) and 2) are already improvements.

### Local Tests

Other than what I described in the summary, I also exercised a switch disconnecting and connecting and even sending flows when blasting with 7k / events per second, and it worked without starvation:

```
2026-05-07 21:29:55,836 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 8, will send n: 10000
2026-05-07 21:29:57,427 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 9, will send n: 10000
2026-05-07 21:29:58,015 - INFO [kytos.core.atcp_server] (MainThread) Connection lost with client 127.0.0.1:60231. Reason: Request closed by client
2026-05-07 21:29:58,828 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 10, will send n: 10000
2026-05-07 21:29:59,616 - WARNING [kytos.core.queue_monitor] (MainThread) app, counted: 5, min/avg/max size: 10239/10239.0/10239, first at: 2026-05-08 00:29:55.615444+00:00, last at: 2026-05-08 00:29:59.6169
31+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 9216
2026-05-07 21:30:00,415 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 11, will send n: 10000
2026-05-07 21:30:01,814 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 12, will send n: 10000
2026-05-07 21:30:03,402 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 13, will send n: 10000
2026-05-07 21:30:04,618 - WARNING [kytos.core.queue_monitor] (MainThread) app, counted: 5, min/avg/max size: 10239/10239.0/10239, first at: 2026-05-08 00:30:00.617189+00:00, last at: 2026-05-08 00:30:04.6186
83+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 9216
2026-05-07 21:30:04,830 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 14, will send n: 10000
2026-05-07 21:30:06,371 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 15, will send n: 10000
2026-05-07 21:30:06,881 - INFO [kytos.core.atcp_server] (MainThread) New connection from 127.0.0.1:60300
2026-05-07 21:30:06,885 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_6) Connection ('127.0.0.1', 60300), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2026-05-07 21:30:07,786 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 16, will send n: 10000
2026-05-07 21:30:08,469 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60302 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&cookie_range=12321848580485677056&cookie_range=12393906174523604991
&dpid=00:00:00:00:00:00:00:01 HTTP/1.1" 200
2026-05-07 21:30:09,366 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 17, will send n: 10000
2026-05-07 21:30:09,620 - WARNING [kytos.core.queue_monitor] (MainThread) app, counted: 5, min/avg/max size: 10239/10239.0/10239, first at: 2026-05-08 00:30:05.619181+00:00, last at: 2026-05-08 00:30:09.6205
27+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 9216
2026-05-07 21:30:10,063 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_19) Event handle_interface_link_up Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2026-05-07 21:30:10,064 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_3) Event handle_interface_link_up Interface('s1', 4294967294, Switch('00:00:00:00:00:00:00:01'))
2026-05-07 21:30:10,064 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_16) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2026-05-07 21:30:10,064 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_18) Event handle_interface_link_up Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01'))
2026-05-07 21:30:10,065 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_1) Event handle_interface_link_up Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01'))
2026-05-07 21:30:10,810 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 18, will send n: 10000
2026-05-07 21:30:12,356 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 19, will send n: 10000
2026-05-07 21:30:13,788 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 20, will send n: 10000
2026-05-07 21:30:14,622 - WARNING [kytos.core.queue_monitor] (MainThread) app, counted: 5, min/avg/max size: 10239/10239.0/10239, first at: 2026-05-08 00:30:10.620934+00:00, last at: 2026-05-08 00:30:14.6220
23+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 9216
2026-05-07 21:30:15,382 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 21, will send n: 10000
2026-05-07 21:30:16,804 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 22, will send n: 10000
2026-05-07 21:30:18,353 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 23, will send n: 10000
2026-05-07 21:30:19,624 - WARNING [kytos.core.queue_monitor] (MainThread) app, counted: 5, min/avg/max size: 10239/10239.0/10239, first at: 2026-05-08 00:30:15.622388+00:00, last at: 2026-05-08 00:30:19.6240
61+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 9216
2026-05-07 21:30:19,789 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 24, will send n: 10000
2026-05-07 21:30:21,370 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 25, will send n: 10000
2026-05-07 21:30:22,805 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 26, will send n: 10000
2026-05-07 21:30:24,356 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 27, will send n: 10000
2026-05-07 21:30:24,628 - WARNING [kytos.core.queue_monitor] (MainThread) app, counted: 5, min/avg/max size: 10239/10239.0/10239, first at: 2026-05-08 00:30:20.626420+00:00, last at: 2026-05-08 00:30:24.6285
12+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 9216
2026-05-07 21:30:25,793 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 28, will send n: 10000
2026-05-07 21:30:26,268 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request command: add, force: True, dpids: ['00:00:00:00:00:00:00:01'], flows[0, 1]: [{'cookie': 3, 'tab
le_id': 2, 'match': {'in_port': 1, 'dl_vlan': 4001, 'dl_type': 2048}}]
2026-05-07 21:30:26,268 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Flows received summary:  switches:['00:00:00:00:00:00:00:01'], flows_by_switch:1,  total_flows_length: 1
2026-05-07 21:30:26,273 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60305 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2026-05-07 21:30:27,358 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 29, will send n: 10000
2026-05-07 21:30:28,809 - INFO [kytos.napps.kytos/sample_ui] (MainThread) iter: 30, will send n: 10000
2026-05-07 21:30:29,630 - WARNING [kytos.core.queue_monitor] (MainThread) app, counted: 5, min/avg/max size: 10239/10239.0/10239, first at: 2026-05-08 00:30:25.628945+00:00, last at: 2026-05-08 00:30:29.6306
31+00:00, delta secs: 5, min_hits: 5, min_size_threshold: 9216




~# ovs-vsctl set-controller s1 tcp:192.168.65.254:6654
~# ovs-vsctl set-controller s1 tcp:192.168.65.254:6653
~# ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0xab00000000000001, duration=11377.931s, table=0, n_packets=5636, n_bytes=236712, send_flow_
rem priority=50000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
 cookie=0xac00000000000001, duration=67.813s, table=0, n_packets=0, n_bytes=0, send_flow_rem priorit
y=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0xac00000000000001, duration=67.812s, table=0, n_packets=0, n_bytes=0, send_flow_rem priorit
y=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0x3, duration=4884.096s, table=2, n_packets=0, n_bytes=0, send_flow_rem ip,in_port="s1-eth1"
,dl_vlan=2001 actions=drop
 cookie=0x3, duration=4869.956s, table=2, n_packets=0, n_bytes=0, send_flow_rem ip,in_port="s1-eth1"
,dl_vlan=3001 actions=drop
 cookie=0x3, duration=4.241s, table=2, n_packets=0, n_bytes=0, send_flow_rem ip,in_port="s1-eth1",dl
_vlan=4001 actions=drop
root@docker-desktop:~# 

```

### End-to-End Tests

Will dispatch an exec, but more testing should focus on stress and exploratory tests

I'll leave the PR in draft in the meantime as I keep researching/exploring item 3)