### PR TITLE
Fix/issue 620

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the kytos project will be documented in this file.
 UNRELEASED - Under development
 ******************************
 
+Changed
+=======
+- Enhanced core status API to export information and critical states for internal components, such as
+Kytos buffers queue size, thread pool size, core tasks status, etc.
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import warnings
 import zipfile
+from asyncio.exceptions import InvalidStateError
 from datetime import datetime
 from glob import glob
 from http import HTTPStatus
@@ -25,7 +26,7 @@ from uvicorn import Server
 
 from kytos.core.auth import authenticated
 from kytos.core.config import KytosConfig
-from kytos.core.helpers import get_thread_pool_max_workers
+from kytos.core.helpers import executors, get_thread_pool_max_workers
 from kytos.core.rest_api import JSONResponse, Request
 
 LOG = logging.getLogger(__name__)
@@ -165,10 +166,38 @@ class APIServer:
     def status_api(self, _request: Request):
         """Display kytos status using the route ``/kytos/status/``."""
         uptime = self.napps_manager._controller.uptime()
+        buffers_qsize = {
+            buf.name: buf.qsize()
+            for buf in self.napps_manager._controller.buffers.get_all_buffers()
+        }
+        thread_pool_qsize = {
+            name: pool._work_queue.qsize() for name, pool in executors.items()
+        }
+        tasks = {}
+        system_status = "running"
+        for task in self.napps_manager._controller._tasks:
+            name, status = f"{task.get_name()}-{task.get_coro()}", ""
+            if not task.done():
+                status = "running"
+            elif task.cancelled():
+                status = "cancelled"
+            else:
+                try:
+                    exc = task.exception()
+                except InvalidStateError:
+                    exc = None
+                status = "finished" if exc is None else f"exception: {exc}"
+            tasks[name] = status
+            if status != "running":
+                system_status = "degradated"
         response = {
             "response": "running",
+            "system_status": system_status,
             "started_at": self.napps_manager._controller.started_at,
             "uptime_seconds": uptime.seconds if uptime else 0,
+            "buffers_qsize": buffers_qsize,
+            "thread_pool_qsize": thread_pool_qsize,
+            "core_task_status": tasks,
         }
         return JSONResponse(response)
 

--- a/kytos/core/api_server.py
+++ b/kytos/core/api_server.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import warnings
 import zipfile
-from asyncio.exceptions import InvalidStateError
+from asyncio.exceptions import CancelledError, InvalidStateError
 from datetime import datetime
 from glob import glob
 from http import HTTPStatus
@@ -184,7 +184,7 @@ class APIServer:
             else:
                 try:
                     exc = task.exception()
-                except InvalidStateError:
+                except (CancelledError, InvalidStateError):
                     exc = None
                 status = "finished" if exc is None else f"exception: {exc}"
             tasks[name] = status

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -288,15 +288,12 @@ class Controller:
             await self.start_controller()
         except (KytosDBInitException, KytosAPMInitException) as exc:
             message = f"Kytos couldn't start because of {str(exc)}"
-            self.log.error(message)
             sys.exit(message)
         except Exception as exc:
             exc_fmt = traceback.format_exc(chain=True)
             message = f"Kytos couldn't start because of {str(exc)} {exc_fmt}"
             counter = self._full_queue_counter()
-            full_msg = self._try_to_fmt_traceback_msg(message, counter)
-            self.log.error(full_msg)
-            sys.exit(full_msg)
+            sys.exit(self._try_to_fmt_traceback_msg(message, counter))
 
     def start_queue_monitors(self) -> None:
         """Start QueueMonitorWindows."""

--- a/kytos/core/controller.py
+++ b/kytos/core/controller.py
@@ -288,12 +288,15 @@ class Controller:
             await self.start_controller()
         except (KytosDBInitException, KytosAPMInitException) as exc:
             message = f"Kytos couldn't start because of {str(exc)}"
+            self.log.error(message)
             sys.exit(message)
         except Exception as exc:
             exc_fmt = traceback.format_exc(chain=True)
             message = f"Kytos couldn't start because of {str(exc)} {exc_fmt}"
             counter = self._full_queue_counter()
-            sys.exit(self._try_to_fmt_traceback_msg(message, counter))
+            full_msg = self._try_to_fmt_traceback_msg(message, counter)
+            self.log.error(full_msg)
+            sys.exit(full_msg)
 
     def start_queue_monitors(self) -> None:
         """Start QueueMonitorWindows."""

--- a/tests/unit/test_core/test_api_server.py
+++ b/tests/unit/test_core/test_api_server.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import warnings
+from asyncio.exceptions import InvalidStateError
 from datetime import datetime, timezone
 # Disable not-grouped imports that conflicts with isort
 from unittest.mock import AsyncMock, MagicMock
@@ -72,8 +73,36 @@ class TestAPIServer:
             "response": "running",
             "started_at": started_at.isoformat(),
             "uptime_seconds": uptime.seconds,
+            "buffers_qsize": {},
+            "thread_pool_qsize": {"sb": 0, "db": 0, "app": 0, "api": 0},
+            "core_task_status": {},
+            "system_status": "running",
         }
-        assert response == expected
+        assert response == expected, str(response)
+
+        # now with some tasks
+        mock_task = MagicMock()
+        mock_task.get_name.side_effect = ["t1", "t2", "t3", "t4"]
+        mock_task.get_coro.side_effect = ["c1", "c2", "c3", "c4"]
+        mock_task.done.side_effect = [False, True, True, True]
+        mock_task.cancelled.side_effect = [True, False, False]
+        mock_task.exception.side_effect = ["boom", InvalidStateError()]
+        self.napps_manager._controller._tasks = [mock_task]*4
+        response = await self.client.get("status/")
+        assert response.status_code == 200, response.text
+        response = response.json()
+        expected = {
+            "response": "running",
+            "started_at": started_at.isoformat(),
+            "uptime_seconds": uptime.seconds,
+            "buffers_qsize": {},
+            "thread_pool_qsize": {"sb": 0, "db": 0, "app": 0, "api": 0},
+            "core_task_status": {
+                "t1-c1": "running", "t2-c2": "cancelled", "t3-c3": "exception: boom", "t4-c4": "finished"
+            },
+            "system_status": "degradated",
+        }
+        assert response == expected, str(response)
 
     def test_stop(self):
         """Test stop method."""

--- a/tests/unit/test_core/test_api_server.py
+++ b/tests/unit/test_core/test_api_server.py
@@ -98,7 +98,10 @@ class TestAPIServer:
             "buffers_qsize": {},
             "thread_pool_qsize": {"sb": 0, "db": 0, "app": 0, "api": 0},
             "core_task_status": {
-                "t1-c1": "running", "t2-c2": "cancelled", "t3-c3": "exception: boom", "t4-c4": "finished"
+                "t1-c1": "running",
+                "t2-c2": "cancelled",
+                "t3-c3": "exception: boom",
+                "t4-c4": "finished",
             },
             "system_status": "degradated",
         }


### PR DESCRIPTION

Closes #620 

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests

Running Kytos with the proposed changes, we can now get the status of core components:

```
# curl http://127.0.0.1:8181/api/kytos/core/status
{
  "response": "running",
  "started_at": "2026-05-06T18:58:07.142207+00:00",
  "uptime_seconds": 3735,
  "buffers_qsize": {
    "conn": 0,
    "raw": 0,
    "msg_in": 0,
    "msg_out": 0,
    "app": 0,
    "meta": 0
  },
  "thread_pool_qsize": {
    "sb": 0,
    "db": 0,
    "app": 0,
    "api": 0
  },
  "core_task_status": {
    "Task-2-<coroutine object APIServer.serve at 0x7f5509165a80>": "running",
    "Task-7-<coroutine object Controller.event_handler at 0x7f549c79ab40>": "running",
    "Task-8-<coroutine object Controller.event_handler at 0x7f549c799340>": "running",
    "Task-9-<coroutine object Controller.event_handler at 0x7f549c79ac40>": "running",
    "Task-10-<coroutine object Controller.msg_out_event_handler at 0x7f54bc381800>": "running",
    "Task-11-<coroutine object Controller.event_handler at 0x7f549c79ad40>": "running",
    "Task-12-<coroutine object Controller.event_handler at 0x7f549c79ae40>": "running"
  }
}
```

Also, forcing a failure on a Napp, now logs the error to syslog:

```
root@72a1480c667a:/# kytosd --database mongodb -E
/usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
  warnings.warn(
root@72a1480c667a:/#
root@72a1480c667a:/#
root@72a1480c667a:/# tail /var/log/syslog
2026-05-11T13:58:41.968823+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:157:  Loading interface iface_id=00:00:00:00:00:00:00:22:59
2026-05-11T13:58:41.969962+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:157:  Loading interface iface_id=00:00:00:00:00:00:00:22:60
2026-05-11T13:58:41.971068+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:157:  Loading interface iface_id=00:00:00:00:00:00:00:22:61
2026-05-11T13:58:41.972171+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:157:  Loading interface iface_id=00:00:00:00:00:00:00:22:62
2026-05-11T13:58:41.973478+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:157:  Loading interface iface_id=00:00:00:00:00:00:00:22:63
2026-05-11T13:58:41.974587+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:157:  Loading interface iface_id=00:00:00:00:00:00:00:22:64
2026-05-11T13:58:41.975726+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:157:  Loading interface iface_id=00:00:00:00:00:00:00:22:165
2026-05-11T13:58:41.976844+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:157:  Loading interface iface_id=00:00:00:00:00:00:00:22:265
2026-05-11T13:58:41.979904+00:00 72a1480c667a kytos.napps.kytos/topology:INFO main:127:  Loading link: 0f1e4e584f6df744797e8e44581a3378959cf4eed86cbe6f4dd16630358cfcd4
2026-05-11T13:58:41.995228+00:00 72a1480c667a kytos.core.controller:ERROR controller:298:  Kytos couldn't start because of KytosNAppSetupException: NApp kytos/topology exception failure on purpose  Traceback (most recent call last):#012  File "/usr/local/lib/python3.11/dist-packages/kytos/core/controller.py", line 904, in load_napp#012    napp = napp_module.Main(controller=self)#012           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^#012  File "/usr/local/lib/python3.11/dist-packages/kytos/core/napps/base.py", line 196, in __init__#012    self.setup()#012  File "//var/lib/kytos/napps/kytos/topology/main.py", line 72, in setup#012    self.load_topology()#012  File "//var/lib/kytos/napps/kytos/topology/main.py", line 206, in load_topology#012    self._load_link(link_att)#012  File "//var/lib/kytos/napps/kytos/topology/main.py", line 130, in _load_link#012    raise Exception("failure on purpose")#012Exception: failure on purpose#012#012The above exception was the direct cause of the following exception:#012#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.11/dist-packages/kytos/core/controller.py", line 288, in start#012    await self.start_controller()#012  File "/usr/local/lib/python3.11/dist-packages/kytos/core/controller.py", line 415, in start_controller#012    self.load_napps()#012  File "/usr/local/lib/python3.11/dist-packages/kytos/core/controller.py", line 939, in load_napps#012    self.load_napp(napp.username, napp.name)#012  File "/usr/local/lib/python3.11/dist-packages/kytos/core/controller.py", line 907, in load_napp#012    raise KytosNAppSetupException(msg) from exc#012kytos.core.exceptions.KytosNAppSetupException: KytosNAppSetupException: NApp kytos/topology exception failure on purpose
```

### End-to-End Tests

Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```